### PR TITLE
Add canonical first-run demo wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ pytest -q
 
 ### Demo entry points
 
+Run this first:
+
+```powershell
+python demo/canonical_demo.py
+```
+
+Other demos:
+
 ```powershell
 python demo/por_api_demo.py
 python demo/por_agent_demo.py

--- a/demo/canonical_demo.py
+++ b/demo/canonical_demo.py
@@ -1,0 +1,10 @@
+"""Canonical first-run demo entrypoint.
+
+Thin wrapper around demo/por_agent_demo.py.
+"""
+
+from por_agent_demo import main
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Provide a minimal, canonical first-run demo entrypoint so newcomers have a single, low-friction way to run the demo. 
- Keep the change as small as possible and preserve the existing `por_agent_demo.py` logic without duplication. 
- Avoid changing architecture, workflows, or unrelated files while adding a clear pointer in the README.

### Description

- Add `demo/canonical_demo.py` as a tiny wrapper that imports `main` from `demo/por_agent_demo.py` and invokes it under `if __name__ == '__main__'`. 
- Update the README by inserting a short "Run this first" entry that points to `python demo/canonical_demo.py` while keeping the existing demo list intact. 
- No demo logic was modified or duplicated and only `demo/canonical_demo.py` and `README.md` were changed.

### Testing

- Ran `python demo/canonical_demo.py` and the wrapper executed successfully producing demo output artifacts. 
- Ran the test suite with `pytest -q` and all tests passed (`6 passed`). 
- No additional automated checks were added and the change is intentionally low-friction.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8d5bc39e08326a4c8ab914a1e2ab7)