### PR TITLE
docs: Add quick guide comparing Baseline vs PoR

### DIFF
--- a/docs/baseline_vs_por_quick_guide.md
+++ b/docs/baseline_vs_por_quick_guide.md
@@ -1,0 +1,28 @@
+# Baseline vs PoR (Quick Guide)
+
+## Thesis (30 seconds)
+- **Baseline:** emits an answer by default.
+- **PoR:** applies release control before output is shown; if output is unstable, it may intentionally return silence.
+
+In short: **same generator, different release decision.**
+
+## Comparison
+
+| Aspect | Baseline | PoR-gated |
+|---|---|---|
+| Default behavior | Emit response | Evaluate stability, then release or silence |
+| On unstable output | Still emits | May withhold output (silence) |
+| Control objective | Always answer | Avoid releasing low-stability output |
+
+## Compact example (same task)
+Task: *"Give a deployment command for service X."*
+
+- **Baseline path:** returns a command string immediately, even if parameters are inconsistent.
+- **PoR path:** detects instability in the candidate output and returns **silence** instead of releasing a risky command.
+
+## Live demo
+Run the canonical side-by-side demo:
+
+```powershell
+python demo/canonical_demo.py
+```


### PR DESCRIPTION
### Motivation
- Clarify the behavioral difference between Baseline and PoR release decisions and provide a compact reference and demo for engineers.

### Description
- Add `docs/baseline_vs_por_quick_guide.md` containing a 30-second thesis, a comparison table, a compact example, and a live demo command `python demo/canonical_demo.py`.

### Testing
- Documentation-only change; no automated tests were run for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8f1833b348326a26d43dca883fd73)