### PR TITLE
Docs: clarify API/runtime surface, threshold regimes, and expand evidence map with visuals

### DIFF
--- a/wiki/Current-Status.md
+++ b/wiki/Current-Status.md
@@ -3,26 +3,24 @@
 ## Completed
 
 - Repeated evaluation runs are committed across multiple task sizes and thresholds (`reports/eval_*.jsonl`, `wiki/runs/`).
-- Threshold regimes are mapped and compared (0.35, 0.39, 0.42, 0.43 artifacts).
+- Threshold regimes are mapped and compared across repository-tracked operating points (`0.35`, `0.39`, `0.42`, `0.43`).
 - Baseline vs PoR framing is explicit in docs and wiki (`docs/baseline_vs_por_quick_guide.md`, `wiki/comparisons/Baseline_vs_PoR.md`).
-- Artifact trail/report surface is established (`reports/` JSONL + plots + run pages).
-- Proof surface maturity improved: claims are connected to artifacts and run summaries.
-- Repo surface / onboarding layer has been strengthened (README + wiki + docs cross-navigation updates already merged).
-- Silence-rate optimization is now a separate documented workstream (`docs/silence_rate_roadmap.md`).
-- Borderline pocket findings are documented (`docs/borderline_pocket_findings.md`).
-- First extension experiment is documented (`docs/first_extension_experiment.md`).
-- First short-regeneration sandbox runner exists (`scripts/short_regen_sandbox.py`).
-- Sandbox CSV BOM/task_id micro-fix has been applied (loader robustness fix merged in PR #97).
-- First short-regeneration sandbox findings are documented (`docs/short_regen_sandbox_findings.md`).
+- Artifact trail and report surface are established (`reports/` JSONL + plots + run pages).
+- Repo onboarding and navigation have been strengthened (README + wiki + docs cross-navigation).
+- API walkthrough exists (`docs/api_walkthrough.md`, `wiki/API-Walkthrough.md`).
+- A structured runtime endpoint surface exists in `api/main.py` (`/health`, `/por/evaluate`, `/generate`, `/por/complete`).
+- Selected evidence plots are tracked in `reports/`, including threshold, accepted-failure, drift, and metrics summaries.
 
 ## In Progress
 
-- Applied API/runtime surface is becoming clearer (`docs/api_walkthrough.md`, `api/main.py`).
-- Controlled follow-up work on extension-layer behavior after first sandbox-level signal.
-- Conservative lane selection for next experiment step using documented borderline-pocket and sandbox evidence.
+- Stronger integration-facing proof surface beyond local/demo-oriented runtime application.
+- Clearer public proof boundaries: keeping repository-demonstrated claims separate from broader external claims.
+- Additional applied runtime examples that improve readability without overstating production-hardening.
+- Extension-layer exploration remains secondary to the main repo-facing proof surface and should stay evidence-bounded.
 
 ## Next
 
-- Run disciplined follow-up sandbox passes (same harness class, tighter lane controls, explicit acceptance criteria).
-- Refine extension-layer direction based on measured sandbox-level signal (not broad runtime retuning).
-- Keep evidence map strict: separate what is documented from what is only suggested by early exploratory results.
+- External integration proof under real runtime constraints.
+- Broader benchmark and domain-transfer testing.
+- Stronger applied demo surface for outsiders evaluating the release-control framing.
+- Continue strict claim-to-evidence discipline: separate what is demonstrated, partially established, and still pending.

--- a/wiki/Evidence-Map.md
+++ b/wiki/Evidence-Map.md
@@ -5,6 +5,7 @@ Purpose: claim-to-evidence index for what is established, partially established,
 ## Core Thesis Evidence
 
 ### Claim
+
 PoR / Silence-as-Control is a runtime **release-control layer**, not a generation method.
 
 - **Established evidence**
@@ -12,7 +13,7 @@ PoR / Silence-as-Control is a runtime **release-control layer**, not a generatio
   - `wiki/concepts/PoR.md`
   - `wiki/architecture/Release_Control_Layer.md`
 - **Partial evidence**
-  - Applied examples exist but are still local/demo-oriented.
+  - Applied examples exist and the runtime/API path is repository-visible, but most proof remains local/repo-scoped.
 - **Future evidence needed**
   - External integration case showing the same release-control framing under real constraints.
 - **Does not establish**
@@ -21,6 +22,7 @@ PoR / Silence-as-Control is a runtime **release-control layer**, not a generatio
 ## Threshold Evidence
 
 ### Claim
+
 Threshold behaves as an operational dial with identifiable regimes.
 
 - **Established evidence**
@@ -29,8 +31,10 @@ Threshold behaves as an operational dial with identifiable regimes.
   - `reports/eval_run5_1000_threshold_042.jsonl`
   - `reports/eval_run5_1000_threshold_043.jsonl`
   - `reports/threshold_control_curve.png`
+  - `reports/accepted_failures_comparison.png`
+  - `reports/drift_separation_comparison.png`
 - **Partial evidence**
-  - Regime naming (safe/transition/boundary) is repository-scoped interpretation, not universal calibration.
+  - Regime naming (conservative / safe anchor / transitional / boundary) is repository-scoped interpretation, not universal calibration.
 - **Future evidence needed**
   - Cross-domain threshold transfer or recalibration studies.
 - **Does not establish**
@@ -39,12 +43,16 @@ Threshold behaves as an operational dial with identifiable regimes.
 ## Evaluation Evidence
 
 ### Claim
+
 Repeated runs support non-trivial gating behavior and safety/coverage tradeoffs.
 
 - **Established evidence**
   - Run artifacts in `reports/eval_*.jsonl`
   - Run summaries in `wiki/runs/Run_1.md`, `wiki/runs/Run_4_300_tasks.md`, `wiki/runs/Run_6_1000_tasks.md`
-  - Drift/metrics plots in `reports/`
+  - Drift and metrics plots in `reports/`, including:
+    - `reports/metrics.png`
+    - `reports/drift.png`
+    - `reports/drift_clean.png`
 - **Partial evidence**
   - Some run summaries are stronger than others; not every run has identical depth of decomposition.
 - **Future evidence needed**
@@ -55,14 +63,15 @@ Repeated runs support non-trivial gating behavior and safety/coverage tradeoffs.
 ## Baseline vs PoR Evidence
 
 ### Claim
+
 Baseline and PoR differ materially at the release-policy layer.
 
 - **Established evidence**
   - `wiki/comparisons/Baseline_vs_PoR.md`
   - `docs/baseline_vs_por_quick_guide.md`
-  - Artifact fields: `no_control_success`, `with_control_success`, `silence`
+  - Artifact fields such as `no_control_success`, `with_control_success`, `silence`
 - **Partial evidence**
-  - Current comparison is strongest inside tracked datasets/runs.
+  - Current comparison is strongest inside tracked datasets and runs.
 - **Future evidence needed**
   - Additional out-of-distribution and integration-level comparisons.
 - **Does not establish**
@@ -71,12 +80,14 @@ Baseline and PoR differ materially at the release-policy layer.
 ## Applied API / Runtime Evidence
 
 ### Claim
-A clearer applied API/runtime path now exists.
+
+A structured applied API/runtime path exists in the repository.
 
 - **Established evidence**
   - `docs/api_walkthrough.md`
+  - `wiki/API-Walkthrough.md`
   - `api/main.py` endpoints (`/health`, `/por/evaluate`, `/generate`, `/por/complete`)
-  - `demo/por_api_demo.py`, `demo_outputs_api/`
+  - `demo/por_api_demo.py`
 - **Partial evidence**
   - Path is clear for local application but not yet a complete external integration proof.
 - **Future evidence needed**
@@ -84,15 +95,38 @@ A clearer applied API/runtime path now exists.
 - **Does not establish**
   - Production-hardening completeness (SLOs, incident behavior, governance controls).
 
+## Visual Evidence Surface
+
+### Claim
+
+Tracked plots improve proof readability and help connect summaries to repository artifacts.
+
+- **Established evidence**
+  - `reports/threshold_control_curve.png`
+  - `reports/accepted_failures_comparison.png`
+  - `reports/drift_separation_comparison.png`
+  - `reports/metrics.png`
+  - `reports/drift.png`
+  - `reports/drift_clean.png`
+- **Partial evidence**
+  - Visual summaries make interpretation easier, but the strongest proof still lives in raw run artifacts and run summaries.
+- **Future evidence needed**
+  - More benchmark-specific visualizations and integration-level runtime traces.
+- **Does not establish**
+  - Claims beyond the underlying recorded artifacts.
+
 ## Open Proof Gaps
 
 - External integration proof remains pending.
-- Public compact narrative should be tightened around claim boundaries.
+- Public compact narrative should continue tightening around claim boundaries.
 - Additional applied use-cases would improve transfer confidence.
+- Production-hardening should not be inferred from repository clarity alone.
 
 ## Reader checklist
 
 Use this page to answer:
+
 1. What is already demonstrated?
 2. Where does the proof live?
-3. What is still pending before stronger external claims are justified?
+3. What is partially established versus fully established?
+4. What is still pending before stronger external claims are justified?

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -12,34 +12,40 @@ if drift > threshold OR coherence < threshold -> SILENCE
 else -> PROCEED
 ```
 
-Silence is an intentional control outcome (not an error and not a timeout).
+Silence is an intentional control outcome, not an error, timeout, or crash.
 
 ## Core framing
 
-- Generation != Authority.
-- Release must be earned by stability.
-- Either correct, or silent.
+Generation != Authority.
+Release must be earned by stability.
+Either correct, or silent.
 
 ## Current project stage
 
 Current stage is:
+
 - post-proof
 - post-threshold-map
-- applied API/runtime surface emerging
-- pre-clear external integration demo
+- structured API/runtime path exists
+- pre-external integration proof
 
 ## Quick navigation
 
-- [Current Status](./Current-Status.md)
-- [API Walkthrough](./API-Walkthrough.md)
-- [Threshold Regimes](./Threshold-Regimes.md)
-- [Evaluation Summary](./Evaluation-Summary.md)
-- [Evidence Map](./Evidence-Map.md)
-- [Reading Order](./Reading-Order.md)
-- [Milestones](./Milestones.md)
+- [Current Status](Current-Status)
+- [API Walkthrough](API-Walkthrough)
+- [Threshold Regimes](Threshold-Regimes)
+- [Evaluation Summary](Evaluation-Summary)
+- [Evidence Map](Evidence-Map)
+- [Reading Order](Reading-Order)
+- [Milestones](Milestones)
 
 ## Repository references
 
 - Runtime/API path: `docs/api_walkthrough.md`, `api/main.py`
-- Evaluation artifacts: `reports/`
-- Existing concept + architecture material: `wiki/concepts/`, `wiki/architecture/`
+- Evaluation artifacts and plots: `reports/`
+- Existing concept and architecture material: `wiki/concepts/`, `wiki/architecture/`
+
+## Notes on evidence surface
+
+The repository now includes tracked JSONL run artifacts, run summaries, and visual evidence snapshots in `reports/`.
+These strengthen proof readability, but they do not replace raw artifacts or external audited integration evidence.

--- a/wiki/Threshold-Regimes.md
+++ b/wiki/Threshold-Regimes.md
@@ -1,35 +1,55 @@
 # Threshold Regimes
 
 Threshold is an **operational control dial** for release behavior.
-Raising/lowering threshold shifts the safety-vs-coverage profile.
+Raising or lowering threshold shifts the safety-vs-coverage profile.
 
 ## Mapped operating points
 
-- **0.35** -> safe / conservative regime
+- **0.35** -> conservative / strict release-control regime
 - **0.39** -> practical safe anchor
-- **0.42** -> transitional / balanced (boundary starts to appear)
-- **0.43** -> boundary / leakage zone
+- **0.42** -> transitional / balanced regime where leakage pressure begins to appear
+- **0.43** -> boundary / leakage-visible regime
 
 These labels summarize observed behavior in committed run artifacts and should be interpreted as repository-scoped evidence, not universal settings.
 
 ## Coverage vs safety tradeoff
 
 Across mapped runs:
-- Safer settings maintain stronger accepted-output precision/risk capture but silence more candidates.
-- Boundary settings recover some coverage but begin allowing accepted failures.
+
+- Safer settings maintain stronger accepted-output precision and risk capture, but silence more candidates.
+- Transitional and boundary settings recover some coverage, but accepted failures begin to reappear.
 
 Use threshold operationally:
+
 - choose lower-risk profiles for strict release control,
 - then tune for acceptable coverage in the target domain.
 
 ## Evidence basis
 
 Primary threshold artifacts:
+
 - `reports/eval_run5_1000_threshold_035.jsonl`
 - `reports/eval_run6_1000_threshold_039.jsonl`
 - `reports/eval_run5_1000_threshold_042.jsonl`
 - `reports/eval_run5_1000_threshold_043.jsonl`
 
-Related context:
+Related run context:
+
 - `wiki/runs/Run_4_300_tasks.md`
 - `wiki/runs/Run_6_1000_tasks.md`
+
+Related visual summaries in `reports/`:
+
+- `reports/threshold_control_curve.png`
+- `reports/accepted_failures_comparison.png`
+- `reports/drift_separation_comparison.png`
+
+## Interpretation discipline
+
+This page documents repository-observed operating behavior.
+
+It does **not** establish:
+
+- a universal best threshold,
+- guaranteed transfer across domains,
+- or a one-time calibration that remains correct under all runtime conditions.


### PR DESCRIPTION
### Motivation

- Tighten repository-framed proof boundaries and make the runtime/API pathway and operating points more explicit. 
- Improve readability of the claim-to-evidence surface by surfacing tracked visual artifacts and clearer artifact references. 
- Clarify threshold regime labels and the intended interpretation of `SILENCE` as a deliberate release-control outcome.

### Description

- Updated `wiki/Current-Status.md` to explicitly call out repository-tracked operating points (`0.35`, `0.39`, `0.42`, `0.43`), list API endpoints in `api/main.py`, and surface selected plots and onboarding/navigation improvements. 
- Expanded `wiki/Evidence-Map.md` with a new "Visual Evidence Surface" section and added references to `reports/` plots such as `reports/threshold_control_curve.png`, `reports/accepted_failures_comparison.png`, `reports/drift_separation_comparison.png`, `reports/metrics.png`, `reports/drift.png`, and `reports/drift_clean.png`, and clarified partial vs established evidence language. 
- Revised `wiki/Home.md` wording to emphasize that `SILENCE` is an intentional control outcome and to reflect a structured API/runtime path and notes about the evidence surface. 
- Refined `wiki/Threshold-Regimes.md` wording and regime labels, added related visual summaries in `reports/`, and added an "Interpretation discipline" section to emphasize repository-scoped evidence and non-transfer assumptions. 

### Testing

- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db452714508326806a1afa00b7e737)