### PR TITLE
Add repository architecture hero section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ PoR does not improve the model itself. It controls when the model is allowed to 
 3. Read the integration path guide: `docs/integration_path.md`
 4. Use `CONTRIBUTING.md` for future work
 
+## Repository Architecture
+
+![Repository architecture](reports/repo_architecture_hero.png)
+
+*Repository architecture across Evidence / Eval, Runtime / API, Deterministic Control, and the MAYBE_SHORT_REGEN extension lane.*
+
 ## Repository layout
 
 - `api/` -> runtime API surface


### PR DESCRIPTION
### Motivation
- Add a prominent repository architecture hero image and caption to the top-level documentation by inserting a new `## Repository Architecture` section immediately after `## Fast orientation` to improve orientation and visual navigation.

### Description
- Inserted the exact markdown block containing `![Repository architecture](reports/repo_architecture_hero.png)` and the requested caption into `README.md` directly before the `## Repository layout` section and did not modify any other files or wording.

### Testing
- This is a documentation-only change and was validated by inspecting the updated file contents and unified diff using `git show` and `nl` to confirm the insertion; no automated unit tests were required or modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd36364dec83268c99a96f35fc4785)