### PR TITLE
docs: clarify quickstart, recommend Python 3.11/3.12, separate editable install

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,22 +48,35 @@ PoR does not improve the model itself. It controls when the model is allowed to 
 
 ## Quickstart (Windows / PowerShell)
 
+Recommended Python versions: **3.11** or **3.12**.
+
+### Minimal runtime setup
+
 ```powershell
 py -m venv .venv
 .\.venv\Scripts\Activate.ps1
 python -m pip install --upgrade pip
 pip install -r requirements.txt
-pip install -e .
 uvicorn api.main:app --reload
 ```
 
-Optional check:
+### Optional editable developer install
+
+```powershell
+pip install -e .
+```
+
+Editable install is optional and mainly intended for developer workflows.
+For the lowest-friction local setup, use `pip install -r requirements.txt` with Python 3.11 or 3.12.
+On very new Python versions, if editable install does not complete, the API, tests, and demos still run without it.
+
+### Optional check
 
 ```powershell
 pytest -q
 ```
 
-## Demo entry points
+### Demo entry points
 
 ```powershell
 python demo/por_api_demo.py


### PR DESCRIPTION
### Motivation

- Clarify supported Python versions and reduce friction for local setup. 
- Make the Quickstart instructions clearer for both end users and developers.

### Description

- Add a recommended Python versions note for `3.11` and `3.12` and introduce a `Minimal runtime setup` section with the standard virtualenv and `pip install -r requirements.txt` workflow. 
- Split out an `Optional editable developer install` section and place `pip install -e .` in its own code block with guidance that the editable install is optional. 
- Add guidance that the API, tests, and demos still run without the editable install and mention behavior on very new Python versions.

### Testing

- Ran the automated test suite with `pytest -q`, and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d73e02f6ac8326afc42c8b6454465d)