### PR TITLE
Update wiki memory for silence-rate workstream and sandbox milestones

### DIFF
--- a/wiki/Current-Status.md
+++ b/wiki/Current-Status.md
@@ -7,15 +7,22 @@
 - Baseline vs PoR framing is explicit in docs and wiki (`docs/baseline_vs_por_quick_guide.md`, `wiki/comparisons/Baseline_vs_PoR.md`).
 - Artifact trail/report surface is established (`reports/` JSONL + plots + run pages).
 - Proof surface maturity improved: claims are connected to artifacts and run summaries.
+- Repo surface / onboarding layer has been strengthened (README + wiki + docs cross-navigation updates already merged).
+- Silence-rate optimization is now a separate documented workstream (`docs/silence_rate_roadmap.md`).
+- Borderline pocket findings are documented (`docs/borderline_pocket_findings.md`).
+- First extension experiment is documented (`docs/first_extension_experiment.md`).
+- First short-regeneration sandbox runner exists (`scripts/short_regen_sandbox.py`).
+- Sandbox CSV BOM/task_id micro-fix has been applied (loader robustness fix merged in PR #97).
+- First short-regeneration sandbox findings are documented (`docs/short_regen_sandbox_findings.md`).
 
 ## In Progress
 
 - Applied API/runtime surface is becoming clearer (`docs/api_walkthrough.md`, `api/main.py`).
-- Documentation path for newcomers is being tightened across README/wiki/docs.
-- Public-facing technical legibility is improving (clearer claim/evidence mapping and runtime flow explanation).
+- Controlled follow-up work on extension-layer behavior after first sandbox-level signal.
+- Conservative lane selection for next experiment step using documented borderline-pocket and sandbox evidence.
 
 ## Next
 
-- Live integration demo that shows gate behavior in an external or near-external flow.
-- Compact external narrative that is strict about what is proven vs pending.
-- Stronger applied use-case demonstration (runtime control value in concrete deployment-like tasks).
+- Run disciplined follow-up sandbox passes (same harness class, tighter lane controls, explicit acceptance criteria).
+- Refine extension-layer direction based on measured sandbox-level signal (not broad runtime retuning).
+- Keep evidence map strict: separate what is documented from what is only suggested by early exploratory results.

--- a/wiki/Milestones.md
+++ b/wiki/Milestones.md
@@ -18,11 +18,29 @@
    - `docs/api_walkthrough.md` + runtime endpoints provide a clearer applied path:
      request -> candidate -> gate -> proceed/silence.
 
-6. **Current stage**
-   - Post-proof, post-threshold-map, applied API surface emerging, pre-clear external integration demo.
+6. **Silence-rate optimization workstream documented**
+   - `docs/silence_rate_roadmap.md` defines the workstream and discipline boundaries.
+
+7. **Borderline pocket findings documented**
+   - `docs/borderline_pocket_findings.md` captures structured exploratory evidence for lane selection.
+
+8. **First extension experiment specified**
+   - `docs/first_extension_experiment.md` documents the first extension-layer direction and conservative next step.
+
+9. **First short-regeneration sandbox runner added**
+   - `scripts/short_regen_sandbox.py` added as a controlled sandbox execution surface.
+
+10. **Sandbox loader micro-fix merged**
+   - BOM/task_id CSV loader fix applied (PR #97), reducing avoidable ingest noise in sandbox runs.
+
+11. **First short-regeneration sandbox findings documented**
+   - `docs/short_regen_sandbox_findings.md` records first sandbox-level signal and limits of interpretation.
+
+12. **Current stage**
+   - Post-proof + post-workstream-documentation + first sandbox signal captured; now in controlled follow-up mode, not basic documentation mode.
 
 ## Next milestone targets
 
-- External/live integration demonstration of runtime gate behavior.
-- Compact external technical narrative tied to evidence map.
-- Stronger applied use-case package for non-research readers.
+- Controlled follow-up sandbox run(s) with explicit lane and stopping criteria.
+- Extension-layer direction refinement based on sandbox-level signal.
+- Conservative bridge from sandbox evidence to stronger applied demonstrations.

--- a/wiki/meta/Evidence_Map.md
+++ b/wiki/meta/Evidence_Map.md
@@ -62,3 +62,37 @@ When updating this appendix:
 3. State what each claim does **not** establish.
 4. Mark support as established vs partial.
 5. Do not fill evidence gaps with inference.
+
+## 7) Recent workstream evidence additions (PRs #93-#98)
+
+Use these mappings for current status claims and milestone traceability.
+
+### A) Workstream definition evidence
+- Artifact: `docs/silence_rate_roadmap.md`
+- Supports: silence-rate optimization is a defined, separate workstream with scoped goals.
+- Support class: **text-direct**
+- Does **not** establish: solved silence behavior or production validation.
+
+### B) Structured exploratory evidence (borderline pocket)
+- Artifact: `docs/borderline_pocket_findings.md`
+- Supports: borderline pocket has been analyzed and summarized for practical lane selection.
+- Support class: **text-direct** (with artifact references inside the doc)
+- Does **not** establish: full silence-band recoverability.
+
+### C) Extension-layer direction evidence
+- Artifact: `docs/first_extension_experiment.md`
+- Supports: first extension experiment is specified as a conservative next step.
+- Support class: **text-direct**
+- Does **not** establish: end-to-end runtime gain in external deployment conditions.
+
+### D) Sandbox-level execution signal
+- Artifact: `scripts/short_regen_sandbox.py`
+- Supports: a committed runner exists for short-regeneration sandbox execution.
+- Support class: **code-direct**
+- Does **not** establish: broad runtime integration validity by itself.
+
+### E) Sandbox findings evidence
+- Artifact: `docs/short_regen_sandbox_findings.md`
+- Supports: first sandbox run findings are documented and bounded.
+- Support class: **mixed-direct** (documented interpretation of committed sandbox artifacts)
+- Does **not** establish: complete production readiness or universal threshold conclusions.


### PR DESCRIPTION
### Motivation

- Recent merged artifacts (roadmap, borderline-pocket analysis, first extension spec, sandbox runner, BOM fix, and sandbox findings) need to be reflected in the repository status/evidence surfaces so the project memory is consistent with the codebase. 
- Keep the repo narrative disciplined and conservative: record documented workstream and sandbox-level signal while avoiding overclaiming production readiness or solved status. 
- Maintain evidence hygiene so downstream reviewers can trace claims to concrete artifacts for controlled follow-up work.

### Description

- Updated `wiki/Current-Status.md` to record that the repo/onboarding surface has been strengthened and to mark `docs/silence_rate_roadmap.md`, `docs/borderline_pocket_findings.md`, `docs/first_extension_experiment.md`, `scripts/short_regen_sandbox.py`, the BOM/task_id micro-fix (PR #97), and `docs/short_regen_sandbox_findings.md` as documented artifacts; shifted “In Progress/Next” toward controlled follow-up sandbox work rather than basic documentation. 
- Extended `wiki/Milestones.md` with a clear progression capturing roadmap creation, borderline-pocket findings, first extension experiment spec, sandbox runner addition, BOM/task_id fix, and short-regeneration sandbox findings, and moved the current-stage framing to reflect controlled follow-up. 
- Added a conservative mapping block to `wiki/meta/Evidence_Map.md` that links the new artifacts to evidence classes (workstream definition, structured exploratory evidence, extension-layer direction, sandbox-level execution signal, and sandbox findings) and explicitly states what these artifacts do not establish.

### Testing

- Verified repository status and changed file set with `git status --short` to confirm only the intended files were modified. 
- Inspected diffs with `git diff -- wiki/Current-Status.md wiki/Milestones.md wiki/meta/Evidence_Map.md` and reviewed the updated contents using `nl -ba`/`sed` to validate the inserted text and structure. 
- Confirmed the changes are limited to the three wiki files and that the edits follow the requested conservative, engineering-focused tone and phrasing (no runtime/code changes were made).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9135d21c8326b6469844c079b8d2)