### PR TITLE
Docs: add Python 3.13 and clarify editable install instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ PoR does not improve the model itself. It controls when the model is allowed to 
 
 ## Quickstart (Windows / PowerShell)
 
-Recommended Python versions: **3.11** or **3.12**.
+Recommended Python versions: **3.11**, **3.12**, or **3.13**.
 
 ### Minimal runtime setup
 
@@ -66,9 +66,10 @@ uvicorn api.main:app --reload
 pip install -e .
 ```
 
-Editable install is optional and mainly intended for developer workflows.
-For the lowest-friction local setup, use `pip install -r requirements.txt` with Python 3.11 or 3.12.
-On very new Python versions, if editable install does not complete, the API, tests, and demos still run without it.
+Editable install is optional and mainly for active developer workflows.
+For the lowest-friction local setup, use `pip install -r requirements.txt`.
+A working editable-install path has been verified on Python 3.13.
+On very new Python versions, if `pip install -e .` does not complete, you can continue; the API, tests, and demos run without it.
 
 ### Optional check
 


### PR DESCRIPTION
### Motivation
- Update the quickstart to acknowledge Python 3.13 support and make the editable install guidance clearer for contributors. 

### Description
- Add `3.13` to the recommended Python versions list. 
- Reword the editable install guidance to state it is for active developer workflows and note that a working editable-install path has been verified on Python `3.13`. 
- Clarify that `pip install -r requirements.txt` remains the lowest-friction local setup and that the API, tests, and demos run without an editable install. 

### Testing
- This is a documentation-only change and no automated tests were run as part of this update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d75aedf2f083268cad2a956e1fd7e1)