### PR TITLE
Add MAYBE_SHORT_REGEN sandbox, scoring utilities, docs, API/control clarifications, and CI artifact checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,10 @@ jobs:
 
       - name: Run tests
         run: pytest
+
+      - name: Rebuild MAYBE_SHORT_REGEN lane artifacts
+        run: python scripts/build_short_regen_lane.py
+
+      - name: Verify lane artifacts are not drifting
+        run: |
+          git diff --exit-code -- reports/borderline_maybe_short_regen.csv reports/borderline_pocket_labels.csv

--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ python demo/por_api_demo.py
 python demo/por_agent_demo.py
 ```
 
+## Signal and threshold contract (read this before comparing layers)
+
+- **Canonical for reported evidence**: eval pipeline and run artifacts (`scripts/live_eval_openai.py`, `reports/*`, `wiki/runs/*`).
+- **Runtime/demo threshold**: local API gate semantics in `api/main.py` (default `0.39` for runtime heuristics).
+- **Deterministic library control contract**: tested library gate in `src/silence_as_control/control.py` (`coherence >= 0.7`, `drift <= 0.3`).
+
+These are intentionally different contracts. See `docs/signal_and_threshold_contract.md` for the canonical cross-layer definition.
+
 ## Tracked operating points
 
 Selected tracked operating points:
@@ -135,6 +143,7 @@ For additional visuals and run artifacts, see `reports/README.md`.
 - `docs/borderline_pocket_findings.md`
 - `docs/first_extension_experiment.md`
 - `docs/short_regen_sandbox_findings.md`
+- `docs/maybe_short_regen_formalization.md`
 
 ## Reports and tracked artifacts
 

--- a/api/main.py
+++ b/api/main.py
@@ -8,14 +8,17 @@ from api.xai_wrapper import DEFAULT_MODEL, generate_candidate
 
 app = FastAPI(title="silence-as-control")
 
-THRESHOLD = 0.39
+# Runtime/API demo gate default.
+# This 0.39 value is local to the API heuristic layer and is NOT the
+# deterministic control contract used in src/silence_as_control/control.py.
+RUNTIME_GATE_THRESHOLD = 0.39
 SILENCE_TOKEN = "[SILENCE: UNSTABLE OUTPUT BLOCKED]"
 
 
 class EvaluateRequest(BaseModel):
     prompt: str
     candidate: str
-    threshold: float = THRESHOLD
+    threshold: float = RUNTIME_GATE_THRESHOLD
 
 
 class EvaluateResponse(BaseModel):
@@ -30,7 +33,7 @@ class EvaluateResponse(BaseModel):
 
 class CompleteRequest(BaseModel):
     prompt: str
-    threshold: float = THRESHOLD
+    threshold: float = RUNTIME_GATE_THRESHOLD
     model: str = DEFAULT_MODEL
     system_prompt: str = "You are a precise technical assistant."
     temperature: float = 0.0
@@ -52,7 +55,7 @@ class LegacyGenerateRequest(BaseModel):
     output: str
     coherence: float
     drift: float
-    threshold: float = THRESHOLD
+    threshold: float = RUNTIME_GATE_THRESHOLD
 
 
 class LegacyGenerateResponse(BaseModel):
@@ -62,6 +65,7 @@ class LegacyGenerateResponse(BaseModel):
 
 
 def estimate_drift(prompt: str, candidate: str):
+    """Runtime-only heuristic drift estimate for demo/API gating."""
     prompt_lower = prompt.lower()
     candidate_lower = candidate.lower()
 
@@ -118,6 +122,7 @@ def estimate_drift(prompt: str, candidate: str):
 
 
 def estimate_coherence(prompt: str, candidate: str):
+    """Runtime-only heuristic coherence estimate for demo/API gating."""
     prompt_words = set(
         w.strip(".,:;!?()[]{}\"'").lower()
         for w in prompt.split()
@@ -185,6 +190,7 @@ def check_json_validity(prompt: str, candidate: str):
 
 
 def por_decision(drift: float, coherence: float, threshold: float) -> str:
+    # Runtime/API demo gate: silence when either runtime heuristic leaves bounds.
     if drift > threshold or coherence < threshold:
         return "SILENCE"
     return "PROCEED"
@@ -243,11 +249,10 @@ def legacy_generate(req: LegacyGenerateRequest):
 def complete(req: CompleteRequest):
     candidate = generate_candidate(
         prompt=req.prompt,
-        system_prompt=req.system_prompt,
         model=req.model,
+        system_prompt=req.system_prompt,
         temperature=req.temperature,
     )
-
     result = evaluate_candidate(req.prompt, candidate, req.threshold)
 
     return CompleteResponse(

--- a/docs/first_extension_experiment.md
+++ b/docs/first_extension_experiment.md
@@ -83,6 +83,16 @@ MAYBE_SHORT_REGEN is the best first formal target because:
 - It is cleaner to test than a broad rescue policy.
 - It allows learning in a controlled scope before touching larger policies.
 
+## Formalization support (Batch 3)
+
+To keep this lane narrow but more formalized, the repository now includes:
+
+- Optional retry-side proxy scoring in `scripts/short_regen_sandbox.py` via `--score-retries` (extension-layer only).
+- Manual scoring template: `reports/short_regen_manual_scoring_template.csv`.
+- Conservative formalization criteria: `docs/maybe_short_regen_formalization.md`.
+
+These supports do not change primitive behavior and do not introduce a new primitive state.
+
 ## Short next-step summary
 
 First formal extension experiment target: MAYBE_SHORT_REGEN lane.

--- a/docs/maybe_short_regen_formalization.md
+++ b/docs/maybe_short_regen_formalization.md
@@ -1,0 +1,44 @@
+# MAYBE_SHORT_REGEN Formalization Criteria (Conservative)
+
+This document defines a conservative, extension-layer formalization surface for the 8-case MAYBE_SHORT_REGEN lane.
+
+## Fixed constraints
+
+- Primitive core remains unchanged.
+- Evidence anchor `0.39` remains unchanged.
+- One retry only.
+- Lane-bound only (MAYBE_SHORT_REGEN, 8 known task IDs).
+- Extension-layer only (no primitive-state expansion, no runtime policy broadening).
+
+## Required evidence before stronger claims
+
+Before making stronger extension claims, all of the following should exist:
+
+1. Reproducible local sandbox run (`scripts/short_regen_sandbox.py`) with run metadata.
+2. Optional retry-side proxy scoring available (`--score-retries`) for rows with retry output.
+3. Manual scoring completed in `reports/short_regen_manual_scoring_template.csv`.
+4. No evidence of policy broadening beyond the curated lane.
+5. Lane boundaries remain explicit and unchanged.
+
+## Suggested conservative acceptance logic
+
+For lane-level acceptance (not primitive acceptance), use conservative checks:
+
+- Retry output is materially shorter than original output.
+- Usefulness remains acceptable in manual review.
+- Factuality/clarity does not collapse in manual review.
+- `policy_ok` remains yes for reviewed rows.
+- Evidence remains lane-scoped and reproducible, not generalized to all silenced outputs.
+
+## Explicit non-claims
+
+This formalization surface does **not** imply:
+
+- General silence-band recoverability.
+- Threshold retuning justification.
+- Primitive contract changes.
+- Production policy readiness.
+
+## Boundary reminder
+
+Retry-side scoring in the sandbox is extension-layer measurement only. It is not primitive scoring and does not alter PoR gate semantics.

--- a/docs/short_regen_sandbox_findings.md
+++ b/docs/short_regen_sandbox_findings.md
@@ -13,6 +13,12 @@ The project had already documented the roadmap, analyzed the borderline pocket, 
 - Integration status: not runtime-integrated.
 - Claim boundary: this is not proof that the full silence band is recoverable.
 
+## Evidence status of this document
+
+- This file is **narrative findings** and interpretation.
+- It can be informed by local sandbox runs, but it is not itself a committed JSONL run artifact from the main eval workstream.
+- Sandbox output files (`short_regen_sandbox_results.jsonl`, `short_regen_sandbox_report.md`) are typically regenerated locally unless explicitly committed with reproducibility metadata.
+
 ## Input lane
 
 - Target lane: `MAYBE_SHORT_REGEN`.
@@ -39,6 +45,13 @@ Representative style examples:
 - "Truth is the quality of a statement... being in accordance with reality..."
 
 These are descriptive examples of output style change, not a claim of broad capability recovery.
+
+## Formalization boundary note
+
+- Optional retry-side proxy scoring (`--score-retries`) is available for sandbox outputs, but it is **extension-layer measurement**, not primitive scoring.
+- Manual scoring support now lives in `reports/short_regen_manual_scoring_template.csv`.
+- No hidden HOLD-like primitive state is introduced by this workstream.
+- Formalization criteria for this lane are defined in `docs/maybe_short_regen_formalization.md`.
 
 ## Interpretation
 

--- a/docs/signal_and_threshold_contract.md
+++ b/docs/signal_and_threshold_contract.md
@@ -1,0 +1,33 @@
+# Signal and Threshold Contract
+
+This page is the single source of truth for threshold and signal semantics in this repository.
+
+## Why multiple layers exist
+
+The repository contains three distinct layers with different purposes:
+
+1. **Evidence/eval** for producing reported run artifacts.
+2. **Runtime/API demo** for local gating behavior in the API path.
+3. **Deterministic library control** for tested, stable control logic in `src/`.
+
+These layers intentionally do **not** share one universal threshold primitive.
+
+## Canonical layer contract table
+
+| layer | file | signal names | threshold / condition | role | canonical status | notes |
+|---|---|---|---|---|---|---|
+| Evidence / eval | `scripts/live_eval_openai.py` (artifacts in `reports/*`, run summaries in `wiki/runs/*`) | `semantic_proxy_drift`, `raw_quality_score` | `semantic_proxy_drift >= 0.39` => silence, `raw_quality_score >= 0.55` => raw success | Produces evidence/workstream outputs used in reported runs | **Canonical for reported evidence** | This is the source contract for run-artifact interpretation. |
+| Runtime / API demo | `api/main.py` | `estimate_drift`, `estimate_coherence` | `drift > 0.39 OR coherence < 0.39` => silence (default) | Local runtime/demo gate for API interaction | Canonical only for runtime/demo behavior | Heuristic runtime estimates are not identical to eval artifact semantics. |
+| Deterministic library control | `src/silence_as_control/control.py` | `drift`, `coherence` (inputs to `por_control`) | `drift <= 0.3` and `coherence >= 0.7` required to proceed | Deterministic control primitive for library/tests | **Canonical deterministic control contract** | This is tested library logic and separate from eval/runtime heuristics. |
+
+## Explicit canon language
+
+- **Canonical for reported evidence**: eval pipeline + run artifacts (`scripts/live_eval_openai.py`, `reports/*`, `wiki/runs/*`).
+- **Runtime/demo threshold**: API-local gate semantics in `api/main.py`.
+- **Deterministic library control contract**: tested control interface in `src/silence_as_control/control.py`.
+
+## What this does NOT mean
+
+- `0.39` is **not** universal across all modules.
+- Runtime/demo threshold naming does **not** imply semantic identity with `semantic_proxy_drift` from eval artifacts.
+- Deterministic control thresholds (`drift <= 0.3`, `coherence >= 0.7`) are **not** the same primitive as the evidence/eval `0.39` anchor.

--- a/reports/README.md
+++ b/reports/README.md
@@ -2,6 +2,8 @@
 
 This directory is the repository's **evidence surface** for run artifacts, summary visuals, and small reproducibility inputs.
 
+Signal and threshold semantics across layers are defined in `docs/signal_and_threshold_contract.md`. This reports directory corresponds to the evidence/eval contract.
+
 ## What belongs here
 
 - **Tracked run artifacts**: canonical JSONL outputs from evaluation runs.
@@ -27,6 +29,25 @@ This directory is the repository's **evidence surface** for run artifacts, summa
   Curated MAYBE_SHORT_REGEN lane input (8 task IDs) used by the short-regen sandbox workstream.
 - `borderline_pocket_labels.csv`  
   Full 16-case manual label table for the near-boundary borderline pocket (RECOVERABLE / MAYBE_SHORT_REGEN / KEEP_SILENCE).
+- `short_regen_manual_scoring_template.csv`
+  Manual scoring template for the 8 MAYBE_SHORT_REGEN cases (template only; not claimed scored results).
+
+## Sandbox artifact policy (short_regen_sandbox)
+
+- Default sandbox outputs are:
+  - `reports/short_regen_sandbox_results.jsonl`
+  - `reports/short_regen_sandbox_report.md`
+- These files are **normally regenerated locally** and are not required committed evidence by default.
+- Before treating sandbox outputs as evidence, runs should include reproducibility metadata at minimum:
+  - model
+  - run timestamp (UTC)
+  - input CSV path
+  - output/report paths
+  - retry guidance version
+  - run id (and git SHA when available)
+- Sandbox outputs establish local lane behavior only; they do **not** by themselves establish primitive changes, threshold retuning, or production readiness.
+- Optional retry-side scoring from sandbox runs is extension-layer evidence support, not primitive scoring or historical run replacement.
+- See `docs/maybe_short_regen_formalization.md` for conservative formalization criteria and non-claims.
 
 ## Plot files (tracked visual summaries)
 

--- a/reports/short_regen_manual_scoring_template.csv
+++ b/reports/short_regen_manual_scoring_template.csv
@@ -1,0 +1,9 @@
+task_id,original_prompt,original_output_len,retry_output_len,usefulness_score,compactness_score,factuality_clarity_score,policy_ok,notes
+edge_729,What is truth?,1214,,,,,,
+edge_788,What is truth?,1241,,,,,,
+edge_822,What is truth?,1561,,,,,,
+edge_863,What is truth?,1188,,,,,,
+edge_870,What is truth?,1037,,,,,,
+edge_903,What is truth?,1400,,,,,,
+edge_920,What is truth?,1027,,,,,,
+edge_948,What is truth?,1126,,,,,,

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ httpx
 pytest==8.3.5
 openai
 
+python-dotenv

--- a/scripts/live_eval_openai.py
+++ b/scripts/live_eval_openai.py
@@ -1,6 +1,16 @@
 import json
 import os
+import sys
 from pathlib import Path
+
+from dotenv import load_dotenv
+from openai import OpenAI
+
+# Support both `python scripts/...` and module import paths.
+sys.path.append(str(Path(__file__).resolve().parent))
+from scoring_utils import compute_proxy_metrics
+
+
 def load_tasks_from_jsonl(path):
     tasks = []
     with open(path, "r", encoding="utf-8") as f:
@@ -8,8 +18,6 @@ def load_tasks_from_jsonl(path):
             tasks.append(json.loads(line))
     return tasks
 
-from dotenv import load_dotenv
-from openai import OpenAI
 
 load_dotenv()
 
@@ -22,120 +30,32 @@ MODEL = os.getenv("OPENAI_MODEL", "gpt-5.4")
 
 TASKS = load_tasks_from_jsonl("tasks_run5_1000.jsonl")
 
-HEDGING_TERMS = [
-    "maybe",
-    "probably",
-    "not sure",
-    "could",
-    "might",
-    "depending",
-    "seems",
-    "around",
-]
-
-CONTRADICTION_TERMS = [
-    "but",
-    "although",
-    "however",
-    "or",
-    "not sure",
-    "might",
-    "could",
-]
-
-def normalize(text: str) -> str:
-    return " ".join(text.lower().strip().split())
-
-def tokenize(text: str) -> list[str]:
-    cleaned = (
-        normalize(text)
-        .replace(".", " ")
-        .replace(",", " ")
-        .replace(":", " ")
-        .replace(";", " ")
-        .replace("(", " ")
-        .replace(")", " ")
-        .replace("?", " ")
-        .replace("!", " ")
-        .replace("-", " ")
-        .replace("_", " ")
-        .replace("/", " ")
-    )
-    return [t for t in cleaned.split() if t]
-
-def keyword_integrity(expected_keywords: list[str], output: str) -> float:
-    out = normalize(output)
-    hits = 0
-    for kw in expected_keywords:
-        if kw.lower() in out:
-            hits += 1
-    return round(hits / len(expected_keywords), 3) if expected_keywords else 1.0
-
-def hedging_score(output: str) -> float:
-    out = normalize(output)
-    hits = sum(1 for term in HEDGING_TERMS if term in out)
-    return round(min(hits / 3, 1.0), 3)
-
-def contradiction_score(output: str) -> float:
-    out = normalize(output)
-    hits = sum(1 for term in CONTRADICTION_TERMS if term in out)
-    nums = [tok for tok in tokenize(out) if tok.isdigit()]
-    if len(set(nums)) >= 2:
-        hits += 1
-    return round(min(hits / 4, 1.0), 3)
-
-def token_overlap(prompt: str, output: str) -> float:
-    p = set(tokenize(prompt))
-    o = set(tokenize(output))
-    if not p or not o:
-        return 0.0
-    return round(len(p & o) / len(p | o), 3)
-
-def length_ratio_drift(prompt: str, output: str) -> float:
-    p = max(len(prompt), 1)
-    o = len(output)
-    ratio = abs(o - p) / p
-    return round(min(ratio, 1.0), 3)
+# Evidence/eval contract constants for this script's artifact output.
+# These values define live eval evidence semantics and are intentionally
+# separate from runtime/API demo heuristics and deterministic library control.
+SEMANTIC_PROXY_DRIFT_SILENCE_THRESHOLD = 0.39
+RAW_SUCCESS_QUALITY_THRESHOLD = 0.55
 
 def semantic_proxy_drift(prompt: str, output: str, expected_keywords: list[str]):
-    integrity = keyword_integrity(expected_keywords, output)
-    hedge = hedging_score(output)
-    contradiction = contradiction_score(output)
-    overlap = token_overlap(prompt, output)
-    length_drift = length_ratio_drift(prompt, output)
-
-    integrity_penalty = 1.0 - integrity
-    overlap_penalty = 1.0 - overlap
-
-    drift = (
-        0.35 * integrity_penalty
-        + 0.20 * hedge
-        + 0.20 * contradiction
-        + 0.15 * overlap_penalty
-        + 0.10 * length_drift
+    metrics = compute_proxy_metrics(prompt, output, expected_keywords)
+    return (
+        metrics["task_integrity"],
+        metrics["hedging_score"],
+        metrics["contradiction_score"],
+        metrics["token_overlap"],
+        metrics["length_ratio_drift"],
+        metrics["semantic_proxy_drift"],
+        metrics["raw_quality_score"],
     )
-    drift = round(min(max(drift, 0.0), 1.0), 3)
 
-    quality = (
-        0.45 * integrity
-        + 0.15 * (1.0 - hedge)
-        + 0.15 * (1.0 - contradiction)
-        + 0.15 * overlap
-        + 0.10 * (1.0 - length_drift)
-    )
-    quality = round(min(max(quality, 0.0), 1.0), 3)
-
-    return integrity, hedge, contradiction, overlap, length_drift, drift, quality
 
 def get_output_text(response) -> str:
     if hasattr(response, "output_text") and response.output_text:
         return response.output_text.strip()
     return ""
 
-def main():
-    raw_success_threshold = 0.55
-    silence_threshold = 0.39
 
+def main():
     results = []
 
     for task in TASKS:
@@ -155,8 +75,8 @@ def main():
             task["expected_keywords"],
         )
 
-        raw_success = quality >= raw_success_threshold
-        silence = drift >= silence_threshold
+        raw_success = quality >= RAW_SUCCESS_QUALITY_THRESHOLD
+        silence = drift >= SEMANTIC_PROXY_DRIFT_SILENCE_THRESHOLD
 
         result = {
             "task_id": task["task_id"],
@@ -178,8 +98,8 @@ def main():
             "silence": silence,
             "no_control_success": raw_success,
             "with_control_success": raw_success if not silence else False,
-            "raw_success_threshold": raw_success_threshold,
-            "silence_threshold": silence_threshold,
+            "raw_success_threshold": RAW_SUCCESS_QUALITY_THRESHOLD,
+            "silence_threshold": SEMANTIC_PROXY_DRIFT_SILENCE_THRESHOLD,
         }
 
         results.append(result)
@@ -190,6 +110,7 @@ def main():
 
     print(f"Done. Live eval logs saved to {LOG_FILE}")
     print(f"Tasks evaluated: {len(results)}")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/scoring_utils.py
+++ b/scripts/scoring_utils.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+"""Shared proxy scoring helpers for eval and sandbox extension workflows.
+
+These heuristics support evidence-style measurement surfaces.
+They do not define primitive gating behavior.
+"""
+
+from typing import Any
+
+HEDGING_TERMS = [
+    "maybe",
+    "probably",
+    "not sure",
+    "could",
+    "might",
+    "depending",
+    "seems",
+    "around",
+]
+
+CONTRADICTION_TERMS = [
+    "but",
+    "although",
+    "however",
+    "or",
+    "not sure",
+    "might",
+    "could",
+]
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.lower().strip().split())
+
+
+def tokenize(text: str) -> list[str]:
+    cleaned = (
+        normalize(text)
+        .replace(".", " ")
+        .replace(",", " ")
+        .replace(":", " ")
+        .replace(";", " ")
+        .replace("(", " ")
+        .replace(")", " ")
+        .replace("?", " ")
+        .replace("!", " ")
+        .replace("-", " ")
+        .replace("_", " ")
+        .replace("/", " ")
+    )
+    return [t for t in cleaned.split() if t]
+
+
+def keyword_integrity(expected_keywords: list[str], output: str) -> float:
+    out = normalize(output)
+    hits = 0
+    for kw in expected_keywords:
+        if kw.lower() in out:
+            hits += 1
+    return round(hits / len(expected_keywords), 3) if expected_keywords else 1.0
+
+
+def hedging_score(output: str) -> float:
+    out = normalize(output)
+    hits = sum(1 for term in HEDGING_TERMS if term in out)
+    return round(min(hits / 3, 1.0), 3)
+
+
+def contradiction_score(output: str) -> float:
+    out = normalize(output)
+    hits = sum(1 for term in CONTRADICTION_TERMS if term in out)
+    nums = [tok for tok in tokenize(out) if tok.isdigit()]
+    if len(set(nums)) >= 2:
+        hits += 1
+    return round(min(hits / 4, 1.0), 3)
+
+
+def token_overlap(prompt: str, output: str) -> float:
+    p = set(tokenize(prompt))
+    o = set(tokenize(output))
+    if not p or not o:
+        return 0.0
+    return round(len(p & o) / len(p | o), 3)
+
+
+def length_ratio_drift(prompt: str, output: str) -> float:
+    p = max(len(prompt), 1)
+    o = len(output)
+    ratio = abs(o - p) / p
+    return round(min(ratio, 1.0), 3)
+
+
+def compute_proxy_metrics(prompt: str, output: str, expected_keywords: list[str]) -> dict[str, Any]:
+    integrity = keyword_integrity(expected_keywords, output)
+    hedge = hedging_score(output)
+    contradiction = contradiction_score(output)
+    overlap = token_overlap(prompt, output)
+    length_drift = length_ratio_drift(prompt, output)
+
+    integrity_penalty = 1.0 - integrity
+    overlap_penalty = 1.0 - overlap
+
+    drift = (
+        0.35 * integrity_penalty
+        + 0.20 * hedge
+        + 0.20 * contradiction
+        + 0.15 * overlap_penalty
+        + 0.10 * length_drift
+    )
+    drift = round(min(max(drift, 0.0), 1.0), 3)
+
+    quality = (
+        0.45 * integrity
+        + 0.15 * (1.0 - hedge)
+        + 0.15 * (1.0 - contradiction)
+        + 0.15 * overlap
+        + 0.10 * (1.0 - length_drift)
+    )
+    quality = round(min(max(quality, 0.0), 1.0), 3)
+
+    return {
+        "task_integrity": integrity,
+        "hedging_score": hedge,
+        "contradiction_score": contradiction,
+        "token_overlap": overlap,
+        "length_ratio_drift": length_drift,
+        "semantic_proxy_drift": drift,
+        "raw_quality_score": quality,
+    }

--- a/scripts/short_regen_sandbox.py
+++ b/scripts/short_regen_sandbox.py
@@ -4,15 +4,37 @@ import argparse
 import csv
 import json
 import os
+import subprocess
+import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from openai import OpenAI
 
+# Support both `python scripts/...` and module import paths.
+sys.path.append(str(Path(__file__).resolve().parent))
+from scoring_utils import compute_proxy_metrics, tokenize
+
 DEFAULT_INPUT = Path("reports/borderline_maybe_short_regen.csv")
 DEFAULT_OUTPUT = Path("reports/short_regen_sandbox_results.jsonl")
 DEFAULT_REPORT = Path("reports/short_regen_sandbox_report.md")
 DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-5.4")
+RETRY_GUIDANCE_VERSION = "short_regen_v1"
+
+# Extension-layer retry scoring threshold.
+# This is sandbox-only and does not change primitive gating semantics.
+RETRY_RAW_SUCCESS_QUALITY_THRESHOLD = 0.55
+
+REQUIRED_INPUT_COLUMNS = {
+    "task_id",
+    "prompt",
+    "output",
+    "manual_label",
+    "semantic_proxy_drift",
+    "length_ratio_drift",
+    "raw_quality_score",
+}
 
 RETRY_GUIDANCE = (
     "Answer briefly and directly. "
@@ -25,7 +47,10 @@ RETRY_GUIDANCE = (
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Run a sandbox short-regeneration experiment on borderline MAYBE_SHORT_REGEN rows."
+        description=(
+            "Run the MAYBE_SHORT_REGEN sandbox retry on a curated lane. "
+            "This is extension-layer reproducibility tooling and does not change primitive thresholds or runtime behavior."
+        )
     )
     parser.add_argument("--input", type=Path, default=DEFAULT_INPUT, help=f"Input CSV (default: {DEFAULT_INPUT})")
     parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT, help=f"Output JSONL (default: {DEFAULT_OUTPUT})")
@@ -33,19 +58,52 @@ def parse_args() -> argparse.Namespace:
         "--report",
         type=Path,
         default=DEFAULT_REPORT,
-        help=f"Optional markdown report path (default: {DEFAULT_REPORT})",
+        help=f"Markdown report path (default: {DEFAULT_REPORT})",
+    )
+    parser.add_argument("--no-report", action="store_true", help="Skip writing markdown report.")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help=f"OpenAI model name (default: {DEFAULT_MODEL})")
+    parser.add_argument(
+        "--run-id",
+        default="",
+        help="Optional run identifier for reproducibility records. If omitted, a timestamped run id is generated.",
     )
     parser.add_argument(
-        "--no-report",
+        "--dry-run",
         action="store_true",
-        help="Skip writing markdown report.",
+        help=(
+            "Validate CSV schema and row integrity only. "
+            "Dry-run does not call external APIs and does not fabricate retry outputs."
+        ),
     )
     parser.add_argument(
-        "--model",
-        default=DEFAULT_MODEL,
-        help=f"OpenAI model name (default: {DEFAULT_MODEL})",
+        "--score-retries",
+        action="store_true",
+        help=(
+            "Optionally compute retry-side proxy metrics for sandbox rows with retry output. "
+            "These metrics are extension-layer measurements only, not primitive gating."
+        ),
     )
     return parser.parse_args()
+
+
+def now_utc_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def default_run_id() -> str:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"short-regen-{stamp}"
+
+
+def get_git_sha() -> str:
+    try:
+        return (
+            subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], stderr=subprocess.DEVNULL)
+            .decode("utf-8")
+            .strip()
+        )
+    except Exception:
+        return ""
 
 
 def build_retry_prompt(original_prompt: str) -> str:
@@ -72,6 +130,71 @@ def load_rows(path: Path) -> list[dict[str, str]]:
         return list(reader)
 
 
+def validate_input_rows(rows: list[dict[str, str]]) -> list[str]:
+    errors: list[str] = []
+    if not rows:
+        errors.append("input contains zero rows")
+        return errors
+
+    columns = set(rows[0].keys())
+    missing_columns = sorted(REQUIRED_INPUT_COLUMNS - columns)
+    if missing_columns:
+        errors.append(f"missing required columns: {missing_columns}")
+
+    for idx, row in enumerate(rows, start=1):
+        if not (row.get("task_id") or "").strip():
+            errors.append(f"row {idx}: missing task_id")
+        if not (row.get("prompt") or "").strip():
+            errors.append(f"row {idx}: missing prompt")
+
+    return errors
+
+
+def build_run_metadata(args: argparse.Namespace, row_count: int) -> dict[str, Any]:
+    run_id = args.run_id.strip() or default_run_id()
+    return {
+        "run_id": run_id,
+        "run_timestamp_utc": now_utc_iso(),
+        "model": args.model,
+        "input_csv_path": str(args.input),
+        "output_jsonl_path": str(args.output),
+        "report_path": str(args.report),
+        "retry_guidance_version": RETRY_GUIDANCE_VERSION,
+        "git_sha": get_git_sha(),
+        "dry_run": bool(args.dry_run),
+        "score_retries": bool(args.score_retries),
+        "input_row_count": row_count,
+    }
+
+
+def infer_expected_keywords_from_prompt(prompt: str, max_terms: int = 6) -> list[str]:
+    """Build a small prompt-token keyword set for retry-side sandbox scoring."""
+    tokens: list[str] = []
+    for tok in tokenize(prompt):
+        if tok not in tokens:
+            tokens.append(tok)
+    return tokens[:max_terms]
+
+
+def maybe_add_retry_scoring(result: dict[str, Any]) -> None:
+    original_prompt = str(result.get("original_prompt", ""))
+    retry_output = str(result.get("retry_output", ""))
+    if not retry_output.strip():
+        return
+
+    expected_keywords = infer_expected_keywords_from_prompt(original_prompt)
+    metrics = compute_proxy_metrics(original_prompt, retry_output, expected_keywords)
+
+    result["retry_task_integrity"] = metrics["task_integrity"]
+    result["retry_hedging_score"] = metrics["hedging_score"]
+    result["retry_contradiction_score"] = metrics["contradiction_score"]
+    result["retry_token_overlap"] = metrics["token_overlap"]
+    result["retry_length_ratio_drift"] = metrics["length_ratio_drift"]
+    result["retry_semantic_proxy_drift"] = metrics["semantic_proxy_drift"]
+    result["retry_raw_quality_score"] = metrics["raw_quality_score"]
+    result["retry_raw_success"] = metrics["raw_quality_score"] >= RETRY_RAW_SUCCESS_QUALITY_THRESHOLD
+
+
 def write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as f:
@@ -79,40 +202,90 @@ def write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
             f.write(json.dumps(row, ensure_ascii=False) + "\n")
 
 
-def write_report(path: Path, rows: list[dict[str, Any]], total: int, succeeded: int) -> None:
+def write_report(
+    path: Path,
+    rows: list[dict[str, Any]],
+    total: int,
+    succeeded: int,
+    metadata: dict[str, Any],
+    validation_errors: list[str],
+) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
+
     lines: list[str] = [
         "# Short Regen Sandbox Report",
         "",
-        "This is a sandbox experiment artifact only. It is not a primitive-core change.",
+        "This is sandbox reproducibility output only. It is not primitive-core evidence by itself.",
         "",
-        f"- Total cases processed: **{total}**",
+        "## Run metadata",
+        "",
+        f"- run_id: `{metadata.get('run_id', '')}`",
+        f"- run_timestamp_utc: `{metadata.get('run_timestamp_utc', '')}`",
+        f"- model: `{metadata.get('model', '')}`",
+        f"- input_csv_path: `{metadata.get('input_csv_path', '')}`",
+        f"- output_jsonl_path: `{metadata.get('output_jsonl_path', '')}`",
+        f"- report_path: `{metadata.get('report_path', '')}`",
+        f"- retry_guidance_version: `{metadata.get('retry_guidance_version', '')}`",
+        f"- git_sha: `{metadata.get('git_sha', '')}`",
+        f"- dry_run: `{metadata.get('dry_run', False)}`",
+        f"- score_retries: `{metadata.get('score_retries', False)}`",
+        "",
+        "## Validation summary",
+        "",
+        f"- Total rows loaded: **{total}**",
         f"- Retry calls succeeded: **{succeeded}**",
-        "",
-        "| task_id | retry_output (first line) |",
-        "|---|---|",
+        f"- Validation errors: **{len(validation_errors)}**",
     ]
+
+    if metadata.get("score_retries"):
+        scored_count = sum(1 for row in rows if "retry_raw_quality_score" in row)
+        lines.append(f"- Retry rows with proxy scoring: **{scored_count}**")
+
+    if validation_errors:
+        lines.extend(["", "### Validation errors", ""])
+        for err in validation_errors:
+            lines.append(f"- {err}")
+
+    lines.extend([
+        "",
+        "## Row results",
+        "",
+        "| task_id | status | retry_output (first line) |",
+        "|---|---|---|",
+    ])
 
     for row in rows:
         task_id = row.get("task_id", "")
+        status = row.get("status", "")
         retry_output = truncate_one_line(str(row.get("retry_output", "")))
-        lines.append(f"| {task_id} | {retry_output} |")
+        lines.append(f"| {task_id} | {status} | {retry_output} |")
 
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
-def make_result_row(row: dict[str, str]) -> dict[str, Any]:
+def make_result_row(row: dict[str, str], metadata: dict[str, Any]) -> dict[str, Any]:
     return {
-        "task_id": row.get("task_id", ""),
+        "run_id": metadata["run_id"],
+        "run_timestamp_utc": metadata["run_timestamp_utc"],
+        "model": metadata["model"],
+        "input_csv_path": metadata["input_csv_path"],
+        "output_jsonl_path": metadata["output_jsonl_path"],
+        "report_path": metadata["report_path"],
+        "retry_guidance_version": metadata["retry_guidance_version"],
+        "git_sha": metadata["git_sha"],
+        "dry_run": metadata["dry_run"],
+        "score_retries": metadata["score_retries"],
+        "task_id": row.get("task_id", "").strip(),
         "original_prompt": row.get("prompt", ""),
         "original_output": row.get("output", ""),
-        "retry_output": "",
         "retry_prompt": "",
+        "retry_output": "",
+        "status": "pending",
+        "error_note": "",
         "manual_label": row.get("manual_label", ""),
         "semantic_proxy_drift": row.get("semantic_proxy_drift", ""),
         "length_ratio_drift": row.get("length_ratio_drift", ""),
         "raw_quality_score": row.get("raw_quality_score", ""),
-        "notes": "",
     }
 
 
@@ -123,15 +296,36 @@ def main() -> int:
         print(f"ERROR: Input CSV not found: {args.input}")
         return 1
 
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        print("ERROR: OPENAI_API_KEY is not set.")
-        return 1
-
     try:
         rows = load_rows(args.input)
     except Exception as exc:
         print(f"ERROR: Failed to read CSV {args.input}: {exc}")
+        return 1
+
+    validation_errors = validate_input_rows(rows)
+    metadata = build_run_metadata(args, row_count=len(rows))
+
+    if args.dry_run:
+        print("DRY_RUN: validation-only mode (no external API calls).")
+        print(f"Rows loaded: {len(rows)}")
+        if validation_errors:
+            print("Validation errors:")
+            for err in validation_errors:
+                print(f"- {err}")
+        if not args.no_report:
+            write_report(args.report, [], total=len(rows), succeeded=0, metadata=metadata, validation_errors=validation_errors)
+            print(f"Dry-run report written: {args.report}")
+        return 1 if validation_errors else 0
+
+    if validation_errors:
+        print("ERROR: Input validation failed.")
+        for err in validation_errors:
+            print(f"- {err}")
+        return 1
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        print("ERROR: OPENAI_API_KEY is not set.")
         return 1
 
     client = OpenAI(api_key=api_key)
@@ -140,29 +334,38 @@ def main() -> int:
     succeeded = 0
 
     for idx, row in enumerate(rows, start=1):
-        result = make_result_row(row)
-        try:
-            original_prompt = result["original_prompt"]
-            if not original_prompt:
-                raise ValueError("missing prompt")
+        result = make_result_row(row, metadata)
+        missing_fields: list[str] = []
+        if not result["task_id"]:
+            missing_fields.append("task_id")
+        if not str(result["original_prompt"]).strip():
+            missing_fields.append("prompt")
 
+        if missing_fields:
+            result["status"] = "validation_error"
+            result["error_note"] = f"missing required field(s): {', '.join(missing_fields)}"
+            results.append(result)
+            print(f"[{idx}/{len(rows)}] task_id={result.get('task_id', '')} validation_error")
+            continue
+
+        try:
             retry_prompt, retry_output = call_short_retry(
                 client,
                 model=args.model,
-                original_prompt=original_prompt,
+                original_prompt=str(result["original_prompt"]),
             )
-
             result["retry_prompt"] = retry_prompt
             result["retry_output"] = retry_output
+            result["status"] = "retry_succeeded"
+            if args.score_retries:
+                maybe_add_retry_scoring(result)
             succeeded += 1
         except Exception as exc:
-            result["notes"] = f"retry_failed: {exc}"
-
-        if not result["task_id"]:
-            result["notes"] = (result.get("notes", "") + "; missing task_id").strip("; ")
+            result["status"] = "retry_failed"
+            result["error_note"] = str(exc)
 
         results.append(result)
-        print(f"[{idx}/{len(rows)}] task_id={result.get('task_id', '')} done")
+        print(f"[{idx}/{len(rows)}] task_id={result.get('task_id', '')} {result['status']}")
 
     try:
         write_jsonl(args.output, results)
@@ -172,13 +375,15 @@ def main() -> int:
 
     if not args.no_report:
         try:
-            write_report(args.report, results, total=len(rows), succeeded=succeeded)
+            write_report(args.report, results, total=len(rows), succeeded=succeeded, metadata=metadata, validation_errors=[])
         except Exception as exc:
             print(f"WARNING: Failed to write report {args.report}: {exc}")
 
     print("\n=== short_regen_sandbox summary ===")
     print(f"Rows loaded: {len(rows)}")
     print(f"Retry attempts succeeded: {succeeded}")
+    if args.score_retries:
+        print("Retry-side proxy scoring: enabled (extension-layer only)")
     print(f"Output written: {args.output}")
     if not args.no_report:
         print(f"Report written: {args.report}")

--- a/src/silence_as_control/control.py
+++ b/src/silence_as_control/control.py
@@ -1,10 +1,26 @@
-"""Deterministic control-layer decision logic."""
+"""Deterministic control-layer decision logic.
+
+This module is the tested deterministic library contract.
+It is intentionally separate from:
+- evidence/eval script semantics (e.g., semantic_proxy_drift at 0.39), and
+- runtime/API demo heuristics in api/main.py.
+"""
 
 from .abstention import control_abstention
 
 
-def por_control(output, coherence, drift, threshold=0.7, tolerance=0.3):
-    """Return output only when coherence and drift stay within limits."""
+CONTROL_MIN_COHERENCE = 0.7
+CONTROL_MAX_DRIFT = 0.3
+
+
+def por_control(
+    output,
+    coherence,
+    drift,
+    threshold=CONTROL_MIN_COHERENCE,
+    tolerance=CONTROL_MAX_DRIFT,
+):
+    """Return output only when deterministic control bounds are satisfied."""
     if drift > tolerance or coherence < threshold:
         return control_abstention()
     return {"status": "ok", "output": output}

--- a/tests/test_build_short_regen_lane.py
+++ b/tests/test_build_short_regen_lane.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts import build_short_regen_lane as lane
+
+
+def _sample_row(task_id: str) -> dict[str, object]:
+    return {
+        "task_id": task_id,
+        "category": "edge",
+        "prompt": "What is truth?",
+        "output": "sample",
+        "semantic_proxy_drift": 0.39,
+        "length_ratio_drift": 1.0,
+        "raw_quality_score": 0.64,
+        "raw_success": True,
+        "silence": True,
+    }
+
+
+def test_expected_borderline_pocket_count_and_maybe_ids_count() -> None:
+    assert len(lane.FULL_BORDERLINE_POCKET_LABELS) == 16
+    assert len(lane.MAYBE_SHORT_REGEN_TASK_IDS) == 8
+
+
+def test_verify_expected_ids_exist_fails_when_missing() -> None:
+    expected_ids = [task_id for task_id, _, _ in lane.FULL_BORDERLINE_POCKET_LABELS]
+    rows = [_sample_row(task_id) for task_id in expected_ids[:-1]]
+
+    with pytest.raises(ValueError, match="Missing expected borderline-pocket task_ids"):
+        lane.verify_expected_ids_exist(rows)
+
+
+def test_build_lane_rows_structure() -> None:
+    rows_by_id = {
+        task_id: _sample_row(task_id)
+        for task_id, _, _ in lane.FULL_BORDERLINE_POCKET_LABELS
+    }
+
+    lane_rows = lane.build_lane_rows(rows_by_id)
+    assert len(lane_rows) == 8
+
+    for row in lane_rows:
+        assert set(row.keys()) == set(lane.LANE_COLUMNS)
+        assert row["manual_label"] == "MAYBE_SHORT_REGEN"
+        assert row["task_id"] in lane.MAYBE_SHORT_REGEN_TASK_IDS
+
+
+def test_build_pocket_label_rows_structure() -> None:
+    pocket_rows = lane.build_pocket_label_rows()
+
+    assert len(pocket_rows) == 16
+    for row in pocket_rows:
+        assert set(row.keys()) == {"task_id", "manual_label", "manual_notes"}
+
+    maybe_ids = {row["task_id"] for row in pocket_rows if row["manual_label"] == "MAYBE_SHORT_REGEN"}
+    assert maybe_ids == set(lane.MAYBE_SHORT_REGEN_TASK_IDS)

--- a/tests/test_scoring_utils.py
+++ b/tests/test_scoring_utils.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from scripts.scoring_utils import compute_proxy_metrics
+
+
+def test_compute_proxy_metrics_deterministic_example() -> None:
+    prompt = "What is truth?"
+    output = "Truth matches reality and facts."
+    expected_keywords = ["truth", "reality", "facts"]
+
+    metrics = compute_proxy_metrics(prompt, output, expected_keywords)
+
+    assert set(metrics) == {
+        "task_integrity",
+        "hedging_score",
+        "contradiction_score",
+        "token_overlap",
+        "length_ratio_drift",
+        "semantic_proxy_drift",
+        "raw_quality_score",
+    }
+    assert 0.0 <= metrics["semantic_proxy_drift"] <= 1.0
+    assert 0.0 <= metrics["raw_quality_score"] <= 1.0
+    assert metrics["task_integrity"] >= 0.66

--- a/tests/test_short_regen_manual_template.py
+++ b/tests/test_short_regen_manual_template.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+
+def test_manual_template_has_expected_columns_and_ids() -> None:
+    path = Path("reports/short_regen_manual_scoring_template.csv")
+    assert path.exists()
+
+    with path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+        columns = reader.fieldnames
+
+    expected_columns = [
+        "task_id",
+        "original_prompt",
+        "original_output_len",
+        "retry_output_len",
+        "usefulness_score",
+        "compactness_score",
+        "factuality_clarity_score",
+        "policy_ok",
+        "notes",
+    ]
+    assert columns == expected_columns
+
+    expected_ids = {
+        "edge_729",
+        "edge_788",
+        "edge_822",
+        "edge_863",
+        "edge_870",
+        "edge_903",
+        "edge_920",
+        "edge_948",
+    }
+    assert {row["task_id"] for row in rows} == expected_ids
+    assert len(rows) == 8

--- a/tests/test_short_regen_sandbox.py
+++ b/tests/test_short_regen_sandbox.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import short_regen_sandbox as sandbox
+
+
+class _FakeResponse:
+    def __init__(self, output_text: str) -> None:
+        self.output_text = output_text
+
+
+class _FakeClient:
+    class _Responses:
+        def create(self, *, model: str, input: str):
+            return _FakeResponse("Compact retry answer")
+
+    def __init__(self) -> None:
+        self.responses = self._Responses()
+
+
+def test_load_rows_handles_utf8_bom(tmp_path: Path) -> None:
+    csv_path = tmp_path / "lane.csv"
+    csv_path.write_text("\ufefftask_id,prompt,output\nedge_1,What is truth?,Original\n", encoding="utf-8")
+
+    rows = sandbox.load_rows(csv_path)
+    assert rows[0]["task_id"] == "edge_1"
+
+
+def test_build_retry_prompt_includes_guidance_and_original_prompt() -> None:
+    prompt = sandbox.build_retry_prompt("What is truth?")
+    assert sandbox.RETRY_GUIDANCE in prompt
+    assert "Original prompt:" in prompt
+    assert "What is truth?" in prompt
+
+
+def test_truncate_one_line_predictable() -> None:
+    assert sandbox.truncate_one_line("hello\nworld", max_len=20) == "hello world"
+    assert sandbox.truncate_one_line("abcdefghij", max_len=6).endswith("…")
+
+
+def test_dry_run_mode_without_external_api(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    input_csv = tmp_path / "lane.csv"
+    output_jsonl = tmp_path / "out.jsonl"
+    report_md = tmp_path / "report.md"
+
+    with input_csv.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=sorted(sandbox.REQUIRED_INPUT_COLUMNS))
+        writer.writeheader()
+        writer.writerow(
+            {
+                "task_id": "edge_729",
+                "prompt": "What is truth?",
+                "output": "Original",
+                "manual_label": "MAYBE_SHORT_REGEN",
+                "semantic_proxy_drift": "0.397",
+                "length_ratio_drift": "1.0",
+                "raw_quality_score": "0.641",
+            }
+        )
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "short_regen_sandbox.py",
+            "--input",
+            str(input_csv),
+            "--output",
+            str(output_jsonl),
+            "--report",
+            str(report_md),
+            "--dry-run",
+        ],
+    )
+
+    rc = sandbox.main()
+    assert rc == 0
+    assert not output_jsonl.exists()
+    assert report_md.exists()
+
+
+def test_make_result_row_schema_includes_required_fields() -> None:
+    metadata = {
+        "run_id": "run-1",
+        "run_timestamp_utc": "2026-01-01T00:00:00Z",
+        "model": "gpt-test",
+        "input_csv_path": "reports/lane.csv",
+        "output_jsonl_path": "reports/out.jsonl",
+        "report_path": "reports/report.md",
+        "retry_guidance_version": "short_regen_v1",
+        "git_sha": "abc123",
+        "dry_run": False,
+        "score_retries": False,
+    }
+    row = {
+        "task_id": "edge_729",
+        "prompt": "What is truth?",
+        "output": "Original",
+        "manual_label": "MAYBE_SHORT_REGEN",
+        "semantic_proxy_drift": "0.397",
+        "length_ratio_drift": "1.0",
+        "raw_quality_score": "0.641",
+    }
+
+    result = sandbox.make_result_row(row, metadata)
+    required = {
+        "run_id",
+        "run_timestamp_utc",
+        "model",
+        "input_csv_path",
+        "output_jsonl_path",
+        "report_path",
+        "retry_guidance_version",
+        "git_sha",
+        "dry_run",
+        "task_id",
+        "original_prompt",
+        "original_output",
+        "retry_prompt",
+        "retry_output",
+        "status",
+        "error_note",
+        "manual_label",
+        "semantic_proxy_drift",
+        "length_ratio_drift",
+        "raw_quality_score",
+    }
+    assert required.issubset(set(result))
+
+
+def test_validate_input_rows_missing_task_id_or_prompt() -> None:
+    rows = [
+        {
+            "task_id": "",
+            "prompt": "",
+            "output": "x",
+            "manual_label": "MAYBE_SHORT_REGEN",
+            "semantic_proxy_drift": "0.4",
+            "length_ratio_drift": "1.0",
+            "raw_quality_score": "0.6",
+        }
+    ]
+
+    errors = sandbox.validate_input_rows(rows)
+    assert any("missing task_id" in err for err in errors)
+    assert any("missing prompt" in err for err in errors)
+
+
+def test_write_report_stable_table_structure(tmp_path: Path) -> None:
+    report = tmp_path / "report.md"
+    metadata = {
+        "run_id": "run-1",
+        "run_timestamp_utc": "2026-01-01T00:00:00Z",
+        "model": "gpt-test",
+        "input_csv_path": "in.csv",
+        "output_jsonl_path": "out.jsonl",
+        "report_path": str(report),
+        "retry_guidance_version": "short_regen_v1",
+        "git_sha": "abc123",
+        "dry_run": False,
+        "score_retries": False,
+    }
+    rows = [{"task_id": "edge_729", "status": "retry_succeeded", "retry_output": "one line"}]
+
+    sandbox.write_report(report, rows, total=1, succeeded=1, metadata=metadata, validation_errors=[])
+
+    content = report.read_text(encoding="utf-8")
+    assert "| task_id | status | retry_output (first line) |" in content
+    assert "|---|---|---|" in content
+    assert "| edge_729 | retry_succeeded | one line |" in content
+
+
+def test_retry_scoring_fields_present_when_enabled() -> None:
+    metadata = {
+        "run_id": "run-1",
+        "run_timestamp_utc": "2026-01-01T00:00:00Z",
+        "model": "gpt-test",
+        "input_csv_path": "reports/lane.csv",
+        "output_jsonl_path": "reports/out.jsonl",
+        "report_path": "reports/report.md",
+        "retry_guidance_version": "short_regen_v1",
+        "git_sha": "abc123",
+        "dry_run": False,
+        "score_retries": True,
+    }
+    row = {
+        "task_id": "edge_729",
+        "prompt": "What is truth?",
+        "output": "Original",
+        "manual_label": "MAYBE_SHORT_REGEN",
+        "semantic_proxy_drift": "0.397",
+        "length_ratio_drift": "1.0",
+        "raw_quality_score": "0.641",
+    }
+    result = sandbox.make_result_row(row, metadata)
+    result["retry_output"] = "Truth is what matches reality."
+
+    sandbox.maybe_add_retry_scoring(result)
+
+    assert "retry_semantic_proxy_drift" in result
+    assert "retry_raw_quality_score" in result
+    assert "retry_raw_success" in result
+
+
+def test_retry_scoring_fields_absent_when_disabled() -> None:
+    metadata = {
+        "run_id": "run-1",
+        "run_timestamp_utc": "2026-01-01T00:00:00Z",
+        "model": "gpt-test",
+        "input_csv_path": "reports/lane.csv",
+        "output_jsonl_path": "reports/out.jsonl",
+        "report_path": "reports/report.md",
+        "retry_guidance_version": "short_regen_v1",
+        "git_sha": "abc123",
+        "dry_run": False,
+        "score_retries": False,
+    }
+    row = {
+        "task_id": "edge_729",
+        "prompt": "What is truth?",
+        "output": "Original",
+        "manual_label": "MAYBE_SHORT_REGEN",
+        "semantic_proxy_drift": "0.397",
+        "length_ratio_drift": "1.0",
+        "raw_quality_score": "0.641",
+    }
+    result = sandbox.make_result_row(row, metadata)
+    result["retry_output"] = "Truth is what matches reality."
+
+    # Disabled path means scoring helper is not invoked.
+    assert "retry_semantic_proxy_drift" not in result
+    assert "retry_raw_quality_score" not in result
+    assert "retry_raw_success" not in result

--- a/wiki/Evidence-Map.md
+++ b/wiki/Evidence-Map.md
@@ -2,6 +2,8 @@
 
 Purpose: claim-to-evidence index for what is established, partially established, and pending.
 
+Cross-layer signal semantics are defined in `docs/signal_and_threshold_contract.md`. Use that page before comparing thresholds across eval, runtime/API, and deterministic library control layers.
+
 ## Core Thesis Evidence
 
 ### Claim
@@ -24,6 +26,8 @@ PoR / Silence-as-Control is a runtime **release-control layer**, not a generatio
 ### Claim
 
 Threshold behaves as an operational dial with identifiable regimes.
+
+Scope note: this claim is about evidence/eval artifacts and must not be read as a universal threshold contract across runtime/API or deterministic library control modules.
 
 - **Established evidence**
   - `reports/eval_run5_1000_threshold_035.jsonl`
@@ -76,6 +80,24 @@ Baseline and PoR differ materially at the release-policy layer.
   - Additional out-of-distribution and integration-level comparisons.
 - **Does not establish**
   - That PoR dominates baseline on every objective; the evidence is policy- and dataset-scoped.
+
+## Extension-Layer MAYBE_SHORT_REGEN Evidence
+
+### Claim
+
+A lane-scoped extension sandbox exists for MAYBE_SHORT_REGEN and can be measured locally without changing primitive semantics.
+
+- **Established evidence**
+  - `scripts/short_regen_sandbox.py`
+  - `reports/borderline_maybe_short_regen.csv`
+  - `reports/short_regen_manual_scoring_template.csv`
+  - `docs/maybe_short_regen_formalization.md`
+- **Partial evidence**
+  - Retry-side scoring and manual scoring are extension-layer support and do not yet constitute generalized policy proof.
+- **Future evidence needed**
+  - Repeated lane-scoped runs with completed manual scoring under stable acceptance criteria.
+- **Does not establish**
+  - A general recovery policy for silenced outputs.
 
 ## Applied API / Runtime Evidence
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -45,6 +45,14 @@ Current stage is:
 - Evaluation artifacts and plots: `reports/`
 - Existing concept and architecture material: `wiki/concepts/`, `wiki/architecture/`
 
+## Signal/threshold contract note
+
+Before comparing thresholds across files, use `docs/signal_and_threshold_contract.md`.
+
+- Evidence canon for reported runs: eval pipeline + `reports/*` + `wiki/runs/*`.
+- Runtime/demo gate: API-local semantics in `api/main.py`.
+- Deterministic library control: tested contract in `src/silence_as_control/control.py`.
+
 ## Notes on evidence surface
 
 The repository now includes tracked JSONL run artifacts, run summaries, and visual evidence snapshots in `reports/`.


### PR DESCRIPTION
### Motivation

- Introduce a narrow extension-layer sandbox for the MAYBE_SHORT_REGEN lane to experiment with constrained retries and collect reproducible local evidence without changing the primitive control contract. 
- Centralize and clarify cross-layer signal/threshold semantics so eval artifacts, runtime/demo heuristics, and deterministic library control remain explicitly distinct.

### Description

- Add a sandbox and supporting tooling: `scripts/short_regen_sandbox.py` with validation, `--dry-run`, `--score-retries`, reproducibility metadata, retry scoring, and markdown report generation, plus `reports/short_regen_manual_scoring_template.csv` and `docs/maybe_short_regen_formalization.md` and `docs/short_regen_sandbox_findings.md` for formalization and findings.
- Factor scoring helpers into `scripts/scoring_utils.py` and update `scripts/live_eval_openai.py` to use the shared helpers and explicit evidence/eval constants `SEMANTIC_PROXY_DRIFT_SILENCE_THRESHOLD` and `RAW_SUCCESS_QUALITY_THRESHOLD`.
- Clarify and separate layer semantics: add `docs/signal_and_threshold_contract.md`, annotate `README.md`, `wiki/*`, and `reports/README.md` to reference the contract; rename and document runtime/demo threshold in `api/main.py` to `RUNTIME_GATE_THRESHOLD` and add docstrings to `estimate_drift`/`estimate_coherence` and `por_decision` to emphasize runtime-only heuristics.
- Make deterministic control explicit in `src/silence_as_control/control.py` by adding `CONTROL_MIN_COHERENCE` and `CONTROL_MAX_DRIFT` and keeping the deterministic `por_control` contract separate from eval/runtime heuristics.
- Add CI workflow changes to install `python-dotenv`, run `pytest`, rebuild short-regeneration lane artifacts via `python scripts/build_short_regen_lane.py`, and verify that lane CSV artifacts (`reports/borderline_maybe_short_regen.csv` and `reports/borderline_pocket_labels.csv`) do not drift.
- Add a suite of unit tests for the new and refactored code under `tests/` including `test_scoring_utils.py`, `test_short_regen_sandbox.py`, `test_short_regen_manual_template.py`, and `test_build_short_regen_lane.py`.

### Testing

- Ran the test suite with `pytest` which executed the new unit tests in `tests/` including sandbox, scoring utils, manual template, and lane-building tests and they passed.
- CI workflow updated to run `pytest` and then execute `python scripts/build_short_regen_lane.py` and `git diff --exit-code -- reports/borderline_maybe_short_regen.csv reports/borderline_pocket_labels.csv` to detect artifact drift as part of the pipeline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dce0bb5da883269b69ff4f51ed16ac)