### PR TITLE
docs: add Repository Architecture section with diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ PoR does not improve the model itself. It controls when the model is allowed to 
 3. Read the integration path guide: `docs/integration_path.md`
 4. Use `CONTRIBUTING.md` for future work
 
+## Repository Architecture
+
+![Repository architecture](repo_architecture_hero.png)
+
+*Repository architecture across Evidence / Eval, Runtime / API, Deterministic Control, and the MAYBE_SHORT_REGEN extension lane.*
+
 ## Repository layout
 
 - `api/` -> runtime API surface


### PR DESCRIPTION
### Motivation
- Provide a high-level visual overview of the repository layout and main components by adding a "Repository Architecture" section to `README.md`.

### Description
- Added a new "Repository Architecture" section to `README.md` that embeds `repo_architecture_hero.png` and includes a concise caption describing the Evidence/Eval, Runtime/API, Deterministic Control, and MAYBE_SHORT_REGEN lanes.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd36364dec83268c99a96f35fc4785)