### PR TITLE
Refine Quickstart editable install wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ uvicorn api.main:app --reload
 pip install -e .
 ```
 
-Editable install is optional and mainly intended for developer workflows.
-For the lowest-friction local setup, use `pip install -r requirements.txt` with Python 3.11 or 3.12.
-On very new Python versions, if editable install does not complete, the API, tests, and demos still run without it.
+Editable install is optional and mainly for active developer workflows.
+For the lowest-friction local setup, use `pip install -r requirements.txt` on Python 3.11 or 3.12.
+On very new Python versions, if `pip install -e .` does not complete, you can continue; the API, tests, and demos run without it.
 
 ### Optional check
 


### PR DESCRIPTION
### Motivation

- Calmly reduce user concern when `pip install -e .` can be problematic on very new Python releases by clarifying that editable install is optional and not required for running the project.
- Encourage the lowest-friction setup path of `pip install -r requirements.txt` on Python 3.11 or 3.12 while assuring users that the API, tests, and demos still run without an editable install.

### Description

- Edited only `README.md` to replace the short explanatory paragraph under the `### Optional editable developer install` heading with a more confidence-preserving, compact wording.
- Kept the existing commands unchanged (`pip install -e .` and `pip install -r requirements.txt`) and limited the diff to three line changes.
- No packaging, dependency, or `pyproject.toml` changes were made.

### Testing

- This is a documentation-only change so no unit or integration tests were required to validate functionality.
- Verified the edit with `git diff -- README.md` and committed the change successfully with `git commit -m "Refine Quickstart editable install wording"`.
- Confirmed the commit with `git show --check --stat --oneline HEAD`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d75aedf2f083268cad2a956e1fd7e1)