### PR TITLE
Add pytest coverage for policy decisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 fastapi
 uvicorn
-pip install -r requirements.txt
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,60 @@
+from core.policy import Decision, Signals, Thresholds, decide
+
+
+def test_respond_when_all_signals_ok():
+    signals = Signals(
+        coherence=0.9,
+        drift=0.1,
+        conflict=0.0,
+        ambiguity=0.0,
+        continuity=True,
+    )
+    decision, meta = decide(signals, Thresholds())
+
+    assert decision == Decision.RESPOND
+    assert meta == {"reasons": []}
+
+
+def test_silence_on_low_coherence():
+    signals = Signals(
+        coherence=0.5,
+        drift=0.1,
+        conflict=0.0,
+        ambiguity=0.0,
+        continuity=True,
+    )
+    decision, meta = decide(signals, Thresholds())
+
+    assert decision == Decision.SILENCE
+    assert ("A1", "low_coherence") in meta["reasons"]
+
+
+def test_minimal_on_ambiguity_only():
+    signals = Signals(
+        coherence=0.9,
+        drift=0.1,
+        conflict=0.0,
+        ambiguity=0.5,
+        continuity=True,
+    )
+    decision, meta = decide(signals, Thresholds())
+
+    assert decision == Decision.MINIMAL
+    assert meta["reasons"] == [("A2", "ambiguity_detected")]
+
+
+def test_silence_on_multiple_issues():
+    signals = Signals(
+        coherence=0.5,
+        drift=0.4,
+        conflict=0.3,
+        ambiguity=0.0,
+        continuity=False,
+    )
+    decision, meta = decide(signals, Thresholds())
+
+    assert decision == Decision.SILENCE
+    assert ("A1", "low_coherence") in meta["reasons"]
+    assert ("D1", "context_drift") in meta["reasons"]
+    assert ("C2", "inter_model_conflict") in meta["reasons"]
+    assert ("K3", "continuity_invalid") in meta["reasons"]


### PR DESCRIPTION
### Motivation
- Add unit tests to verify the core decision logic for responding, silencing, and minimal replies. 
- Ensure tests can import the production code by marking `core` as a package and fixing test import paths. 
- Make `pytest` an explicit test dependency and remove an invalid entry from `requirements.txt`. 
- Prevent noisy git commits by ignoring Python cache directories with `.gitignore`. 

### Description
- Add `tests/test_policy.py` containing unit tests for `Decision`, `Signals`, `Thresholds`, and `decide` behavior under multiple signal scenarios. 
- Add `tests/conftest.py` which appends the project root to `sys.path` so tests can import `core`. 
- Add an empty `core/__init__.py` to mark `core` as a package. 
- Update `requirements.txt` to include `pytest` instead of an erroneous line and add `.gitignore` to ignore `__pycache__/` and `.pytest_cache/`. 

### Testing
- Ran `pytest` after changes. 
- The test suite initially failed due to a missing `core` package and was fixed by adding `core/__init__.py` and `tests/conftest.py`. 
- Final `pytest` run collected 5 items and completed successfully. 
- All tests passed: `5 passed in 0.02s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69523cbfbf448326a70fe264b955dabe)