### PR TITLE
Add Local workflow and PR/branch guidance to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,74 @@ This repository separates:
 
 Please keep these in separate pull requests whenever possible.
 
+## Local workflow (Phase 2)
+
+### Recommended local environment
+
+- Python 3.13.x
+- A project-local virtual environment in `.venv`
+
+### Minimal setup
+
+```powershell
+py -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+### Run this first (canonical local demo)
+
+```powershell
+python demo/canonical_demo.py
+```
+
+Use this as the first-run local sanity check. It is the canonical demo path and does **not** require an API key.
+
+### Optional API run
+
+```powershell
+uvicorn api.main:app --reload
+```
+
+### Optional tests
+
+```powershell
+pytest -q
+```
+
+### Branch discipline
+
+Start new feature work from a fresh `main` branch:
+
+```powershell
+git checkout main
+git pull
+git checkout -b feature-name
+```
+
+### Artifact hygiene
+
+Do not accidentally include generated outputs in unrelated pull requests. Keep them out of normal feature PRs unless the PR is explicitly about tracked artifacts.
+
+Common examples:
+- `demo_outputs/`
+- `demo_outputs_api/`
+- generated `.jsonl` files
+- generated demo reports
+
+### Before opening a pull request
+
+- Check `git status`.
+- Confirm you are on the correct branch.
+- Confirm no unrelated generated files are staged.
+- Run `python demo/canonical_demo.py` when your change affects the local demo path.
+- Run `pytest -q` when relevant and low-friction.
+
+### Scope discipline for PRs
+
+Keep pull requests focused. Avoid unrelated cleanup and noise-only diffs.
+
 ## Pull request expectations
 
 - Explain what changed and why.


### PR DESCRIPTION
### Motivation

- Provide a clear, repeatable local setup and first-run demo path to reduce onboarding friction. 
- Clarify branch discipline, artifact hygiene, and PR scope to keep changes focused and avoid accidental inclusion of generated outputs. 

### Description

- Add a new "Local workflow (Phase 2)" section documenting a recommended environment targeting Python `3.13.x` and a project-local virtual environment in `.venv`.
- Include minimal setup commands for creating and activating the venv and installing dependencies with `pip` (`py -m venv .venv`, `.\.venv\Scripts\Activate.ps1`, `pip install -r requirements.txt`).
- Add a canonical local demo command `python demo/canonical_demo.py` and an optional API run example using `uvicorn api.main:app --reload`.
- Document optional test invocation `pytest -q`, branch discipline with `git checkout main`/`git checkout -b feature-name`, artifact hygiene examples (e.g., `demo_outputs/`), and a pre-PR checklist of commands to run and items to verify.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8e67c2b3483268166a9571ee6e970)