### PR TITLE
Add Fast orientation navigation block to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ PoR does not improve the model itself. It controls when the model is allowed to 
 - `wiki/index.md`: concepts, architecture, runs, and supporting evidence.
 - `wiki/meta/Evidence_Map.md`: claim-to-artifact audit trail.
 
+## Fast orientation
+
+1. Run the canonical demo: `python demo/canonical_demo.py`
+2. Read the baseline vs PoR quick guide: `docs/baseline_vs_por_quick_guide.md`
+3. Read the integration path guide: `docs/integration_path.md`
+4. Use `CONTRIBUTING.md` for future work
+
 ## Repository layout
 
 - `api/` -> runtime API surface


### PR DESCRIPTION
### Motivation
- Add a minimal, practical navigation entry at the repo front door so readers can quickly follow the recommended Phase 2 path to the canonical demo, baseline-vs-PoR quick guide, integration path, and contribution guidance.

### Description
- Inserted a compact `## Fast orientation` block into `README.md` that points to `python demo/canonical_demo.py`, `docs/baseline_vs_por_quick_guide.md`, `docs/integration_path.md`, and `CONTRIBUTING.md`; change recorded with message `Add fast-orientation navigation block to README`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8f4c703b4832696d228c689d8458e)