### PR TITLE
Add comprehensive project wiki and evidence appendices

### DIFF
--- a/wiki/API-Walkthrough.md
+++ b/wiki/API-Walkthrough.md
@@ -1,0 +1,49 @@
+# API Walkthrough
+
+This page mirrors the applied runtime path documented in `docs/api_walkthrough.md`.
+
+## Runtime flow
+
+```text
+Request -> Candidate Output -> PoR Gate -> PROCEED / SILENCE
+```
+
+- `Request`: caller sends prompt/context.
+- `Candidate Output`: model (or provided candidate) produces text.
+- `PoR Gate`: runtime evaluates drift/coherence against threshold policy.
+- `Decision`:
+  - `PROCEED` -> release output
+  - `SILENCE` -> withhold output intentionally
+
+## Why the gate matters
+
+Without a gate, generation is typically release-by-default.
+PoR inserts an explicit control decision before release, so unstable candidates can be withheld.
+
+## Why silence is valid
+
+In this project, silence is a control action:
+- not transport failure
+- not timeout
+- not crash behavior
+
+Silence indicates the runtime decided the candidate did not meet release stability criteria.
+
+## How this differs from baseline always-output systems
+
+- Baseline path: output is emitted by default.
+- PoR path: output release is conditional on stability checks.
+
+This is a policy difference, not a claim of model-weight improvement.
+
+## Current API endpoints (from docs + code)
+
+Current documented endpoints in this repository:
+- `GET /health`
+- `POST /por/evaluate`
+- `POST /generate` (legacy compatibility)
+- `POST /por/complete`
+
+See:
+- `docs/api_walkthrough.md`
+- `api/main.py`

--- a/wiki/Current-Status.md
+++ b/wiki/Current-Status.md
@@ -1,0 +1,21 @@
+# Current Status
+
+## Completed
+
+- Repeated evaluation runs are committed across multiple task sizes and thresholds (`reports/eval_*.jsonl`, `wiki/runs/`).
+- Threshold regimes are mapped and compared (0.35, 0.39, 0.42, 0.43 artifacts).
+- Baseline vs PoR framing is explicit in docs and wiki (`docs/baseline_vs_por_quick_guide.md`, `wiki/comparisons/Baseline_vs_PoR.md`).
+- Artifact trail/report surface is established (`reports/` JSONL + plots + run pages).
+- Proof surface maturity improved: claims are connected to artifacts and run summaries.
+
+## In Progress
+
+- Applied API/runtime surface is becoming clearer (`docs/api_walkthrough.md`, `api/main.py`).
+- Documentation path for newcomers is being tightened across README/wiki/docs.
+- Public-facing technical legibility is improving (clearer claim/evidence mapping and runtime flow explanation).
+
+## Next
+
+- Live integration demo that shows gate behavior in an external or near-external flow.
+- Compact external narrative that is strict about what is proven vs pending.
+- Stronger applied use-case demonstration (runtime control value in concrete deployment-like tasks).

--- a/wiki/Evaluation-Summary.md
+++ b/wiki/Evaluation-Summary.md
@@ -1,0 +1,44 @@
+# Evaluation Summary
+
+## What the repository already demonstrates
+
+- Multiple repeated runs are committed at different scales and thresholds (`reports/eval_*.jsonl`).
+- In documented safe modes (notably 0.35 and 0.39 operating points), accepted precision/risk capture reached 100% in tracked summaries.
+- Baseline-vs-PoR comparison is visible through `no_control_success` vs `with_control_success` fields and run pages.
+- Drift separation between success/failure cohorts is repeatedly observed in reports and plots.
+
+## Why baseline vs PoR matters
+
+The project’s core change is release policy:
+- baseline: release by default,
+- PoR: evaluate and decide release.
+
+This makes tradeoffs explicit:
+- lower accepted-risk exposure in safe regimes,
+- at the cost of non-zero silence rate.
+
+## Silence rate / coverage tradeoff
+
+In the mapped 1000-task artifacts, silence is explicitly:
+- 46.5% at threshold 0.35 (`eval_run5_1000_threshold_035.jsonl`)
+- 45.6% at threshold 0.39 (`eval_run6_1000_threshold_039.jsonl`)
+- 43.7% at threshold 0.42 (`eval_run5_1000_threshold_042.jsonl`)
+- 45.0% at threshold 0.43 (`eval_run5_1000_threshold_043.jsonl`)
+
+This indicates consistent withholding behavior rather than always-output behavior.
+Coverage therefore depends on chosen threshold regime.
+
+## Evidence discipline
+
+This summary intentionally follows committed artifacts and run docs.
+It does not claim universal optimality or deployment-complete proof beyond recorded runs.
+
+## Primary evidence files
+
+- `reports/eval_run4_300_threshold_035.jsonl`
+- `reports/eval_run5_1000_threshold_035.jsonl`
+- `reports/eval_run6_1000_threshold_039.jsonl`
+- `reports/eval_run5_1000_threshold_042.jsonl`
+- `reports/eval_run5_1000_threshold_043.jsonl`
+- `wiki/runs/Run_4_300_tasks.md`
+- `wiki/runs/Run_6_1000_tasks.md`

--- a/wiki/Evidence-Map.md
+++ b/wiki/Evidence-Map.md
@@ -1,0 +1,98 @@
+# Evidence Map
+
+Purpose: claim-to-evidence index for what is established, partially established, and pending.
+
+## Core Thesis Evidence
+
+### Claim
+PoR / Silence-as-Control is a runtime **release-control layer**, not a generation method.
+
+- **Established evidence**
+  - `README.md`
+  - `wiki/concepts/PoR.md`
+  - `wiki/architecture/Release_Control_Layer.md`
+- **Partial evidence**
+  - Applied examples exist but are still local/demo-oriented.
+- **Future evidence needed**
+  - External integration case showing the same release-control framing under real constraints.
+- **Does not establish**
+  - That PoR improves underlying model capability or truthfulness by itself.
+
+## Threshold Evidence
+
+### Claim
+Threshold behaves as an operational dial with identifiable regimes.
+
+- **Established evidence**
+  - `reports/eval_run5_1000_threshold_035.jsonl`
+  - `reports/eval_run6_1000_threshold_039.jsonl`
+  - `reports/eval_run5_1000_threshold_042.jsonl`
+  - `reports/eval_run5_1000_threshold_043.jsonl`
+  - `reports/threshold_control_curve.png`
+- **Partial evidence**
+  - Regime naming (safe/transition/boundary) is repository-scoped interpretation, not universal calibration.
+- **Future evidence needed**
+  - Cross-domain threshold transfer or recalibration studies.
+- **Does not establish**
+  - A globally optimal threshold that transfers unchanged across domains.
+
+## Evaluation Evidence
+
+### Claim
+Repeated runs support non-trivial gating behavior and safety/coverage tradeoffs.
+
+- **Established evidence**
+  - Run artifacts in `reports/eval_*.jsonl`
+  - Run summaries in `wiki/runs/Run_1.md`, `wiki/runs/Run_4_300_tasks.md`, `wiki/runs/Run_6_1000_tasks.md`
+  - Drift/metrics plots in `reports/`
+- **Partial evidence**
+  - Some run summaries are stronger than others; not every run has identical depth of decomposition.
+- **Future evidence needed**
+  - Broader benchmark sets and more detailed error-taxonomy analysis.
+- **Does not establish**
+  - Universal robustness outside the recorded datasets and metric definitions.
+
+## Baseline vs PoR Evidence
+
+### Claim
+Baseline and PoR differ materially at the release-policy layer.
+
+- **Established evidence**
+  - `wiki/comparisons/Baseline_vs_PoR.md`
+  - `docs/baseline_vs_por_quick_guide.md`
+  - Artifact fields: `no_control_success`, `with_control_success`, `silence`
+- **Partial evidence**
+  - Current comparison is strongest inside tracked datasets/runs.
+- **Future evidence needed**
+  - Additional out-of-distribution and integration-level comparisons.
+- **Does not establish**
+  - That PoR dominates baseline on every objective; the evidence is policy- and dataset-scoped.
+
+## Applied API / Runtime Evidence
+
+### Claim
+A clearer applied API/runtime path now exists.
+
+- **Established evidence**
+  - `docs/api_walkthrough.md`
+  - `api/main.py` endpoints (`/health`, `/por/evaluate`, `/generate`, `/por/complete`)
+  - `demo/por_api_demo.py`, `demo_outputs_api/`
+- **Partial evidence**
+  - Path is clear for local application but not yet a complete external integration proof.
+- **Future evidence needed**
+  - End-to-end external integration demo with audited runtime outcomes.
+- **Does not establish**
+  - Production-hardening completeness (SLOs, incident behavior, governance controls).
+
+## Open Proof Gaps
+
+- External integration proof remains pending.
+- Public compact narrative should be tightened around claim boundaries.
+- Additional applied use-cases would improve transfer confidence.
+
+## Reader checklist
+
+Use this page to answer:
+1. What is already demonstrated?
+2. Where does the proof live?
+3. What is still pending before stronger external claims are justified?

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,45 @@
+# Home
+
+## Silence-as-Control in one paragraph
+
+Silence-as-Control (Proof of Resonance, PoR) is a **runtime release-control layer**.
+It does not change generation weights or decoding. It evaluates a candidate output and decides whether to release it (`PROCEED`) or withhold it (`SILENCE`).
+
+Canonical gate logic:
+
+```text
+if drift > threshold OR coherence < threshold -> SILENCE
+else -> PROCEED
+```
+
+Silence is an intentional control outcome (not an error and not a timeout).
+
+## Core framing
+
+- Generation != Authority.
+- Release must be earned by stability.
+- Either correct, or silent.
+
+## Current project stage
+
+Current stage is:
+- post-proof
+- post-threshold-map
+- applied API/runtime surface emerging
+- pre-clear external integration demo
+
+## Quick navigation
+
+- [Current Status](./Current-Status.md)
+- [API Walkthrough](./API-Walkthrough.md)
+- [Threshold Regimes](./Threshold-Regimes.md)
+- [Evaluation Summary](./Evaluation-Summary.md)
+- [Evidence Map](./Evidence-Map.md)
+- [Reading Order](./Reading-Order.md)
+- [Milestones](./Milestones.md)
+
+## Repository references
+
+- Runtime/API path: `docs/api_walkthrough.md`, `api/main.py`
+- Evaluation artifacts: `reports/`
+- Existing concept + architecture material: `wiki/concepts/`, `wiki/architecture/`

--- a/wiki/Milestones.md
+++ b/wiki/Milestones.md
@@ -1,0 +1,28 @@
+# Milestones
+
+## Timeline (project evolution)
+
+1. **Core thesis established**
+   - Silence-as-Control defined as release control (not generation improvement).
+
+2. **Initial proof runs committed**
+   - Early repeated evaluations showed release gating behavior and baseline contrast.
+
+3. **Threshold map established**
+   - Operating regimes around 0.35 / 0.39 / 0.42 / 0.43 became explicit in artifacts.
+
+4. **Safe-mode behavior confirmed at scale**
+   - 1000-task runs in safe anchors retained strong accepted-output control characteristics.
+
+5. **Applied API/runtime path clarified (latest upgrade)**
+   - `docs/api_walkthrough.md` + runtime endpoints provide a clearer applied path:
+     request -> candidate -> gate -> proceed/silence.
+
+6. **Current stage**
+   - Post-proof, post-threshold-map, applied API surface emerging, pre-clear external integration demo.
+
+## Next milestone targets
+
+- External/live integration demonstration of runtime gate behavior.
+- Compact external technical narrative tied to evidence map.
+- Stronger applied use-case package for non-research readers.

--- a/wiki/Reading-Order.md
+++ b/wiki/Reading-Order.md
@@ -1,0 +1,17 @@
+# Reading Order
+
+For a new engineer, use this order:
+
+1. `README.md`
+2. [Wiki Home](./Home.md)
+3. [API Walkthrough](./API-Walkthrough.md)
+4. [Threshold Regimes](./Threshold-Regimes.md)
+5. [Evaluation Summary](./Evaluation-Summary.md)
+6. Reports + artifacts (`reports/`, `wiki/runs/`)
+7. Source/runtime surface (`api/`, `src/silence_as_control/`)
+
+## Why this order
+
+- Steps 1-2 establish thesis and stage.
+- Steps 3-5 define runtime path and evaluation interpretation.
+- Steps 6-7 let the reader verify claims in artifacts and implementation.

--- a/wiki/Threshold-Regimes.md
+++ b/wiki/Threshold-Regimes.md
@@ -1,0 +1,35 @@
+# Threshold Regimes
+
+Threshold is an **operational control dial** for release behavior.
+Raising/lowering threshold shifts the safety-vs-coverage profile.
+
+## Mapped operating points
+
+- **0.35** -> safe / conservative regime
+- **0.39** -> practical safe anchor
+- **0.42** -> transitional / balanced (boundary starts to appear)
+- **0.43** -> boundary / leakage zone
+
+These labels summarize observed behavior in committed run artifacts and should be interpreted as repository-scoped evidence, not universal settings.
+
+## Coverage vs safety tradeoff
+
+Across mapped runs:
+- Safer settings maintain stronger accepted-output precision/risk capture but silence more candidates.
+- Boundary settings recover some coverage but begin allowing accepted failures.
+
+Use threshold operationally:
+- choose lower-risk profiles for strict release control,
+- then tune for acceptable coverage in the target domain.
+
+## Evidence basis
+
+Primary threshold artifacts:
+- `reports/eval_run5_1000_threshold_035.jsonl`
+- `reports/eval_run6_1000_threshold_039.jsonl`
+- `reports/eval_run5_1000_threshold_042.jsonl`
+- `reports/eval_run5_1000_threshold_043.jsonl`
+
+Related context:
+- `wiki/runs/Run_4_300_tasks.md`
+- `wiki/runs/Run_6_1000_tasks.md`

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,43 +1,34 @@
-# Does every input deserve an output?
+# Wiki Index
 
-Most software pipelines silently assume a default rule: **input arrives, output is produced, output is released**.
+This wiki describes Silence-as-Control / Proof of Resonance (PoR) as a runtime release-control project.
 
-This repository explores a different systems question: should there be an explicit control mechanism between generation and release?
+## Primary pages
 
-In **Silence-as-Control / Proof of Resonance (PoR)**, the answer is yes. PoR is not a new generation method. It is a **release control layer** that evaluates whether a generated candidate should be released or silenced.
+- [Home](./Home.md)
+- [Current Status](./Current-Status.md)
+- [API Walkthrough](./API-Walkthrough.md)
+- [Threshold Regimes](./Threshold-Regimes.md)
+- [Evaluation Summary](./Evaluation-Summary.md)
+- [Evidence Map](./Evidence-Map.md)
+- [Reading Order](./Reading-Order.md)
+- [Milestones](./Milestones.md)
 
-The central idea is simple and strict:
+## Existing detailed references
 
-- Generation can remain probabilistic.
-- Release should be conditional.
-- Silence can be a valid control action.
-
-If you are new to this repository, start here:
-
-1. [Schema](./SCHEMA.md)
-2. Core concepts:
-   - [PoR](./concepts/PoR.md)
-   - [Silence as Control](./concepts/Silence_as_Control.md)
-   - [Threshold Model](./concepts/Threshold_Model.md)
-   - [Drift vs Coherence](./concepts/Drift_vs_Coherence.md)
-3. Architecture:
-   - [PoR Gate](./architecture/PoR_Gate.md)
-   - [Release Control Layer](./architecture/Release_Control_Layer.md)
-4. Comparisons:
-   - [Baseline vs PoR](./comparisons/Baseline_vs_PoR.md)
-5. Run documentation:
-   - [Run 1](./runs/Run_1.md)
-   - [Run 4 (300 tasks)](./runs/Run_4_300_tasks.md)
-   - [Run 6 (1000 tasks)](./runs/Run_6_1000_tasks.md)
-
-Audit layer:
-
-- [Evidence Map](./meta/Evidence_Map.md)
-
----
-
-## Scope and tone
-
-This wiki is written for technical readers outside the project.
-It focuses on definitions, control surfaces, and observed behavior.
-It intentionally avoids promotional language and exaggerated claims.
+- [Schema](./SCHEMA.md)
+- Concepts:
+  - [PoR](./concepts/PoR.md)
+  - [Silence as Control](./concepts/Silence_as_Control.md)
+  - [Threshold Model](./concepts/Threshold_Model.md)
+  - [Drift vs Coherence](./concepts/Drift_vs_Coherence.md)
+- Architecture:
+  - [PoR Gate](./architecture/PoR_Gate.md)
+  - [Release Control Layer](./architecture/Release_Control_Layer.md)
+- Comparison:
+  - [Baseline vs PoR](./comparisons/Baseline_vs_PoR.md)
+- Runs:
+  - [Run 1](./runs/Run_1.md)
+  - [Run 4 (300 tasks)](./runs/Run_4_300_tasks.md)
+  - [Run 6 (1000 tasks)](./runs/Run_6_1000_tasks.md)
+- Legacy evidence map page:
+  - [meta/Evidence_Map](./meta/Evidence_Map.md)

--- a/wiki/meta/Evidence_Map.md
+++ b/wiki/meta/Evidence_Map.md
@@ -1,96 +1,64 @@
-# Evidence Map
+# Evidence Map — Detailed Audit Appendix
 
-_Back to [index](../index.md)_
+Primary reader-facing evidence map:
+- [../Evidence-Map.md](../Evidence-Map.md)
 
-Purpose: provide an audit surface that connects wiki claims to committed repository evidence.
+This appendix preserves deeper repository-scoped audit discipline for stricter technical review.
 
-## Core claims and support status
+## 1) Purpose
 
-| Claim (as stated in wiki/docs) | Supporting files | Support type (taxonomy) | What this does **not** establish |
-|---|---|---|---|
-| PoR is a **release control layer**, not a generation method. | `wiki/concepts/PoR.md`, `wiki/architecture/Release_Control_Layer.md`, `README.md` | **Text-direct** (explicit text statement) | Does not establish model-quality improvement by itself. |
-| Current gate behavior is operationally **proceed/release vs silence**. | `wiki/architecture/PoR_Gate.md`, `wiki/concepts/Silence_as_Control.md`, `api/main.py` (`por_decision`, `evaluate_candidate`) | **Code-direct** (implemented decision path) | Does not establish additional active states (e.g., hold) in current implementation. |
-| Silence is treated as a control outcome (not automatically failure). | `wiki/concepts/Silence_as_Control.md`, `README.md` core idea section, run pages with non-zero `silence` counts | **Mixed-direct** (definition + observed artifact fields) | Does not prove silence is optimal in all contexts. |
-| Baseline-vs-gated comparison is available via artifact outcome fields. | `wiki/comparisons/Baseline_vs_PoR.md`, run pages, JSONL fields `no_control_success` and `with_control_success` | **Artifact-direct** (comparison fields present in JSONL) | Does not prove universal causal superiority outside recorded runs. |
-| Run pages summarize committed evidence for Run 1 / Run 4 / Run 6. | `wiki/runs/Run_1.md`, `wiki/runs/Run_4_300_tasks.md`, `wiki/runs/Run_6_1000_tasks.md`, corresponding JSONL files | **Artifact-direct** (explicit run-file mapping) | Does not cover all runs or provide full per-class evaluation where absent. |
+Use this page as a compact technical appendix:
+- to map runs to committed artifacts,
+- to clarify field-level interpretation,
+- to define support-strength categories,
+- and to state explicit evidence boundaries.
 
-## Run-to-artifact mapping
+## 2) Run-to-artifact mapping
 
-- **Run 1** -> `reports/eval_35_tasks.jsonl`.
-- **Run 4 (300 tasks)** -> `reports/eval_run4_300_threshold_035.jsonl`.
-- **Run 6 (1000 tasks)** -> `reports/eval_run6_1000_threshold_039.jsonl`.
+Core mapped runs:
+- Run 1 -> `reports/eval_35_tasks.jsonl`
+- Run 4 -> `reports/eval_run4_300_threshold_035.jsonl`
+- Run 6 -> `reports/eval_run6_1000_threshold_039.jsonl`
 
-Repository cross-reference:
+Additional 1000-task threshold mapping artifacts:
+- `reports/eval_run5_1000_threshold_035.jsonl`
+- `reports/eval_run5_1000_threshold_042.jsonl`
+- `reports/eval_run5_1000_threshold_043.jsonl`
 
-- `README.md` lists these artifacts in “Reports and tracked artifacts”.
-- `README.md` names Run #4 (threshold 0.35) and Run #6 (threshold 0.39) in “Evaluation highlights”.
+## 3) Field-level notes
 
-## Field-level notes (JSONL)
-
-The run pages rely on these committed per-record fields:
-
-- `silence`: whether output was silenced.
-- `raw_success`: task judged successful before release-control filtering.
-- `with_control_success`: success under the control/evaluated path.
-- `no_control_success`: success under the no-control comparison path.
-- `silence_threshold`: threshold value used for silence gating.
+Committed artifacts and run docs commonly rely on these fields:
+- `silence`: release was withheld by the gate.
+- `raw_success`: outcome label before release-control filtering.
+- `with_control_success`: success in the gated path.
+- `no_control_success`: success in the ungated comparison path.
+- `silence_threshold`: threshold used for silence gating.
 - `raw_success_threshold`: threshold used in raw-success labeling.
 
-Interpretation discipline used in wiki run pages:
+Interpretation rule:
+- aggregate from committed row-level fields first, then state summary metrics.
 
-- Rates/counts are aggregates of committed row-level fields.
-- “Accepted failures under control” is computed as rows with `silence=false` and `raw_success=false`.
+## 4) Evidence strength / support discipline
 
-## Supporting artifacts index
+- **text-direct**: claim is explicitly stated in docs/wiki text.
+- **code-direct**: claim is directly represented in committed implementation.
+- **artifact-direct**: claim is directly observable in committed artifacts/fields.
+- **mixed-direct**: claim depends on a direct combination of docs + artifacts/code.
+- **partial**: directionally supported but missing needed decomposition for stronger inference.
 
-Primary documentation:
+## 5) Known evidence boundaries
 
-- `README.md`
-- `wiki/index.md`
-- `wiki/SCHEMA.md`
-- `wiki/concepts/PoR.md`
-- `wiki/concepts/Silence_as_Control.md`
-- `wiki/architecture/PoR_Gate.md`
-- `wiki/architecture/Release_Control_Layer.md`
-- `wiki/comparisons/Baseline_vs_PoR.md`
-- `wiki/runs/Run_1.md`
-- `wiki/runs/Run_4_300_tasks.md`
-- `wiki/runs/Run_6_1000_tasks.md`
+- No universal generalization beyond documented runs/artifacts.
+- No claim of globally optimal threshold across all domains.
+- No claim of complete deployment proof or production hardening.
+- No claim that PoR guarantees truth.
+- Release-policy improvement does not imply universal capability improvement.
 
-Primary run artifacts:
+## 6) Maintenance rule
 
-- `reports/eval_35_tasks.jsonl`
-- `reports/eval_run4_300_threshold_035.jsonl`
-- `reports/eval_run6_1000_threshold_039.jsonl`
-
-Implementation references (only for decision-path grounding):
-
-- `api/main.py` (`por_decision`, `evaluate_candidate`)
-
-## Evidence strength
-
-- **Text-direct**: claim is explicitly stated in committed docs/wiki text.
-- **Code-direct**: claim is explicitly represented in committed implementation logic.
-- **Artifact-direct**: claim is directly observable in committed artifact fields/files.
-- **Mixed-direct**: claim depends on both explicit documentation and artifact observation.
-- **Partial**: claim is directionally supported but missing decomposition needed for stronger inference.
-
-For the current wiki set, core claims listed above are supported directly at repository scope; extrapolations remain out of scope.
-
-## Known evidence boundaries
-
-- No claim of universal generalization beyond documented runs.
-- No claim of global threshold optimality across all distributions.
-- No claim that one metric family is universally sufficient for deployment safety.
-- No claim of complete per-class/per-domain analysis where such summaries are not committed.
-- No claim that PoR guarantees truth; it changes release policy.
-
-## Maintenance rule
-
-When updating this map:
-
+When updating this appendix:
 1. Add only claims already present in repository docs/wiki.
-2. Link each claim to concrete files.
-3. Mark support as direct vs partial.
-4. State what each claim does not establish.
-5. If evidence is missing, record that explicitly instead of filling gaps.
+2. Map each claim to concrete files/artifacts.
+3. State what each claim does **not** establish.
+4. Mark support as established vs partial.
+5. Do not fill evidence gaps with inference.


### PR DESCRIPTION
### Motivation

- Provide a coherent, reader-focused wiki that explains the PoR (Silence-as-Control) thesis, runtime flow, current status, and evidence mapping.
- Make the applied API/runtime path and threshold regimes explicit for newcomers and reviewers.
- Surface committed evaluation artifacts and run summaries in a compact evidence map and evaluation summary. 

### Description

- Add new wiki pages: `wiki/Home.md`, `wiki/API-Walkthrough.md`, `wiki/Current-Status.md`, `wiki/Evaluation-Summary.md`, `wiki/Evidence-Map.md`, `wiki/Milestones.md`, `wiki/Reading-Order.md`, and `wiki/Threshold-Regimes.md` that document thesis, runtime flow, endpoints, evaluation artifacts, and operating points. 
- Update `wiki/index.md` to reference the new primary pages and streamline the landing navigation. 
- Replace and rework the detailed audit appendix at `wiki/meta/Evidence_Map.md` to preserve run-to-artifact mappings, field-level notes, evidence-strength taxonomy, and maintenance rules. 
- Document current API endpoints and applied runtime flow (request -> candidate -> gate -> proceed/silence) and list primary evidence artifacts used across the repo. 

### Testing

- No automated tests were executed because these are documentation-only changes that do not modify runtime code or tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92cf1df3c832684d6efffdb03306e)