### PR TITLE
Fix runtime coherence scaling and deterministic fallback hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Code: `api/core_primitive.py`, `src/silence_as_control/control.py`.
 ### 2) Runtime Extensions (optional deployment layer)
 Adaptive thresholds, environment configuration, embedding-based scoring, multi-sample drift.
 
+Runtime fallback embeddings are lightweight and deterministic (for offline/demo reproducibility), not a claim of state-of-the-art semantics. Production systems can inject stronger embedding backends while keeping the same gate logic.
+
 Code: `api/por_runtime.py`.
 
 ### 3) Experimental Features (optional, non-core)
@@ -99,5 +101,5 @@ curl -s http://127.0.0.1:8000/por/complete \
 
 ## Positioning
 - **Paper-core claim**: deterministic fixed-threshold PoR release control.
-- **Runtime extensions**: practical deployment helpers, optional.
+- **Runtime extensions**: practical deployment helpers, optional deployment scaffolding.
 - **Experimental features**: MAYBE_SHORT_REGEN, optional and non-core.

--- a/api/por_runtime.py
+++ b/api/por_runtime.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import math
 import os
+from hashlib import sha256
 from dataclasses import dataclass
 from typing import Callable, Iterable, Sequence
 
@@ -36,6 +37,33 @@ def _clip(value: float, low: float = 0.0, high: float = 1.0) -> float:
     return max(low, min(value, high))
 
 
+def _stable_token_index(token: str, dim: int) -> int:
+    """Map token to embedding slot with deterministic hashing.
+
+    Python's built-in `hash()` is process-randomized, so we use SHA-256 and
+    take the first 8 bytes for a stable integer across runs and machines.
+    """
+    digest = sha256(token.encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], byteorder="big") % dim
+
+
+def map_similarity_to_coherence(similarity: float, *, nonnegative_space: bool) -> float:
+    """Convert cosine similarity to coherence in [0, 1] for runtime gating.
+
+    - For nonnegative bag-of-words fallback embeddings, cosine is already in
+      [0, 1], so we only clamp.
+    - For signed embedding spaces, cosine is in [-1, 1], so we map with
+      `(cos + 1) / 2`.
+    """
+    if nonnegative_space:
+        return _clip(similarity)
+    return _clip((similarity + 1.0) / 2.0)
+
+
+def _is_nonnegative_vector(vec: Sequence[float]) -> bool:
+    return all(v >= 0.0 for v in vec)
+
+
 def get_runtime_threshold(default: float = RUNTIME_EXTENSION_DEFAULT_THRESHOLD) -> float:
     """[RUNTIME] Resolve runtime threshold from env with safe fallback.
 
@@ -59,7 +87,7 @@ def get_embedding(text: str) -> list[float]:
     """
     vec = [0.0] * 64
     for token in text.lower().split():
-        vec[hash(token) % 64] += 1.0
+        vec[_stable_token_index(token, len(vec))] += 1.0
 
     norm = math.sqrt(sum(v * v for v in vec))
     if norm == 0.0:
@@ -92,9 +120,11 @@ def estimate_coherence(
     candidate_vec = embedding_fn(candidate)
     cos = cosine_similarity(prompt_vec, candidate_vec)
 
-    # Map cosine from [-1, 1] into [0, 1] for gate compatibility.
-    coherence = _clip((cos + 1.0) / 2.0)
-    notes.append("embedding_cosine")
+    nonnegative_space = _is_nonnegative_vector(prompt_vec) and _is_nonnegative_vector(
+        candidate_vec
+    )
+    coherence = map_similarity_to_coherence(cos, nonnegative_space=nonnegative_space)
+    notes.append("embedding_cosine_nonnegative" if nonnegative_space else "embedding_cosine")
     return coherence, notes
 
 
@@ -116,7 +146,12 @@ def estimate_drift(
             pairwise.append(cosine_similarity(vectors[i], vectors[j]))
 
     avg_similarity = (sum(pairwise) / len(pairwise)) if pairwise else 1.0
-    drift = _clip(1.0 - ((avg_similarity + 1.0) / 2.0))
+    nonnegative_space = all(_is_nonnegative_vector(vec) for vec in vectors)
+    coherence_between_samples = map_similarity_to_coherence(
+        avg_similarity,
+        nonnegative_space=nonnegative_space,
+    )
+    drift = _clip(1.0 - coherence_between_samples)
     notes.append(f"pairwise_samples:{len(cleaned)}")
     return drift, notes
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,6 +24,8 @@ Useful, optional runtime helpers:
 - embedding-based coherence,
 - multi-sample drift estimation.
 
+The bundled embedding fallback is deterministic and lightweight for reproducible runtime behavior; production deployments may provide stronger semantic embeddings.
+
 Reference module: `api/por_runtime.py`.
 
 ## 3) Experimental Borderline Recovery

--- a/docs/runtime_extensions.md
+++ b/docs/runtime_extensions.md
@@ -9,6 +9,11 @@ You are here: optional deployment-layer behavior (non-core).
 - Embedding-based coherence scoring.
 - Multi-sample embedding disagreement for drift.
 
+Runtime embedding note:
+- The default fallback embedding is intentionally lightweight and deterministic (stable token hashing) for offline/demo reproducibility.
+- It is a runtime approximation, not the core thesis claim.
+- Deployments can inject stronger semantic embeddings without changing the core fixed-threshold release primitive.
+
 Implementation: `api/por_runtime.py`, wired via `api/main.py`.
 
 ## Why they exist

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -72,6 +72,23 @@ def test_api_evaluate_stays_fixed_when_adaptive_disabled():
     assert payload["threshold"] == 0.39
 
 
+def test_api_evaluate_can_silence_on_low_coherence_runtime_signal():
+    response = client.post(
+        "/por/evaluate",
+        json={
+            "prompt": "Explain recursion with code examples",
+            "candidate": "bananas orbit silently over parquet",
+            "threshold": 0.39,
+            "use_adaptive_threshold": False,
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["drift"] == 0.0
+    assert payload["coherence"] < 0.25
+    assert payload["decision"] == "SILENCE"
+
+
 # ---------------------------------
 # Experimental MAYBE_SHORT_REGEN
 # ---------------------------------

--- a/tests/test_por_runtime.py
+++ b/tests/test_por_runtime.py
@@ -19,12 +19,25 @@ def test_runtime_adaptive_threshold_moves_toward_recent_instability():
 
 def test_runtime_embedding_estimators_return_bounded_values_and_trivial_ordering():
     coherence, _ = por_runtime.estimate_coherence("alpha beta", "alpha beta")
+    coherence_unrelated, _ = por_runtime.estimate_coherence(
+        "alpha beta", "quantum nebula parquet"
+    )
     drift_same, _ = por_runtime.estimate_drift(["same answer", "same answer"])
     drift_diff, _ = por_runtime.estimate_drift(["same answer", "totally different"])
 
     assert 0.0 <= coherence <= 1.0
+    assert 0.0 <= coherence_unrelated <= 1.0
     assert 0.0 <= drift_same <= 1.0
     assert 0.0 <= drift_diff <= 1.0
     assert coherence > 0.95
+    assert coherence_unrelated < 0.5
     assert drift_same <= 0.05
     assert drift_diff >= drift_same
+
+
+def test_runtime_fallback_token_hashing_is_deterministic():
+    idx = por_runtime._stable_token_index("stable-token", 64)
+    repeated = [por_runtime._stable_token_index("stable-token", 64) for _ in range(10)]
+
+    assert all(slot == idx for slot in repeated)
+    assert 0 <= idx < 64


### PR DESCRIPTION
### Motivation
- Fix a correctness bug where fallback (nonnegative) embeddings were remapped from `[-1,1]` to `[0,1]`, compressing coherence into `[0.5,1.0]` and weakening the PoR gate.
- Fix a reproducibility bug where fallback embeddings used Python's process-randomized `hash()` causing non-deterministic embeddings across runs.
- Keep the change scoped to the RUNTIME layer and preserve the CORE primitive and EXPERIMENTAL recovery separation and behavior.

### Description
- Add a deterministic token-to-slot helper ` _stable_token_index(token, dim)` using `hashlib.sha256` and replace `hash(token) % 64` in the fallback `get_embedding` implementation.
- Introduce `map_similarity_to_coherence(similarity, *, nonnegative_space)` and `_is_nonnegative_vector(...)` so nonnegative (BoW-like) embeddings are treated as having cosine in `[0,1]` (clamped) while signed embeddings still map from `[-1,1]` to `[0,1]` via `(cos+1)/2`.
- Apply the new mapping in both `estimate_coherence` and `estimate_drift` to ensure coherent, interpretable scores used by the runtime gate and adaptive thresholding.
- Add/modify tests and docs: deterministic-hash stability test, unrelated-text low-coherence check, an API-level test demonstrating low coherence can drive `SILENCE`, and short clarifications in `README.md` and `docs/*` that fallback embeddings are lightweight deterministic runtime scaffolding.

### Testing
- Ran `pytest -q tests/test_por_runtime.py tests/test_api.py` and all tests passed (`13 passed`).
- New/updated automated tests include a deterministic hashing test for `_stable_token_index`, a coherence check for unrelated text (`coherence_unrelated < 0.5`), and an API-level test asserting low coherence can produce `SILENCE` in the runtime scoring path.
- No changes were made to core decision logic; tests exercising core behavior and experimental recovery remained unchanged and green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8c4ed4f7c83268a34ef3381d08a1c)