### PR TITLE
Fix BOM handling for sandbox CSV task_id parsing

### DIFF
--- a/scripts/short_regen_sandbox.py
+++ b/scripts/short_regen_sandbox.py
@@ -67,7 +67,7 @@ def call_short_retry(client: OpenAI, *, model: str, original_prompt: str) -> tup
 
 
 def load_rows(path: Path) -> list[dict[str, str]]:
-    with path.open("r", encoding="utf-8", newline="") as f:
+    with path.open("r", encoding="utf-8-sig", newline="") as f:
         reader = csv.DictReader(f)
         return list(reader)
 


### PR DESCRIPTION
### Motivation
- PowerShell `Export-Csv` can write a UTF-8 BOM into the CSV header which prevents the CSV reader from matching the `task_id` header when opened with `encoding="utf-8"`, resulting in blank `task_id` values in outputs and reports.

### Description
- Update `load_rows()` in `scripts/short_regen_sandbox.py` to open the CSV with `encoding="utf-8-sig"` so the BOM is removed and headers (including `task_id`) parse correctly; this is a single-line change and no other behavior was modified.

### Testing
- No automated tests were run for this micro-fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da85966b2c83269bbbad550c628b9a)