### PR TITLE
Document short regen sandbox findings

### DIFF
--- a/docs/short_regen_sandbox_findings.md
+++ b/docs/short_regen_sandbox_findings.md
@@ -1,0 +1,66 @@
+# Short Regen Sandbox Findings
+
+## Why this sandbox was run
+
+The project had already documented the roadmap, analyzed the borderline pocket, and written the first extension experiment specification. This sandbox run was executed to check whether `MAYBE_SHORT_REGEN` cases could produce shorter but still useful responses through a constrained retry path, without changing the primitive core.
+
+## Scope and constraints
+
+- Primitive core: unchanged.
+- `0.39` anchor: unchanged.
+- Experiment mode: sandbox only.
+- Execution context: local experiment only.
+- Integration status: not runtime-integrated.
+- Claim boundary: this is not proof that the full silence band is recoverable.
+
+## Input lane
+
+- Target lane: `MAYBE_SHORT_REGEN`.
+- Lane size: `8` cases.
+- Dominant prompt family: `"What is truth?"`.
+- Pre-sandbox interpretation: semantically useful but over-expanded near-boundary silenced cases.
+
+## Execution result summary
+
+- Total cases processed: `8`.
+- Retry attempts succeeded: `8`.
+- `task_id` preservation issue was fixed before the successful run.
+- Retry outputs became visibly shorter/tighter.
+- Retry outputs still appeared semantically useful.
+
+## What was observed in the outputs
+
+Observed retries no longer resembled long philosophical wall-of-text answers. They shifted toward compact definitions and compact reality-based descriptions of truth.
+
+Representative style examples:
+
+- "Truth is what accurately matches reality or the facts..."
+- "Truth is what accurately corresponds to reality or the facts..."
+- "Truth is the quality of a statement... being in accordance with reality..."
+
+These are descriptive examples of output style change, not a claim of broad capability recovery.
+
+## Interpretation
+
+- This is a positive sandbox-level signal.
+- The lane choice (`MAYBE_SHORT_REGEN`) appears justified for this test.
+- The intervention type (constrained shorter retry) appears promising.
+- This is still not sufficient to justify primitive-core changes.
+- This is still not evidence that the full silence band is broadly recoverable.
+
+## What this does **not** prove
+
+- It does **not** prove production readiness.
+- It does **not** justify moving the `0.39` anchor.
+- It does **not** justify broad recovery of all silenced cases.
+- It does **not** justify merging extension logic into the primitive core.
+- It does **not** replace a more formal evaluation layer.
+
+## Best next step
+
+Preserve this run as sandbox evidence in repository memory. Then choose one conservative path:
+
+1. Add a lightweight structured evaluation layer for this lane, or
+2. Define the next tighter experiment iteration with explicit acceptance criteria.
+
+Either path should remain scoped, evidence-driven, and non-disruptive to the primitive core.


### PR DESCRIPTION
### Motivation
- Preserve the first sandbox execution signal for the `MAYBE_SHORT_REGEN` lane by recording purpose, scope, lane details, observed results, interpretation, explicit non-claims, and conservative next-step options.

### Description
- Add a single documentation file `docs/short_regen_sandbox_findings.md` that captures why the sandbox was run, scope and constraints, input lane details, execution result summary, representative output observations, interpretation, explicit limitations, and recommended next steps; commit message: `Add short regen sandbox findings document`.

### Testing
- Automated tests: none were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8d882634832689dc88adc9e002bb)