### PR TITLE
Relax SimpleQA correctness matching to allow normalized substring checks

### DIFF
--- a/benchmarks/simpleqa/metrics.py
+++ b/benchmarks/simpleqa/metrics.py
@@ -18,9 +18,19 @@ def is_correct(answer: str, references: list[str]) -> bool:
     norm_answer = normalize_text(answer)
     if not norm_answer:
         return False
+
     for ref in references:
-        if norm_answer == normalize_text(ref):
+        norm_ref = normalize_text(ref)
+        if not norm_ref:
+            continue
+
+        if norm_answer == norm_ref:
             return True
+        if norm_ref in norm_answer:
+            return True
+        if norm_answer in norm_ref:
+            return True
+
     return False
 
 


### PR DESCRIPTION
### Motivation
- The existing exact-match-only correctness labeled many valid answers as wrong when the answer contained the reference plus extra context (e.g., `"Paris"` vs `"The capital of France is Paris."`).
- Keep the change minimal and deterministic without introducing any LLM-as-judge or redesigning the benchmark.

### Description
- Updated `benchmarks/simpleqa/metrics.py` to normalize strings (lowercase, remove punctuation, trim and squash whitespace) via the existing `normalize_text` and then apply deterministic matching rules. 
- The new `is_correct` logic returns correct when (in order) the normalized strings are equal, the normalized reference is a substring of the normalized answer, or the normalized answer is a substring of the normalized reference, and otherwise returns wrong. 
- Added a guard to skip empty normalized references so blank refs don't produce false positives.

### Testing
- Ran a direct Python validation calling `is_correct` which produced the expected results for representative cases (`The capital of France is Paris.` vs `Paris` => `True`; `Paris` vs `The capital of France is Paris.` => `True`; `Lyon` vs `Paris` => `False`).
- The above automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8fd79fa9c8326bd71a3a0148240a1)