### PR TITLE
Add borderline-pocket artifacts and short-regen lane builder; refresh reports README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,17 +116,25 @@ Selected tracked operating points:
 
 Threshold is a control dial for release behavior. For run-level interpretation and supporting details, use `wiki/runs/` and `wiki/meta/Evidence_Map.md`.
 
-## Visual proof
+## Selected evidence snapshots
 
-![PoR threshold control curve](reports/threshold_control_curve.png)
+![Threshold control curve](reports/threshold_control_curve.png)
+*Threshold operating-mode behavior across tracked runs.*
+
 ![Accepted failures comparison](reports/accepted_failures_comparison.png)
+*Failure leakage appears at boundary/aggressive thresholds and returns to zero at the conservative-safe setting.*
+
 ![Drift separation comparison](reports/drift_separation_comparison.png)
-![Run metrics](reports/metrics.png)
+*Success/failure drift separation remains visible across operating points.*
 
-Additional tracked plots:
+For additional visuals and run artifacts, see `reports/README.md`.
 
-- `reports/drift.png`
-- `reports/drift_clean.png`
+## Silence-rate workstream (recent docs)
+
+- `docs/silence_rate_roadmap.md`
+- `docs/borderline_pocket_findings.md`
+- `docs/first_extension_experiment.md`
+- `docs/short_regen_sandbox_findings.md`
 
 ## Reports and tracked artifacts
 

--- a/docs/borderline_pocket_findings.md
+++ b/docs/borderline_pocket_findings.md
@@ -28,6 +28,11 @@ Manual labeling of the 16-case pocket produced:
 - MAYBE_SHORT_REGEN = 8
 - KEEP_SILENCE = 3
 
+Tracked artifacts for this split:
+
+- Full pocket labels: `reports/borderline_pocket_labels.csv` (16 rows).
+- MAYBE_SHORT_REGEN sandbox subset: `reports/borderline_maybe_short_regen.csv` (8 rows).
+
 ## Interpretation
 
 The silence band is not homogeneous. Most silenced cases still appear to be hard silence, but there is a small near-boundary pocket with real rescue potential. The pocket also appears internally structured rather than random.

--- a/reports/README.md
+++ b/reports/README.md
@@ -1,309 +1,56 @@
-# -*- coding: utf-8 -*-
+# Reports
 
-from pathlib import Path
+This directory is the repository's **evidence surface** for run artifacts, summary visuals, and small reproducibility inputs.
 
-readme_content = """# Silence-as-Control — Proof Surface
+## What belongs here
 
-Silence-as-Control is a control-layer primitive for AI systems:
-when coherence or task-output alignment cannot be guaranteed,
-intentional silence is preferred over misleading output.
+- **Tracked run artifacts**: canonical JSONL outputs from evaluation runs.
+- **Plots / visual summaries**: stable images used for quick evidence inspection.
+- **Helper scripts**: local analysis/plot scripts that generate or summarize report outputs.
+- **Reproducibility inputs**: small, curated CSVs used by sandbox or extension-lane experiments.
 
-Core idea:
-- Baseline: model emits
-- PoR: model emits only if runtime state is stable enough
-- If unstable -> silence
+## Tracked run artifacts (JSONL)
 
-This repository tracks:
-- repeated live eval runs
-- threshold operating modes
-- boundary discovery
-- integration demos
+- `eval_35_tasks.jsonl`
+- `eval_100_tasks.jsonl`
+- `eval_run2_100_tasks.jsonl`
+- `eval_run3.jsonl`
+- `eval_run4_300_threshold_035.jsonl`
+- `eval_run5_1000_threshold_035.jsonl`
+- `eval_run5_1000_threshold_042.jsonl`
+- `eval_run5_1000_threshold_043.jsonl`
+- `eval_run6_1000_threshold_039.jsonl`
 
----
+## Reproducibility lane artifacts (CSV)
 
-## Core Logic
+- `borderline_maybe_short_regen.csv`  
+  Curated MAYBE_SHORT_REGEN lane input (8 task IDs) used by the short-regen sandbox workstream.
+- `borderline_pocket_labels.csv`  
+  Full 16-case manual label table for the near-boundary borderline pocket (RECOVERABLE / MAYBE_SHORT_REGEN / KEEP_SILENCE).
 
-if drift > threshold or coherence < threshold:
-    return SilenceToken
-else:
-    return Proceed
+## Plot files (tracked visual summaries)
 
-PoR does not try to make the model smarter.
-PoR decides when the model is allowed to speak.
+- `threshold_control_curve.png`
+- `accepted_failures_comparison.png`
+- `drift_separation_comparison.png`
+- `metrics.png`
+- `drift.png`
+- `drift_clean.png`
 
----
+## Helper scripts
 
-## Run #1 — 35 tasks (mixed good / bad / edge cases)
+- `plot_threshold_comparison.py`
 
-Silence rate: 14.3%
-Coverage: 85.7%
-Accepted precision: 100%
-Risk capture: 100%
-Silence precision: 40%
+## Interpretation notes
 
-Drift:
+- JSONL files are **run outputs** and should be treated as primary evidence.
+- CSV files are **curated reproducibility inputs**, not runtime logic.
+- PNG files are **visual summaries**; interpretation should be anchored to the corresponding JSONL artifacts.
 
-* success: 0.218
-* fail: 0.566
-* separation: \~2.60x
+## Maintenance policy
 
-Notes:
+Keep this directory disciplined:
 
-* Clear separation between correct and incorrect outputs
-* Some over-silencing present
-
-
----
-
-## Run #2 — 100 tasks
-
-Silence rate: 27.0%
-Coverage: 73.0%
-Accepted precision: 100%
-Risk capture: 100%
-Silence precision: 22.22%
-
-Drift:
-
-* success: 0.245
-* fail: 0.540
-* separation: \~2.20x
-
-<<<<<<< HEAD
-Notes:
-- Stable behavior
-- Conservative (over-silencing)
-=======
-Quality:
-
-* accepted: 0.802
-* all: 0.750
-
-Notes:
-
-* Drift separation stable vs Run #1
-* No recalibration used
-* Conservative behavior (over-silencing)
-
->>>>>>> dd95cbe (Add Run #4 robustness results (300 tasks, threshold 0.35))
-
----
-
-## Run #3 — 100 tasks
-
-Silence rate: 24.0%
-Coverage: 76.0%
-Accepted precision: 100%
-Risk capture: 100%
-Silence precision: 20.83%
-
-Drift:
-
-* success: 0.242
-* fail: 0.571
-* separation: \~2.36x
-
-Notes:
-<<<<<<< HEAD
-- Repeatability confirmed
-
----
-
-## Run #4 — 300 tasks (threshold = 0.35)
-
-Silence rate: 36.0%
-Coverage: 64.0%
-Accepted precision: 100%
-Risk capture: 100%
-Silence precision: 96.3%
-
-Drift:
-- success: 0.254
-- fail: 0.716
-- separation: ~2.82x
-
-Notes:
-- First strong robustness result
-- Zero accepted failures
-- Control regime confirmed
-
----
-
-## Run #5 — 1000 tasks (threshold = 0.35)
-
-Silence rate: 46.5%
-Coverage: 53.5%
-Accepted precision: 100%
-Risk capture: 100%
-Silence precision: 93.76%
-
-Drift:
-- success: 0.253
-- fail: 0.676
-- separation: ~2.67x
-
-Notes:
-- Scaling confirmed
-- Safe regime preserved
-
----
-
-## Run #6 — 1000 tasks (threshold = 0.42)
-
-Silence rate: 43.7%
-Coverage: 56.3%
-Accepted precision: 98.76%
-Risk capture: 98.41%
-Silence precision: 98.86%
-Accepted raw fail: 7
-
-Drift:
-- success: 0.250
-- fail: 0.670
-- separation: ~2.68x
-
-Notes:
-- Boundary regime discovered
-- First accepted failures appear
-
----
-
-## Run #7 — 1000 tasks (threshold = 0.39)
-
-Silence rate: 45.6%
-Coverage: 54.4%
-Accepted precision: 100.0%
-Risk capture: 100.0%
-Silence precision: 96.71%
-Accepted raw fail: 0
-
-Drift:
-- success: 0.247
-- fail: 0.671
-- separation: ~2.71x
-
-Notes:
-- Optimal safe operating point
-- Zero accepted failures restored
-- Best balance vs 0.35
-
----
-
-## Threshold Operating Modes
-
-0.35 -> Safe mode (conservative)
-0.39 -> Optimal safe mode (best balance)
-0.42 -> Boundary (leakage begins)
-0.43 -> Aggressive / unsafe
-
-Threshold is a control dial.
-
----
-
-## Baseline vs PoR
-
-Baseline:
-- higher coverage
-- emits incorrect outputs
-
-PoR:
-- lower coverage
-- eliminates accepted failures
-
-Trade-off:
--> small coverage loss for full control
-
----
-
-## Integration Demo
-
-Baseline FAIL -> PoR SILENCE
-drift = 0.460 > threshold = 0.39
-
-PoR blocks unstable output instead of emitting incorrect code.
-
----
-
-## Key Insight
-
-PoR does not improve the model.
-
-PoR controls the model.
-
-From:
-"generate and hope"
-
-To:
-"evaluate and decide"
-"""
-
-Path("reports").mkdir(exist_ok=True)
-Path("reports/README.md").write_text(readme_content, encoding="utf-8")
-
-print("README FULLY FIXED — NO CONFLICTS")
-=======
-
-* Repeatability confirmed on another 100-task dataset
-* Accepted precision remained perfect
-* Conservative behavior still present
-
-
-
-## Run #4 — 300 tasks (threshold = 0.35)
-
-Silence rate: 36.0%  
-Coverage: 64.0%
-
-Accepted precision: 100%  
-Risk capture: 100%  
-Silence precision: 96.3%
-
-Drift:
-
-* success: 0.254
-* fail: 0.716
-* separation: \~2.82x
-
-Quality:
-
-* accepted: 0.763
-* all: 0.571
-* 
-
-Notes:
-
-* 300-tasks robustness run
-* threshold increased 0.30 to 0.35
-* coverage improved significantly
-* no accepted failures
-* strong drift separation preserved
-
-
-
-<<<<<<< HEAD
->>>>>>> dd95cbe (Add Run #4 robustness results (300 tasks, threshold 0.35))
-=======
-## Run #5 — 1000 tasks (threshold = 0.35)
-
-Silence rate: 46.5%  
-Coverage: 53.5%
-
-Accepted precision: 100%  
-Risk capture: 100%  
-Silence precision: 93.76%
-
-Drift:
-
-* success: 0.253
-* fail: 0.676
-* separation: \~2.67x
-
-Notes:
-
-* Scaling test from 300 → 1000 tasks
-* Zero accepted failures preservedcoverage improved significantly
-* Drift separation remains stable
-* strong drift separation preserved
-* Increased silence (more conservative behavior)
-
->>>>>>> (Add Run #5 results (1000 tasks, threshold 0.35))
+- Prefer small, auditable artifacts.
+- Do not add generated noise files or scratch outputs.
+- Keep filenames explicit about run context (task count, threshold, or lane purpose).

--- a/reports/borderline_maybe_short_regen.csv
+++ b/reports/borderline_maybe_short_regen.csv
@@ -1,0 +1,250 @@
+task_id,category,prompt,output,semantic_proxy_drift,length_ratio_drift,raw_quality_score,raw_success,silence,manual_label,manual_notes
+edge_729,edge,What is truth?,"“Truth” usually means: **what is actually the case**.
+
+A statement is true if it matches reality.  
+For example:
+
+- “Water freezes at 0°C at standard pressure” → true
+- “The Moon is made of cheese” → false
+
+But the idea gets deeper in philosophy. Common ways people think about truth include:
+
+1. **Correspondence theory**  
+   Truth is when a belief or statement matches the facts.
+
+2. **Coherence theory**  
+   Truth is when something fits consistently within a larger system of beliefs.
+
+3. **Pragmatic theory**  
+   Truth is what proves reliable or works in practice.
+
+4. **Deflationary view**  
+   Saying “it is true that snow is white” adds little beyond saying “snow is white.”
+
+There’s also a difference between:
+
+- **Objective truth**: independent of opinion  
+  - e.g. “The Earth orbits the Sun.”
+- **Subjective truth**: dependent on personal experience  
+  - e.g. “This music is comforting to me.”
+
+In everyday life, truth often means **honesty**, **accuracy**, or **reality as opposed to illusion or error**.
+
+A short answer:  
+**Truth is the quality of being in accord with reality.**
+
+If you want, I can also answer this:
+- philosophically,
+- scientifically,
+- religiously,
+- or in a more poetic way.",0.397,1.0,0.641,True,True,MAYBE_SHORT_REGEN,Boundary pocket lane; short-regeneration sandbox input.
+edge_788,edge,What is truth?,"Truth is what is actually the case.
+
+That sounds simple, but philosophers have meant a few different things by it:
+
+- **Correspondence theory**: a statement is true if it matches reality.  
+  - “Water boils at 100°C at sea level” is true if that’s how the world works.
+- **Coherence theory**: a belief is true if it fits consistently within a larger system of beliefs.
+- **Pragmatic theory**: truth is what proves reliable in practice or inquiry.
+- **Deflationary views**: saying “it is true that snow is white” adds little beyond saying “snow is white.”
+
+There’s also a difference between:
+- **Objective truth**: independent of opinion, like mathematical or many physical facts.
+- **Subjective truth**: grounded in personal experience, like “this music makes me sad.”
+
+In everyday life, “truth” usually means:
+1. Honest representation,
+2. Accuracy about facts,
+3. Sometimes deeper reality or meaning.
+
+A short answer:  
+**Truth is the alignment of belief, statement, or perception with reality — though what counts as “reality” and how we know it is where the debate begins.**
+
+If you want, I can also answer this:
+- philosophically,
+- scientifically,
+- spiritually,
+- or in the style of a specific thinker like Plato, Nietzsche, or Buddha.",0.397,1.0,0.641,True,True,MAYBE_SHORT_REGEN,Boundary pocket lane; short-regeneration sandbox input.
+edge_822,edge,What is truth?,"Truth is what is actually the case.
+
+That sounds simple, but the question gets deep fast because people mean different things by “truth”:
+
+- **Everyday truth:** A statement matches reality.  
+  - “Water freezes at 0°C at standard pressure” is true.
+- **Logical or mathematical truth:** A statement follows from definitions or rules.  
+  - “2 + 2 = 4.”
+- **Subjective or personal truth:** Someone’s real experience or feeling.  
+  - “I felt hurt by that” can be true as a report of experience.
+- **Moral or existential truth:** A deeper claim about meaning, value, or human life.  
+  - Harder to verify, but still what many people mean by “truth.”
+
+Philosophers have proposed different theories:
+
+- **Correspondence theory:** Truth is when a belief matches reality.
+- **Coherence theory:** Truth is when a belief fits consistently within a larger system of beliefs.
+- **Pragmatic theory:** Truth is what proves reliable or works in practice.
+- **Deflationary views:** Saying “it is true” often just means saying the statement itself.
+
+There’s also a human problem: we often confuse truth with:
+
+- what we want to be true,
+- what feels true,
+- what most people believe,
+- what is useful to believe.
+
+Those can overlap with truth, but they are not the same thing.
+
+A short answer:
+**Truth is reality correctly described.**
+
+A deeper answer:
+**Truth is the goal of thought when we are trying not merely to believe, but to believe rightly.**
+
+If you want, I can also answer this:
+- philosophically,
+- scientifically,
+- spiritually,
+- or in a one-sentence poetic way.",0.397,1.0,0.641,True,True,MAYBE_SHORT_REGEN,Boundary pocket lane; short-regeneration sandbox input.
+edge_863,edge,What is truth?,"“Truth” usually means **what is actually the case**.
+
+A statement is true if it matches reality.  
+For example:
+
+- “Water freezes at 0°C at standard pressure” — true.
+- “The Moon is made of cheese” — false.
+
+But philosophers have given different ways of understanding truth:
+
+1. **Correspondence theory**  
+   Truth is when a belief or statement matches the facts.
+
+2. **Coherence theory**  
+   Truth is when a belief fits consistently within a larger system of beliefs.
+
+3. **Pragmatic theory**  
+   Truth is what proves reliable or works in practice.
+
+4. **Deflationary/minimal theory**  
+   Saying “it is true that snow is white” adds little beyond saying “snow is white.”
+
+There’s also a deeper issue:  
+- **Objective truth**: true regardless of what anyone thinks.  
+- **Subjective truth**: true relative to personal experience, like “this music is beautiful.”
+
+In everyday life, “truth” usually means **honesty**, **accuracy**, or **reality as it is rather than as we wish it to be**.
+
+A short answer:  
+**Truth is the alignment of belief, statement, or perception with reality.**
+
+If you want, I can also answer this **philosophically, scientifically, religiously, or poetically**.",0.396,1.0,0.641,True,True,MAYBE_SHORT_REGEN,Boundary pocket lane; short-regeneration sandbox input.
+edge_870,edge,What is truth?,"Truth is what is the case.
+
+That’s the shortest answer, but “truth” can mean a few different things depending on context:
+
+- Correspondence view: a statement is true if it matches reality.  
+  - “Water boils at 100°C at sea level” is true if, in fact, that happens.
+
+- Coherence view: something is true if it fits consistently within a larger system of beliefs or statements.
+
+- Pragmatic view: truth is what proves reliable in practice or inquiry.
+
+- Existential or personal sense: “truth” can mean honesty, authenticity, or facing reality without self-deception.
+
+People also distinguish:
+
+- Objective truth: true regardless of anyone’s opinion.
+- Subjective truth: true as a matter of personal experience.
+  - “This song makes me sad” can be true for you.
+
+A classic philosophical problem is that humans don’t access reality perfectly, so we often ask not just “What is truth?” but “How do we know what is true?”
+
+If you want, I can also answer this:
+- philosophically,
+- scientifically,
+- religiously,
+- or in a plain everyday sense.",0.412,1.0,0.629,True,True,MAYBE_SHORT_REGEN,Boundary pocket lane; short-regeneration sandbox input.
+edge_903,edge,What is truth?,"“Truth” can mean a few related things:
+
+1. Correspondence to reality  
+A statement is true if it matches the way things actually are.  
+Example: “Water freezes at 0°C at standard pressure” is true because that is how reality behaves.
+
+2. Logical or mathematical truth  
+Some things are true within a formal system because they follow from definitions or rules.  
+Example: “2 + 2 = 4.”
+
+3. Sincerity or honesty  
+Sometimes “truth” means speaking honestly or authentically.  
+Example: “Tell me the truth” means “don’t deceive me.”
+
+4. Deeper or existential truth  
+People also use “truth” to mean a profound insight about life, self, or meaning.  
+Example: “A hard truth about life is that it includes loss.”
+
+Philosophically, different theories explain truth differently:
+- Correspondence theory: truth matches reality.
+- Coherence theory: truth fits consistently within a whole system of beliefs.
+- Pragmatic theory: truth is what proves reliable or workable in experience.
+- Deflationary view: saying “it is true that snow is white” just means “snow is white.”
+
+Pilate’s famous question, “What is truth?”, matters because truth is both simple and difficult: we use it constantly, but defining it fully raises deep questions about reality, language, knowledge, and perception.
+
+If you want, I can also give:
+- a philosophical answer,
+- a religious answer,
+- a scientific answer, or
+- a poetic answer.",0.397,1.0,0.641,True,True,MAYBE_SHORT_REGEN,Boundary pocket lane; short-regeneration sandbox input.
+edge_920,edge,What is truth?,"“Truth” usually means **what is actually the case**.
+
+A statement is true if it matches reality.  
+For example:
+
+- “Water freezes at 0°C at standard pressure” — true.
+- “The Moon is made of cheese” — false.
+
+But “truth” can mean slightly different things depending on context:
+
+- **Everyday sense:** accuracy, honesty, or fact.
+- **Philosophy:** a deeper question: *what makes something true?*
+  - **Correspondence theory:** truth is when beliefs match reality.
+  - **Coherence theory:** truth is when a belief fits consistently within a larger system of beliefs.
+  - **Pragmatic theory:** truth is what proves reliable or useful in practice.
+
+There’s also a personal sense:
+- **Objective truth:** independent of anyone’s opinions.
+- **Subjective truth:** true from a person’s perspective or experience, like “I am in pain.”
+
+So the shortest answer is:
+
+**Truth is what is real, factual, or in accordance with reality.**
+
+If you want, I can also answer this:
+- philosophically,
+- scientifically,
+- religiously,
+- or poetically.",0.412,1.0,0.629,True,True,MAYBE_SHORT_REGEN,Boundary pocket lane; short-regeneration sandbox input.
+edge_948,edge,What is truth?,"“Truth” can mean a few related things:
+
+- **Correspondence to reality:** A statement is true if it matches the way things actually are.  
+  - Example: “Water freezes at 0°C at standard pressure” is true because it reflects reality under those conditions.
+
+- **Logical or mathematical truth:** Something is true because it follows from definitions or rules.  
+  - Example: “2 + 2 = 4.”
+
+- **Personal or existential truth:** What feels deeply real or authentic to someone.  
+  - Example: “It is true for me that music gives my life meaning.”
+
+Philosophers have proposed different theories:
+
+- **Correspondence theory:** Truth = matching reality.
+- **Coherence theory:** Truth = fitting consistently within a larger system of beliefs.
+- **Pragmatic theory:** Truth = what proves reliable or useful in practice.
+- **Deflationary views:** Saying “it is true that X” often just means “X.”
+
+A short answer: **truth is what is the case**—but determining that can be simple in math, harder in science, and hardest in human life.
+
+If you want, I can also answer this:
+- philosophically,
+- scientifically,
+- religiously,
+- or poetically.",0.396,1.0,0.641,True,True,MAYBE_SHORT_REGEN,Boundary pocket lane; short-regeneration sandbox input.

--- a/reports/borderline_pocket_labels.csv
+++ b/reports/borderline_pocket_labels.csv
@@ -1,0 +1,17 @@
+task_id,manual_label,manual_notes
+edge_946,RECOVERABLE,Near-boundary recoverable case.
+edge_913,RECOVERABLE,Near-boundary recoverable case.
+good_213,RECOVERABLE,Near-boundary recoverable case.
+good_141,RECOVERABLE,Near-boundary recoverable case.
+good_62,RECOVERABLE,Near-boundary recoverable case.
+edge_729,MAYBE_SHORT_REGEN,Boundary pocket lane; short-regeneration sandbox input.
+edge_788,MAYBE_SHORT_REGEN,Boundary pocket lane; short-regeneration sandbox input.
+edge_822,MAYBE_SHORT_REGEN,Boundary pocket lane; short-regeneration sandbox input.
+edge_863,MAYBE_SHORT_REGEN,Boundary pocket lane; short-regeneration sandbox input.
+edge_870,MAYBE_SHORT_REGEN,Boundary pocket lane; short-regeneration sandbox input.
+edge_903,MAYBE_SHORT_REGEN,Boundary pocket lane; short-regeneration sandbox input.
+edge_920,MAYBE_SHORT_REGEN,Boundary pocket lane; short-regeneration sandbox input.
+edge_948,MAYBE_SHORT_REGEN,Boundary pocket lane; short-regeneration sandbox input.
+bad_474,KEEP_SILENCE,Near-boundary case that should remain silenced.
+bad_572,KEEP_SILENCE,Near-boundary case that should remain silenced.
+bad_457,KEEP_SILENCE,Near-boundary case that should remain silenced.

--- a/scripts/build_short_regen_lane.py
+++ b/scripts/build_short_regen_lane.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+SOURCE_JSONL = Path("reports/eval_run6_1000_threshold_039.jsonl")
+MAYBE_SHORT_REGEN_CSV = Path("reports/borderline_maybe_short_regen.csv")
+POCKET_LABELS_CSV = Path("reports/borderline_pocket_labels.csv")
+
+FULL_BORDERLINE_POCKET_LABELS: list[tuple[str, str, str]] = [
+    ("edge_946", "RECOVERABLE", "Near-boundary recoverable case."),
+    ("edge_913", "RECOVERABLE", "Near-boundary recoverable case."),
+    ("good_213", "RECOVERABLE", "Near-boundary recoverable case."),
+    ("good_141", "RECOVERABLE", "Near-boundary recoverable case."),
+    ("good_62", "RECOVERABLE", "Near-boundary recoverable case."),
+    (
+        "edge_729",
+        "MAYBE_SHORT_REGEN",
+        "Boundary pocket lane; short-regeneration sandbox input.",
+    ),
+    (
+        "edge_788",
+        "MAYBE_SHORT_REGEN",
+        "Boundary pocket lane; short-regeneration sandbox input.",
+    ),
+    (
+        "edge_822",
+        "MAYBE_SHORT_REGEN",
+        "Boundary pocket lane; short-regeneration sandbox input.",
+    ),
+    (
+        "edge_863",
+        "MAYBE_SHORT_REGEN",
+        "Boundary pocket lane; short-regeneration sandbox input.",
+    ),
+    (
+        "edge_870",
+        "MAYBE_SHORT_REGEN",
+        "Boundary pocket lane; short-regeneration sandbox input.",
+    ),
+    (
+        "edge_903",
+        "MAYBE_SHORT_REGEN",
+        "Boundary pocket lane; short-regeneration sandbox input.",
+    ),
+    (
+        "edge_920",
+        "MAYBE_SHORT_REGEN",
+        "Boundary pocket lane; short-regeneration sandbox input.",
+    ),
+    (
+        "edge_948",
+        "MAYBE_SHORT_REGEN",
+        "Boundary pocket lane; short-regeneration sandbox input.",
+    ),
+    ("bad_474", "KEEP_SILENCE", "Near-boundary case that should remain silenced."),
+    ("bad_572", "KEEP_SILENCE", "Near-boundary case that should remain silenced."),
+    ("bad_457", "KEEP_SILENCE", "Near-boundary case that should remain silenced."),
+]
+
+MAYBE_SHORT_REGEN_TASK_IDS = [
+    "edge_729",
+    "edge_788",
+    "edge_822",
+    "edge_863",
+    "edge_870",
+    "edge_903",
+    "edge_920",
+    "edge_948",
+]
+
+LANE_COLUMNS = [
+    "task_id",
+    "category",
+    "prompt",
+    "output",
+    "semantic_proxy_drift",
+    "length_ratio_drift",
+    "raw_quality_score",
+    "raw_success",
+    "silence",
+    "manual_label",
+    "manual_notes",
+]
+
+
+def load_rows(path: Path) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            rows.append(json.loads(line))
+    return rows
+
+
+def verify_expected_ids_exist(rows: list[dict[str, object]]) -> dict[str, dict[str, object]]:
+    rows_by_id = {str(row.get("task_id", "")): row for row in rows}
+    expected_ids = {task_id for task_id, _, _ in FULL_BORDERLINE_POCKET_LABELS}
+    missing_ids = sorted(expected_ids - set(rows_by_id))
+    if missing_ids:
+        raise ValueError(f"Missing expected borderline-pocket task_ids: {missing_ids}")
+    return rows_by_id
+
+
+def build_lane_rows(rows_by_id: dict[str, dict[str, object]]) -> list[dict[str, object]]:
+    notes_by_id = {
+        task_id: note
+        for task_id, label, note in FULL_BORDERLINE_POCKET_LABELS
+        if label == "MAYBE_SHORT_REGEN"
+    }
+    lane_rows: list[dict[str, object]] = []
+    for task_id in MAYBE_SHORT_REGEN_TASK_IDS:
+        row = rows_by_id[task_id]
+        lane_rows.append(
+            {
+                "task_id": row.get("task_id", ""),
+                "category": row.get("category", ""),
+                "prompt": row.get("prompt", ""),
+                "output": row.get("output", ""),
+                "semantic_proxy_drift": row.get("semantic_proxy_drift", ""),
+                "length_ratio_drift": row.get("length_ratio_drift", ""),
+                "raw_quality_score": row.get("raw_quality_score", ""),
+                "raw_success": row.get("raw_success", ""),
+                "silence": row.get("silence", ""),
+                "manual_label": "MAYBE_SHORT_REGEN",
+                "manual_notes": notes_by_id[task_id],
+            }
+        )
+    return lane_rows
+
+
+def build_pocket_label_rows() -> list[dict[str, str]]:
+    return [
+        {
+            "task_id": task_id,
+            "manual_label": manual_label,
+            "manual_notes": manual_notes,
+        }
+        for task_id, manual_label, manual_notes in FULL_BORDERLINE_POCKET_LABELS
+    ]
+
+
+def write_csv(path: Path, fieldnames: list[str], rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    rows = load_rows(SOURCE_JSONL)
+    rows_by_id = verify_expected_ids_exist(rows)
+
+    lane_rows = build_lane_rows(rows_by_id)
+    pocket_rows = build_pocket_label_rows()
+
+    write_csv(MAYBE_SHORT_REGEN_CSV, LANE_COLUMNS, lane_rows)
+    write_csv(POCKET_LABELS_CSV, ["task_id", "manual_label", "manual_notes"], pocket_rows)
+
+    print(f"Wrote {len(lane_rows)} rows -> {MAYBE_SHORT_REGEN_CSV}")
+    print(f"Wrote {len(pocket_rows)} rows -> {POCKET_LABELS_CSV}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Capture and surface a curated near-boundary "borderline pocket" for short-regeneration experiments and make the run artifacts auditable. 
- Provide a small reproducibility lane and tooling so the MAYBE_SHORT_REGEN subset can be regenerated from the canonical run output. 

### Description

- Added curated artifacts: `reports/borderline_maybe_short_regen.csv` and `reports/borderline_pocket_labels.csv` containing the 8-case short-regen lane and full 16-case manual labels respectively. 
- Added `scripts/build_short_regen_lane.py`, which reads `reports/eval_run6_1000_threshold_039.jsonl`, verifies expected task IDs, and writes the lane CSV and the pocket labels CSV. 
- Updated top-level `README.md` to rename the Visual proof section to `Selected evidence snapshots` and link the tracked plots and documents. 
- Rewrote `reports/README.md` to be a concise evidence-surface index listing tracked JSONL artifacts, plot files, CSV reproducibility inputs, and helper scripts, and cleaned up stale merge-conflict noise. 
- Augmented `docs/borderline_pocket_findings.md` to reference the new tracked CSV artifacts for the borderline pocket. 

### Testing

- Ran the generator script with `python scripts/build_short_regen_lane.py` and it completed successfully and produced `reports/borderline_maybe_short_regen.csv` and `reports/borderline_pocket_labels.csv`. 
- No unit tests were added or modified in this change set. 
- Documentation builds were visually inspected by opening the modified `README.md` and `reports/README.md` and verifying paths and filenames referenced are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db3fa6d268832686d823e97e4f1741)