### PR TITLE
Add SimpleQA PoR benchmark harness with threshold tradeoff outputs

### DIFF
--- a/benchmarks/simpleqa/README.md
+++ b/benchmarks/simpleqa/README.md
@@ -5,7 +5,7 @@ This benchmark evaluates **baseline answering** vs **PoR-gated release control**
 It is designed to test the Silence-as-Control hypothesis:
 
 - baseline: always answers,
-- PoR-gated: answers only when instability is below threshold, otherwise silences.
+- PoR-gated: generates multiple candidates, computes drift across that candidate set, then answers only when instability is below threshold (otherwise silences).
 
 ## Why SimpleQA
 
@@ -22,6 +22,8 @@ This harness preserves repository layer boundaries:
 - **core primitive**: `api/core_primitive.py`
 - **runtime scoring extensions**: `api/por_runtime.py`
 - **experimental recovery**: **disabled by default** (not used in this benchmark)
+
+This benchmark evaluates **release-control tradeoffs**, not model-generation improvement.
 
 ## Files
 
@@ -56,6 +58,7 @@ python benchmarks/simpleqa/run_simpleqa_por.py \
   --model gpt-4o-mini \
   --max-examples 200 \
   --thresholds 0.35 0.39 0.42 0.43 \
+  --por-samples 3 \
   --output-dir results/simpleqa
 ```
 
@@ -77,6 +80,12 @@ The run writes:
 4. Plot:
    - `results/simpleqa/simpleqa_threshold_tradeoff.png`
 
+Per-example rows include:
+
+- `por_candidates_json` (all PoR candidates used for drift),
+- `por_primary_candidate` (candidate[0], used for coherence and release output),
+- `por_sample_count`.
+
 ## Metric definitions
 
 ### Baseline
@@ -88,6 +97,7 @@ The run writes:
 
 ### Per-threshold PoR
 
+- PoR drift uses multi-sample candidates per prompt (`--por-samples`, minimum 2, default 3)
 - `total_examples`
 - `answered_count` = non-silenced outputs
 - `silence_count`
@@ -111,6 +121,10 @@ Default correctness is deterministic normalized exact-match:
 - whitespace squashed
 
 No hidden judge heuristics are used by default.
+
+## Threshold precision
+
+Thresholds preserve full precision internally for grouping/aggregation (no 2-decimal bucket collapsing). Display formatting is separate from grouping keys.
 
 ## Interpretation
 

--- a/benchmarks/simpleqa/README.md
+++ b/benchmarks/simpleqa/README.md
@@ -1,0 +1,120 @@
+# SimpleQA PoR Benchmark Harness
+
+This benchmark evaluates **baseline answering** vs **PoR-gated release control** on a local SimpleQA-style dataset.
+
+It is designed to test the Silence-as-Control hypothesis:
+
+- baseline: always answers,
+- PoR-gated: answers only when instability is below threshold, otherwise silences.
+
+## Why SimpleQA
+
+SimpleQA gives short factual QA examples with canonical answers, making it suitable for measuring:
+
+- accepted wrong answers,
+- controlled silence,
+- threshold tradeoffs.
+
+## Architecture alignment
+
+This harness preserves repository layer boundaries:
+
+- **core primitive**: `api/core_primitive.py`
+- **runtime scoring extensions**: `api/por_runtime.py`
+- **experimental recovery**: **disabled by default** (not used in this benchmark)
+
+## Files
+
+- `benchmarks/simpleqa/run_simpleqa_por.py` — end-to-end runner
+- `benchmarks/simpleqa/dataset_loader.py` — deterministic local dataset loader
+- `benchmarks/simpleqa/model_adapter.py` — model-provider adapter interface
+- `benchmarks/simpleqa/por_adapter.py` — bridge to repo PoR runtime + core gate
+- `benchmarks/simpleqa/metrics.py` — scoring + aggregate metrics
+- `benchmarks/simpleqa/plot_results.py` — matplotlib tradeoff plot
+
+## Dataset format
+
+Use a local `.json`, `.jsonl`, or `.csv` file with mapped fields:
+
+- question: text prompt (`--question-field`)
+- answer(s): canonical answer(s) (`--answer-field` and/or `--answers-field`)
+- id: optional unique id (`--id-field`)
+
+Defaults:
+
+- `question`
+- `answer`
+- `answers`
+- `id`
+
+## Run
+
+```bash
+python benchmarks/simpleqa/run_simpleqa_por.py \
+  --dataset-path /path/to/simpleqa.jsonl \
+  --provider openai \
+  --model gpt-4o-mini \
+  --max-examples 200 \
+  --thresholds 0.35 0.39 0.42 0.43 \
+  --output-dir results/simpleqa
+```
+
+Environment variables for OpenAI-compatible adapter:
+
+- `OPENAI_API_KEY` (required)
+- `OPENAI_BASE_URL` (optional)
+
+## Output artifacts
+
+The run writes:
+
+1. Per-example CSV:
+   - `results/simpleqa/simpleqa_por_results.csv`
+2. Aggregate metrics JSON:
+   - `results/simpleqa/simpleqa_por_metrics.json`
+3. Threshold summary CSV:
+   - `results/simpleqa/simpleqa_threshold_summary.csv`
+4. Plot:
+   - `results/simpleqa/simpleqa_threshold_tradeoff.png`
+
+## Metric definitions
+
+### Baseline
+
+- `total_examples`
+- `answered_count`
+- `correctness_rate`
+- `error_rate`
+
+### Per-threshold PoR
+
+- `total_examples`
+- `answered_count` = non-silenced outputs
+- `silence_count`
+- `answer_rate` = answered_count / total_examples
+- `silence_rate` = silence_count / total_examples
+- `accepted_correct_count`
+- `accepted_wrong_count`
+- `accepted_precision` = accepted_correct_count / answered_count
+- `accepted_error_rate` = accepted_wrong_count / answered_count
+- `false_silence_count`
+- `false_silence_rate` = false_silence_count / total_examples
+
+`false_silence` is defined as: PoR silences a candidate that would have been judged correct under deterministic matching.
+
+## Correctness evaluation
+
+Default correctness is deterministic normalized exact-match:
+
+- lowercase
+- punctuation removed
+- whitespace squashed
+
+No hidden judge heuristics are used by default.
+
+## Interpretation
+
+PoR is beneficial when:
+
+- `accepted_error_rate` decreases materially relative to baseline,
+- while `silence_rate` stays within an interpretable operational range.

--- a/benchmarks/simpleqa/__init__.py
+++ b/benchmarks/simpleqa/__init__.py
@@ -1,0 +1,1 @@
+"""SimpleQA benchmark harness for PoR release-control evaluation."""

--- a/benchmarks/simpleqa/dataset_loader.py
+++ b/benchmarks/simpleqa/dataset_loader.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+@dataclass(frozen=True)
+class SimpleQAExample:
+    """Single SimpleQA benchmark example."""
+
+    example_id: str
+    question: str
+    reference_answers: list[str]
+    raw: dict[str, Any]
+
+
+class DatasetFormatError(ValueError):
+    """Raised when dataset schema cannot be mapped to required fields."""
+
+
+def _as_list_of_strings(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [str(v) for v in value if str(v).strip()]
+    return [str(value)]
+
+
+def _validate_example(
+    item: dict[str, Any],
+    idx: int,
+    *,
+    question_field: str,
+    answer_field: str | None,
+    answers_field: str | None,
+    id_field: str | None,
+) -> SimpleQAExample:
+    question = str(item.get(question_field, "")).strip()
+    if not question:
+        raise DatasetFormatError(
+            f"Example {idx} missing non-empty question field '{question_field}'."
+        )
+
+    refs: list[str] = []
+    if answers_field:
+        refs.extend(_as_list_of_strings(item.get(answers_field)))
+    if answer_field:
+        refs.extend(_as_list_of_strings(item.get(answer_field)))
+
+    refs = [r.strip() for r in refs if r and r.strip()]
+    if not refs:
+        raise DatasetFormatError(
+            f"Example {idx} missing reference answers in '{answer_field}'/'{answers_field}'."
+        )
+
+    if id_field:
+        example_id = str(item.get(id_field, f"ex_{idx:06d}"))
+    else:
+        example_id = f"ex_{idx:06d}"
+
+    return SimpleQAExample(
+        example_id=example_id,
+        question=question,
+        reference_answers=refs,
+        raw=item,
+    )
+
+
+def _read_json(path: Path) -> list[dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, list):
+        return [dict(x) for x in payload]
+    if isinstance(payload, dict):
+        for key in ("data", "examples", "rows", "items"):
+            if key in payload and isinstance(payload[key], list):
+                return [dict(x) for x in payload[key]]
+    raise DatasetFormatError(
+        "JSON file must be either a list of examples or an object containing one of: data/examples/rows/items."
+    )
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            obj = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            raise DatasetFormatError(f"Invalid JSONL on line {line_no}: {exc}") from exc
+        if not isinstance(obj, dict):
+            raise DatasetFormatError(f"JSONL line {line_no} is not an object.")
+        items.append(obj)
+    return items
+
+
+def _read_csv(path: Path) -> list[dict[str, Any]]:
+    with path.open("r", encoding="utf-8", newline="") as f:
+        return [dict(row) for row in csv.DictReader(f)]
+
+
+def load_simpleqa_dataset(
+    dataset_path: str | Path,
+    *,
+    question_field: str = "question",
+    answer_field: str | None = "answer",
+    answers_field: str | None = "answers",
+    id_field: str | None = "id",
+    max_examples: int | None = None,
+) -> list[SimpleQAExample]:
+    """Load a SimpleQA-style local dataset from JSON/JSONL/CSV.
+
+    Required mapped fields:
+    - `question_field`: question string.
+    - one of `answer_field` or `answers_field` must provide references.
+
+    This loader is deterministic and does not fetch remote datasets.
+    """
+    path = Path(dataset_path)
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Dataset file not found: {path}. Provide a local SimpleQA export file."
+        )
+
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        raw_items = _read_json(path)
+    elif suffix == ".jsonl":
+        raw_items = _read_jsonl(path)
+    elif suffix == ".csv":
+        raw_items = _read_csv(path)
+    else:
+        raise DatasetFormatError(
+            f"Unsupported dataset extension '{suffix}'. Use .json, .jsonl, or .csv."
+        )
+
+    examples: list[SimpleQAExample] = []
+    for idx, item in enumerate(raw_items):
+        if max_examples is not None and len(examples) >= max_examples:
+            break
+        examples.append(
+            _validate_example(
+                item,
+                idx,
+                question_field=question_field,
+                answer_field=answer_field,
+                answers_field=answers_field,
+                id_field=id_field,
+            )
+        )
+
+    if not examples:
+        raise DatasetFormatError("No valid examples were loaded from dataset.")
+
+    return examples

--- a/benchmarks/simpleqa/metrics.py
+++ b/benchmarks/simpleqa/metrics.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import re
+import string
+from dataclasses import dataclass
+from typing import Any
+
+
+def normalize_text(text: str) -> str:
+    """Deterministic normalization used for default SimpleQA exact matching."""
+    lowered = text.lower().strip()
+    no_punct = lowered.translate(str.maketrans("", "", string.punctuation))
+    squashed = re.sub(r"\s+", " ", no_punct)
+    return squashed
+
+
+def is_correct(answer: str, references: list[str]) -> bool:
+    norm_answer = normalize_text(answer)
+    if not norm_answer:
+        return False
+    for ref in references:
+        if norm_answer == normalize_text(ref):
+            return True
+    return False
+
+
+@dataclass(frozen=True)
+class BaselineMetrics:
+    total_examples: int
+    answered_count: int
+    correctness_rate: float
+    error_rate: float
+
+
+@dataclass(frozen=True)
+class ThresholdMetrics:
+    threshold: float
+    total_examples: int
+    answered_count: int
+    silence_count: int
+    answer_rate: float
+    silence_rate: float
+    accepted_correct_count: int
+    accepted_wrong_count: int
+    accepted_precision: float
+    accepted_error_rate: float
+    false_silence_count: int
+    false_silence_rate: float
+
+
+def _safe_div(num: int, denom: int) -> float:
+    if denom == 0:
+        return 0.0
+    return num / denom
+
+
+def compute_baseline_metrics(rows: list[dict[str, Any]]) -> BaselineMetrics:
+    baseline_rows = [r for r in rows if r["threshold_label"] == "baseline"]
+    total = len(baseline_rows)
+    answered = sum(1 for r in baseline_rows if not r.get("silence_flag", False))
+    correct = sum(1 for r in baseline_rows if r.get("correctness_label") == "correct")
+
+    correctness_rate = _safe_div(correct, total)
+    error_rate = 1.0 - correctness_rate if total > 0 else 0.0
+    return BaselineMetrics(
+        total_examples=total,
+        answered_count=answered,
+        correctness_rate=correctness_rate,
+        error_rate=error_rate,
+    )
+
+
+def compute_threshold_metrics(rows: list[dict[str, Any]], threshold: float) -> ThresholdMetrics:
+    key = f"{threshold:.2f}"
+    subset = [r for r in rows if r.get("threshold_label") == key]
+    total = len(subset)
+    answered = sum(1 for r in subset if not r.get("silence_flag", False))
+    silence = total - answered
+    accepted_correct = sum(
+        1
+        for r in subset
+        if (not r.get("silence_flag", False)) and r.get("correctness_label") == "correct"
+    )
+    accepted_wrong = sum(
+        1
+        for r in subset
+        if (not r.get("silence_flag", False)) and r.get("correctness_label") == "wrong"
+    )
+    false_silence = sum(1 for r in subset if r.get("false_silence_flag", False))
+
+    return ThresholdMetrics(
+        threshold=threshold,
+        total_examples=total,
+        answered_count=answered,
+        silence_count=silence,
+        answer_rate=_safe_div(answered, total),
+        silence_rate=_safe_div(silence, total),
+        accepted_correct_count=accepted_correct,
+        accepted_wrong_count=accepted_wrong,
+        accepted_precision=_safe_div(accepted_correct, answered),
+        accepted_error_rate=_safe_div(accepted_wrong, answered),
+        false_silence_count=false_silence,
+        false_silence_rate=_safe_div(false_silence, total),
+    )

--- a/benchmarks/simpleqa/metrics.py
+++ b/benchmarks/simpleqa/metrics.py
@@ -71,8 +71,7 @@ def compute_baseline_metrics(rows: list[dict[str, Any]]) -> BaselineMetrics:
 
 
 def compute_threshold_metrics(rows: list[dict[str, Any]], threshold: float) -> ThresholdMetrics:
-    key = f"{threshold:.2f}"
-    subset = [r for r in rows if r.get("threshold_label") == key]
+    subset = [r for r in rows if r.get("threshold_value") == threshold]
     total = len(subset)
     answered = sum(1 for r in subset if not r.get("silence_flag", False))
     silence = total - answered

--- a/benchmarks/simpleqa/model_adapter.py
+++ b/benchmarks/simpleqa/model_adapter.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+class ModelAdapterError(RuntimeError):
+    """Raised when a model adapter cannot answer."""
+
+
+class ModelAdapter:
+    """Interface for model responses used by the benchmark."""
+
+    def answer(self, question: str) -> str:
+        raise NotImplementedError
+
+
+@dataclass
+class OpenAIChatAdapter(ModelAdapter):
+    """OpenAI-compatible chat adapter.
+
+    Uses deterministic settings by default (`temperature=0`).
+    """
+
+    model: str
+    api_key_env: str = "OPENAI_API_KEY"
+    base_url_env: str = "OPENAI_BASE_URL"
+    timeout: float = 60.0
+
+    def __post_init__(self) -> None:
+        try:
+            from openai import OpenAI
+        except Exception as exc:  # noqa: BLE001
+            raise ModelAdapterError(
+                "openai package is required for provider='openai'. Install dependencies first."
+            ) from exc
+
+        api_key = os.getenv(self.api_key_env)
+        if not api_key:
+            raise ModelAdapterError(
+                f"Environment variable {self.api_key_env} is required for provider='openai'."
+            )
+
+        kwargs = {"api_key": api_key, "timeout": self.timeout}
+        base_url = os.getenv(self.base_url_env)
+        if base_url:
+            kwargs["base_url"] = base_url
+
+        self._client = OpenAI(**kwargs)
+
+    def answer(self, question: str) -> str:
+        try:
+            resp = self._client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": "Answer briefly and directly. If uncertain, provide your best factual answer.",
+                    },
+                    {"role": "user", "content": question},
+                ],
+                temperature=0,
+            )
+            text = (resp.choices[0].message.content or "").strip()
+            return text
+        except Exception as exc:  # noqa: BLE001
+            raise ModelAdapterError(f"Model call failed: {exc}") from exc
+
+
+def build_model_adapter(provider: str, model: str) -> ModelAdapter:
+    provider_normalized = provider.strip().lower()
+    if provider_normalized == "openai":
+        return OpenAIChatAdapter(model=model)
+    raise ModelAdapterError(
+        f"Unsupported provider '{provider}'. Supported providers: openai."
+    )

--- a/benchmarks/simpleqa/plot_results.py
+++ b/benchmarks/simpleqa/plot_results.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+
+
+def build_threshold_tradeoff_plot(summary_csv_path: str | Path, output_path: str | Path) -> Path:
+    summary_path = Path(summary_csv_path)
+    out = Path(output_path)
+
+    thresholds: list[float] = []
+    silence_rates: list[float] = []
+    accepted_error_rates: list[float] = []
+    accepted_precisions: list[float] = []
+
+    with summary_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            thresholds.append(float(row["threshold"]))
+            silence_rates.append(float(row["silence_rate"]))
+            accepted_error_rates.append(float(row["accepted_error_rate"]))
+            accepted_precisions.append(float(row["accepted_precision"]))
+
+    import matplotlib.pyplot as plt
+
+    plt.figure(figsize=(8, 5))
+    plt.plot(thresholds, silence_rates, marker="o", label="silence_rate")
+    plt.plot(thresholds, accepted_error_rates, marker="o", label="accepted_error_rate")
+    plt.plot(thresholds, accepted_precisions, marker="o", label="accepted_precision")
+    plt.xlabel("PoR threshold")
+    plt.ylabel("Rate")
+    plt.title("SimpleQA PoR tradeoff: silence vs accepted error")
+    plt.ylim(0.0, 1.0)
+    plt.grid(alpha=0.3)
+    plt.legend()
+    plt.tight_layout()
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(out, dpi=200)
+    plt.close()
+    return out

--- a/benchmarks/simpleqa/por_adapter.py
+++ b/benchmarks/simpleqa/por_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Sequence
 
 from api.core_primitive import compute_instability_score, fixed_threshold_release_decision
 from api.por_runtime import estimate_coherence, estimate_drift
@@ -15,10 +16,16 @@ class PoREvaluation:
     por_decision: str
 
 
-def evaluate_por_gate(*, prompt: str, candidate: str, threshold: float) -> PoREvaluation:
+def evaluate_por_gate(
+    *,
+    prompt: str,
+    primary_candidate: str,
+    candidate_samples: Sequence[str],
+    threshold: float,
+) -> PoREvaluation:
     """Evaluate candidate with repository PoR runtime surface + core primitive gate."""
-    coherence, _ = estimate_coherence(prompt, candidate)
-    drift, _ = estimate_drift([candidate])
+    coherence, _ = estimate_coherence(prompt, primary_candidate)
+    drift, _ = estimate_drift(candidate_samples)
     instability = compute_instability_score(drift=drift, coherence=coherence)
     decision = fixed_threshold_release_decision(instability, threshold)
     return PoREvaluation(

--- a/benchmarks/simpleqa/por_adapter.py
+++ b/benchmarks/simpleqa/por_adapter.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from api.core_primitive import compute_instability_score, fixed_threshold_release_decision
+from api.por_runtime import estimate_coherence, estimate_drift
+
+
+@dataclass(frozen=True)
+class PoREvaluation:
+    threshold: float
+    drift: float
+    coherence: float
+    instability_score: float
+    por_decision: str
+
+
+def evaluate_por_gate(*, prompt: str, candidate: str, threshold: float) -> PoREvaluation:
+    """Evaluate candidate with repository PoR runtime surface + core primitive gate."""
+    coherence, _ = estimate_coherence(prompt, candidate)
+    drift, _ = estimate_drift([candidate])
+    instability = compute_instability_score(drift=drift, coherence=coherence)
+    decision = fixed_threshold_release_decision(instability, threshold)
+    return PoREvaluation(
+        threshold=threshold,
+        drift=drift,
+        coherence=coherence,
+        instability_score=instability,
+        por_decision=decision,
+    )

--- a/benchmarks/simpleqa/run_simpleqa_por.py
+++ b/benchmarks/simpleqa/run_simpleqa_por.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from benchmarks.simpleqa.dataset_loader import load_simpleqa_dataset
+from benchmarks.simpleqa.metrics import (
+    compute_baseline_metrics,
+    compute_threshold_metrics,
+    is_correct,
+)
+from benchmarks.simpleqa.model_adapter import ModelAdapterError, build_model_adapter
+from benchmarks.simpleqa.plot_results import build_threshold_tradeoff_plot
+from benchmarks.simpleqa.por_adapter import evaluate_por_gate
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run SimpleQA PoR benchmark harness.")
+    parser.add_argument("--dataset-path", required=True, help="Path to local SimpleQA file (.json/.jsonl/.csv).")
+    parser.add_argument("--provider", default="openai", help="Model provider (default: openai).")
+    parser.add_argument("--model", required=True, help="Model name for the selected provider.")
+    parser.add_argument("--max-examples", type=int, default=None)
+    parser.add_argument("--thresholds", type=float, nargs="+", default=[0.35, 0.39, 0.42, 0.43])
+    parser.add_argument("--output-dir", default="results/simpleqa")
+
+    parser.add_argument("--question-field", default="question")
+    parser.add_argument("--answer-field", default="answer")
+    parser.add_argument("--answers-field", default="answers")
+    parser.add_argument("--id-field", default="id")
+
+    parser.add_argument(
+        "--separate-por-call",
+        action="store_true",
+        help="If set, generate PoR candidate with a second model call. Default reuses baseline answer.",
+    )
+    return parser.parse_args()
+
+
+def _to_csv_value(v: Any) -> str:
+    if isinstance(v, (dict, list)):
+        return json.dumps(v, ensure_ascii=False)
+    if v is None:
+        return ""
+    return str(v)
+
+
+def run() -> None:
+    args = _parse_args()
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    per_example_csv = out_dir / "simpleqa_por_results.csv"
+    metrics_json = out_dir / "simpleqa_por_metrics.json"
+    threshold_summary_csv = out_dir / "simpleqa_threshold_summary.csv"
+    tradeoff_plot = out_dir / "simpleqa_threshold_tradeoff.png"
+
+    examples = load_simpleqa_dataset(
+        dataset_path=args.dataset_path,
+        question_field=args.question_field,
+        answer_field=args.answer_field,
+        answers_field=args.answers_field,
+        id_field=args.id_field,
+        max_examples=args.max_examples,
+    )
+
+    adapter = build_model_adapter(provider=args.provider, model=args.model)
+
+    rows: list[dict[str, Any]] = []
+    fieldnames = [
+        "example_id",
+        "question",
+        "reference_answers",
+        "baseline_answer",
+        "por_candidate",
+        "threshold",
+        "threshold_label",
+        "drift",
+        "coherence",
+        "instability_score",
+        "por_decision",
+        "final_output",
+        "correctness_label",
+        "silence_flag",
+        "false_silence_flag",
+        "accepted_error_flag",
+        "error",
+    ]
+
+    with per_example_csv.open("w", encoding="utf-8", newline="") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+        writer.writeheader()
+
+        for idx, ex in enumerate(examples, start=1):
+            print(f"[{idx}/{len(examples)}] {ex.example_id}")
+            try:
+                baseline_answer = adapter.answer(ex.question)
+            except ModelAdapterError as exc:
+                err = str(exc)
+                baseline_answer = ""
+                # record baseline failure and skip threshold rows because no candidate exists
+                fail_row = {
+                    "example_id": ex.example_id,
+                    "question": ex.question,
+                    "reference_answers": ex.reference_answers,
+                    "baseline_answer": baseline_answer,
+                    "por_candidate": "",
+                    "threshold": "",
+                    "threshold_label": "baseline",
+                    "drift": "",
+                    "coherence": "",
+                    "instability_score": "",
+                    "por_decision": "ERROR",
+                    "final_output": "",
+                    "correctness_label": "wrong",
+                    "silence_flag": False,
+                    "false_silence_flag": False,
+                    "accepted_error_flag": True,
+                    "error": err,
+                }
+                rows.append(fail_row)
+                writer.writerow({k: _to_csv_value(v) for k, v in fail_row.items()})
+                csv_file.flush()
+                continue
+
+            baseline_correct = is_correct(baseline_answer, ex.reference_answers)
+            baseline_row = {
+                "example_id": ex.example_id,
+                "question": ex.question,
+                "reference_answers": ex.reference_answers,
+                "baseline_answer": baseline_answer,
+                "por_candidate": baseline_answer,
+                "threshold": "",
+                "threshold_label": "baseline",
+                "drift": "",
+                "coherence": "",
+                "instability_score": "",
+                "por_decision": "PROCEED",
+                "final_output": baseline_answer,
+                "correctness_label": "correct" if baseline_correct else "wrong",
+                "silence_flag": False,
+                "false_silence_flag": False,
+                "accepted_error_flag": not baseline_correct,
+                "error": "",
+            }
+            rows.append(baseline_row)
+            writer.writerow({k: _to_csv_value(v) for k, v in baseline_row.items()})
+
+            por_candidate = baseline_answer
+            if args.separate_por_call:
+                try:
+                    por_candidate = adapter.answer(ex.question)
+                except ModelAdapterError as exc:
+                    por_candidate = ""
+                    err_row = {
+                        "example_id": ex.example_id,
+                        "question": ex.question,
+                        "reference_answers": ex.reference_answers,
+                        "baseline_answer": baseline_answer,
+                        "por_candidate": por_candidate,
+                        "threshold": "",
+                        "threshold_label": "por_candidate_error",
+                        "drift": "",
+                        "coherence": "",
+                        "instability_score": "",
+                        "por_decision": "ERROR",
+                        "final_output": "",
+                        "correctness_label": "wrong",
+                        "silence_flag": True,
+                        "false_silence_flag": False,
+                        "accepted_error_flag": False,
+                        "error": str(exc),
+                    }
+                    rows.append(err_row)
+                    writer.writerow({k: _to_csv_value(v) for k, v in err_row.items()})
+                    csv_file.flush()
+                    continue
+
+            candidate_correct = is_correct(por_candidate, ex.reference_answers)
+
+            for threshold in args.thresholds:
+                eval_result = evaluate_por_gate(
+                    prompt=ex.question,
+                    candidate=por_candidate,
+                    threshold=threshold,
+                )
+                silence_flag = eval_result.por_decision == "SILENCE"
+                final_output = "" if silence_flag else por_candidate
+                correctness_label = "wrong" if silence_flag else ("correct" if candidate_correct else "wrong")
+                false_silence_flag = silence_flag and candidate_correct
+                accepted_error_flag = (not silence_flag) and (not candidate_correct)
+
+                row = {
+                    "example_id": ex.example_id,
+                    "question": ex.question,
+                    "reference_answers": ex.reference_answers,
+                    "baseline_answer": baseline_answer,
+                    "por_candidate": por_candidate,
+                    "threshold": f"{threshold:.2f}",
+                    "threshold_label": f"{threshold:.2f}",
+                    "drift": eval_result.drift,
+                    "coherence": eval_result.coherence,
+                    "instability_score": eval_result.instability_score,
+                    "por_decision": eval_result.por_decision,
+                    "final_output": final_output,
+                    "correctness_label": correctness_label,
+                    "silence_flag": silence_flag,
+                    "false_silence_flag": false_silence_flag,
+                    "accepted_error_flag": accepted_error_flag,
+                    "error": "",
+                }
+                rows.append(row)
+                writer.writerow({k: _to_csv_value(v) for k, v in row.items()})
+
+            csv_file.flush()
+
+    baseline_metrics = compute_baseline_metrics(rows)
+    threshold_metrics = [compute_threshold_metrics(rows, t) for t in args.thresholds]
+
+    with threshold_summary_csv.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "threshold",
+                "total_examples",
+                "answered_count",
+                "silence_count",
+                "answer_rate",
+                "silence_rate",
+                "accepted_correct_count",
+                "accepted_wrong_count",
+                "accepted_precision",
+                "accepted_error_rate",
+                "false_silence_count",
+                "false_silence_rate",
+            ],
+        )
+        writer.writeheader()
+        for tm in threshold_metrics:
+            writer.writerow(asdict(tm))
+
+    plot_path = build_threshold_tradeoff_plot(threshold_summary_csv, tradeoff_plot)
+
+    payload = {
+        "run_timestamp_utc": datetime.now(timezone.utc).isoformat(),
+        "config": {
+            "dataset_path": str(args.dataset_path),
+            "provider": args.provider,
+            "model": args.model,
+            "max_examples": args.max_examples,
+            "thresholds": args.thresholds,
+            "question_field": args.question_field,
+            "answer_field": args.answer_field,
+            "answers_field": args.answers_field,
+            "id_field": args.id_field,
+            "separate_por_call": args.separate_por_call,
+            "experimental_short_regen_enabled": False,
+        },
+        "baseline": asdict(baseline_metrics),
+        "thresholds": [asdict(tm) for tm in threshold_metrics],
+        "artifacts": {
+            "per_example_csv": str(per_example_csv),
+            "threshold_summary_csv": str(threshold_summary_csv),
+            "tradeoff_plot": str(plot_path),
+        },
+    }
+
+    metrics_json.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    print("Done.")
+    print(f"- {per_example_csv}")
+    print(f"- {threshold_summary_csv}")
+    print(f"- {metrics_json}")
+    print(f"- {plot_path}")
+
+
+if __name__ == "__main__":
+    run()

--- a/benchmarks/simpleqa/run_simpleqa_por.py
+++ b/benchmarks/simpleqa/run_simpleqa_por.py
@@ -24,6 +24,17 @@ from benchmarks.simpleqa.plot_results import build_threshold_tradeoff_plot
 from benchmarks.simpleqa.por_adapter import evaluate_por_gate
 
 
+def threshold_to_key(threshold: float) -> str:
+    """Non-lossy threshold key for grouping/output labels."""
+    return format(threshold, ".17g")
+
+
+def validate_por_samples(value: int) -> int:
+    if value < 2:
+        raise ValueError("--por-samples must be >= 2 to compute multi-sample drift.")
+    return value
+
+
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run SimpleQA PoR benchmark harness.")
     parser.add_argument("--dataset-path", required=True, help="Path to local SimpleQA file (.json/.jsonl/.csv).")
@@ -37,11 +48,17 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--answer-field", default="answer")
     parser.add_argument("--answers-field", default="answers")
     parser.add_argument("--id-field", default="id")
+    parser.add_argument(
+        "--por-samples",
+        type=int,
+        default=3,
+        help="Number of PoR candidate samples per prompt (minimum: 2).",
+    )
 
     parser.add_argument(
         "--separate-por-call",
         action="store_true",
-        help="If set, generate PoR candidate with a second model call. Default reuses baseline answer.",
+        help="If set, PoR samples are all newly generated; otherwise baseline answer is reused as sample[0].",
     )
     return parser.parse_args()
 
@@ -56,6 +73,10 @@ def _to_csv_value(v: Any) -> str:
 
 def run() -> None:
     args = _parse_args()
+    try:
+        por_samples = validate_por_samples(args.por_samples)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
     out_dir = Path(args.output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -82,8 +103,12 @@ def run() -> None:
         "reference_answers",
         "baseline_answer",
         "por_candidate",
+        "por_candidates_json",
+        "por_primary_candidate",
+        "por_sample_count",
         "threshold",
         "threshold_label",
+        "threshold_value",
         "drift",
         "coherence",
         "instability_score",
@@ -114,8 +139,12 @@ def run() -> None:
                     "reference_answers": ex.reference_answers,
                     "baseline_answer": baseline_answer,
                     "por_candidate": "",
+                    "por_candidates_json": [],
+                    "por_primary_candidate": "",
+                    "por_sample_count": 0,
                     "threshold": "",
                     "threshold_label": "baseline",
+                    "threshold_value": "",
                     "drift": "",
                     "coherence": "",
                     "instability_score": "",
@@ -139,8 +168,12 @@ def run() -> None:
                 "reference_answers": ex.reference_answers,
                 "baseline_answer": baseline_answer,
                 "por_candidate": baseline_answer,
+                "por_candidates_json": [baseline_answer],
+                "por_primary_candidate": baseline_answer,
+                "por_sample_count": 1,
                 "threshold": "",
                 "threshold_label": "baseline",
+                "threshold_value": "",
                 "drift": "",
                 "coherence": "",
                 "instability_score": "",
@@ -155,42 +188,79 @@ def run() -> None:
             rows.append(baseline_row)
             writer.writerow({k: _to_csv_value(v) for k, v in baseline_row.items()})
 
-            por_candidate = baseline_answer
-            if args.separate_por_call:
-                try:
-                    por_candidate = adapter.answer(ex.question)
-                except ModelAdapterError as exc:
-                    por_candidate = ""
-                    err_row = {
-                        "example_id": ex.example_id,
-                        "question": ex.question,
-                        "reference_answers": ex.reference_answers,
-                        "baseline_answer": baseline_answer,
-                        "por_candidate": por_candidate,
-                        "threshold": "",
-                        "threshold_label": "por_candidate_error",
-                        "drift": "",
-                        "coherence": "",
-                        "instability_score": "",
-                        "por_decision": "ERROR",
-                        "final_output": "",
-                        "correctness_label": "wrong",
-                        "silence_flag": True,
-                        "false_silence_flag": False,
-                        "accepted_error_flag": False,
-                        "error": str(exc),
-                    }
-                    rows.append(err_row)
-                    writer.writerow({k: _to_csv_value(v) for k, v in err_row.items()})
-                    csv_file.flush()
-                    continue
+            por_candidates: list[str] = []
+            if not args.separate_por_call:
+                por_candidates.append(baseline_answer)
+            try:
+                while len(por_candidates) < por_samples:
+                    por_candidates.append(adapter.answer(ex.question))
+            except ModelAdapterError as exc:
+                err_row = {
+                    "example_id": ex.example_id,
+                    "question": ex.question,
+                    "reference_answers": ex.reference_answers,
+                    "baseline_answer": baseline_answer,
+                    "por_candidate": "",
+                    "por_candidates_json": por_candidates,
+                    "por_primary_candidate": "",
+                    "por_sample_count": len(por_candidates),
+                    "threshold": "",
+                    "threshold_label": "por_candidate_error",
+                    "threshold_value": "",
+                    "drift": "",
+                    "coherence": "",
+                    "instability_score": "",
+                    "por_decision": "ERROR",
+                    "final_output": "",
+                    "correctness_label": "wrong",
+                    "silence_flag": True,
+                    "false_silence_flag": False,
+                    "accepted_error_flag": False,
+                    "error": str(exc),
+                }
+                rows.append(err_row)
+                writer.writerow({k: _to_csv_value(v) for k, v in err_row.items()})
+                csv_file.flush()
+                continue
 
+            if len(por_candidates) < 2:
+                err_row = {
+                    "example_id": ex.example_id,
+                    "question": ex.question,
+                    "reference_answers": ex.reference_answers,
+                    "baseline_answer": baseline_answer,
+                    "por_candidate": "",
+                    "por_candidates_json": por_candidates,
+                    "por_primary_candidate": "",
+                    "por_sample_count": len(por_candidates),
+                    "threshold": "",
+                    "threshold_label": "por_candidate_error",
+                    "threshold_value": "",
+                    "drift": "",
+                    "coherence": "",
+                    "instability_score": "",
+                    "por_decision": "ERROR",
+                    "final_output": "",
+                    "correctness_label": "wrong",
+                    "silence_flag": True,
+                    "false_silence_flag": False,
+                    "accepted_error_flag": False,
+                    "error": "Insufficient PoR candidate samples to compute drift.",
+                }
+                rows.append(err_row)
+                writer.writerow({k: _to_csv_value(v) for k, v in err_row.items()})
+                csv_file.flush()
+                continue
+
+            por_candidate = por_candidates[0]
             candidate_correct = is_correct(por_candidate, ex.reference_answers)
 
             for threshold in args.thresholds:
+                threshold_key = threshold_to_key(threshold)
                 eval_result = evaluate_por_gate(
                     prompt=ex.question,
-                    candidate=por_candidate,
+                    primary_candidate=por_candidate,
+                    candidate_samples=por_candidates,
                     threshold=threshold,
                 )
                 silence_flag = eval_result.por_decision == "SILENCE"
@@ -205,8 +275,12 @@ def run() -> None:
                     "reference_answers": ex.reference_answers,
                     "baseline_answer": baseline_answer,
                     "por_candidate": por_candidate,
-                    "threshold": f"{threshold:.2f}",
-                    "threshold_label": f"{threshold:.2f}",
+                    "por_candidates_json": por_candidates,
+                    "por_primary_candidate": por_candidate,
+                    "por_sample_count": len(por_candidates),
+                    "threshold": threshold_key,
+                    "threshold_label": threshold_key,
+                    "threshold_value": threshold,
                     "drift": eval_result.drift,
                     "coherence": eval_result.coherence,
                     "instability_score": eval_result.instability_score,
@@ -263,6 +337,7 @@ def run() -> None:
             "answers_field": args.answers_field,
             "id_field": args.id_field,
             "separate_por_call": args.separate_por_call,
+            "por_samples": por_samples,
             "experimental_short_regen_enabled": False,
         },
         "baseline": asdict(baseline_metrics),

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ pytest==8.3.5
 openai
 
 python-dotenv
+
+matplotlib

--- a/tests/test_simpleqa_benchmark_harness.py
+++ b/tests/test_simpleqa_benchmark_harness.py
@@ -1,0 +1,49 @@
+from benchmarks.simpleqa.metrics import compute_threshold_metrics
+from benchmarks.simpleqa.por_adapter import evaluate_por_gate
+from benchmarks.simpleqa.run_simpleqa_por import validate_por_samples
+
+
+def test_validate_por_samples_rejects_lt_2() -> None:
+    try:
+        validate_por_samples(1)
+    except ValueError as exc:
+        assert ">= 2" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for por_samples < 2")
+
+
+def test_threshold_metrics_preserve_precision_buckets() -> None:
+    rows = [
+        {
+            "threshold_label": "0.341",
+            "threshold_value": 0.341,
+            "silence_flag": False,
+            "correctness_label": "correct",
+            "false_silence_flag": False,
+        },
+        {
+            "threshold_label": "0.344",
+            "threshold_value": 0.344,
+            "silence_flag": True,
+            "correctness_label": "wrong",
+            "false_silence_flag": True,
+        },
+    ]
+
+    m_341 = compute_threshold_metrics(rows, 0.341)
+    m_344 = compute_threshold_metrics(rows, 0.344)
+
+    assert m_341.total_examples == 1
+    assert m_341.answered_count == 1
+    assert m_344.total_examples == 1
+    assert m_344.silence_count == 1
+
+
+def test_por_gate_uses_multi_sample_drift() -> None:
+    result = evaluate_por_gate(
+        prompt="What is the capital of France?",
+        primary_candidate="Paris",
+        candidate_samples=["Paris", "Lyon", "Marseille"],
+        threshold=0.39,
+    )
+    assert result.drift > 0.0


### PR DESCRIPTION
### Motivation
- Provide a reproducible, end-to-end benchmark to evaluate Proof-of-Resonance (PoR) / Silence-as-Control against a SimpleQA dataset and produce per-example logs, aggregated metrics, threshold summaries, and a final tradeoff plot. 
- Integrate evaluation with the repository's existing PoR runtime and core primitive surfaces while keeping experimental recovery disabled by default. 
- Make it straightforward to run locally with a configurable model adapter and deterministic dataset loader so results are auditable and reproducible. 

### Description
- Added a new benchmark package `benchmarks/simpleqa/` implementing a CLI runner `run_simpleqa_por.py`, dataset loader `dataset_loader.py`, model adapter `model_adapter.py`, PoR bridge `por_adapter.py`, metrics `metrics.py`, plotting `plot_results.py`, and a README `README.md`. 
- The benchmark uses the repository PoR surfaces (`api.por_runtime.estimate_coherence`, `api.por_runtime.estimate_drift`, `api.core_primitive.compute_instability_score`, `api.core_primitive.fixed_threshold_release_decision`) via `por_adapter.py` to keep the core primitive unchanged. 
- Implemented deterministic SimpleQA correctness with `metrics.is_correct` (normalized exact-match), baseline and per-threshold metric computations (including `silence_rate`, `accepted_precision`, `accepted_error_rate`, and `false_silence_rate`), and per-example CSV + threshold summary CSV + aggregate JSON artifact writing. 
- Added a matplotlib-based tradeoff plot generator `build_threshold_tradeoff_plot` and updated `requirements.txt` to include `matplotlib`, with the import deferred inside the plotting function so `--help` works without matplotlib installed. 

### Testing
- Compiled the new benchmark modules with `python -m py_compile benchmarks/simpleqa/*.py` and the compilation succeeded. 
- Verified CLI help with `python benchmarks/simpleqa/run_simpleqa_por.py --help`, which ran successfully and displayed options. 
- Performed a dataset-loader smoke test by creating a temporary JSONL sample and invoking `load_simpleqa_dataset`, which loaded 2 examples as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e6282be08326aef9c2649ecf8247)