### PR TITLE
simpleqa: add independent baseline and PoR generation temperatures

### DIFF
--- a/benchmarks/simpleqa/README.md
+++ b/benchmarks/simpleqa/README.md
@@ -59,6 +59,8 @@ python benchmarks/simpleqa/run_simpleqa_por.py \
   --max-examples 200 \
   --thresholds 0.35 0.39 0.42 0.43 \
   --por-samples 3 \
+  --baseline-temperature 0.0 \
+  --por-temperature 0.4 \
   --output-dir results/simpleqa
 ```
 
@@ -66,6 +68,11 @@ Environment variables for OpenAI-compatible adapter:
 
 - `OPENAI_API_KEY` (required)
 - `OPENAI_BASE_URL` (optional)
+
+Temperature controls:
+
+- `--baseline-temperature` defaults to `0.0` (deterministic baseline behavior).
+- `--por-temperature` defaults to `0.4`, allowing PoR candidate samples to vary and expose instability/drift.
 
 ## Output artifacts
 

--- a/benchmarks/simpleqa/model_adapter.py
+++ b/benchmarks/simpleqa/model_adapter.py
@@ -11,7 +11,12 @@ class ModelAdapterError(RuntimeError):
 class ModelAdapter:
     """Interface for model responses used by the benchmark."""
 
-    def answer(self, question: str) -> str:
+    def answer(
+        self,
+        question: str,
+        temperature: float = 0.0,
+        seed: int | None = None,
+    ) -> str:
         raise NotImplementedError
 
 
@@ -48,18 +53,29 @@ class OpenAIChatAdapter(ModelAdapter):
 
         self._client = OpenAI(**kwargs)
 
-    def answer(self, question: str) -> str:
+    def answer(
+        self,
+        question: str,
+        temperature: float = 0.0,
+        seed: int | None = None,
+    ) -> str:
         try:
-            resp = self._client.chat.completions.create(
-                model=self.model,
-                messages=[
+            request_kwargs = {
+                "model": self.model,
+                "messages": [
                     {
                         "role": "system",
                         "content": "Answer briefly and directly. If uncertain, provide your best factual answer.",
                     },
                     {"role": "user", "content": question},
                 ],
-                temperature=0,
+                "temperature": temperature,
+            }
+            if seed is not None:
+                request_kwargs["seed"] = seed
+
+            resp = self._client.chat.completions.create(
+                **request_kwargs,
             )
             text = (resp.choices[0].message.content or "").strip()
             return text

--- a/benchmarks/simpleqa/run_simpleqa_por.py
+++ b/benchmarks/simpleqa/run_simpleqa_por.py
@@ -54,6 +54,18 @@ def _parse_args() -> argparse.Namespace:
         default=3,
         help="Number of PoR candidate samples per prompt (minimum: 2).",
     )
+    parser.add_argument(
+        "--baseline-temperature",
+        type=float,
+        default=0.0,
+        help="Generation temperature for baseline answer (default: 0.0, deterministic).",
+    )
+    parser.add_argument(
+        "--por-temperature",
+        type=float,
+        default=0.4,
+        help="Generation temperature for PoR candidate sampling (default: 0.4).",
+    )
 
     parser.add_argument(
         "--separate-por-call",
@@ -128,7 +140,10 @@ def run() -> None:
         for idx, ex in enumerate(examples, start=1):
             print(f"[{idx}/{len(examples)}] {ex.example_id}")
             try:
-                baseline_answer = adapter.answer(ex.question)
+                baseline_answer = adapter.answer(
+                    ex.question,
+                    temperature=args.baseline_temperature,
+                )
             except ModelAdapterError as exc:
                 err = str(exc)
                 baseline_answer = ""
@@ -193,7 +208,12 @@ def run() -> None:
                 por_candidates.append(baseline_answer)
             try:
                 while len(por_candidates) < por_samples:
-                    por_candidates.append(adapter.answer(ex.question))
+                    por_candidates.append(
+                        adapter.answer(
+                            ex.question,
+                            temperature=args.por_temperature,
+                        )
+                    )
             except ModelAdapterError as exc:
                 err_row = {
                     "example_id": ex.example_id,
@@ -338,6 +358,8 @@ def run() -> None:
             "id_field": args.id_field,
             "separate_por_call": args.separate_por_call,
             "por_samples": por_samples,
+            "baseline_temperature": args.baseline_temperature,
+            "por_temperature": args.por_temperature,
             "experimental_short_regen_enabled": False,
         },
         "baseline": asdict(baseline_metrics),


### PR DESCRIPTION
### Motivation
- PoR candidate samples were often identical because generation was fully deterministic, forcing drift to zero and preventing meaningful instability gating tests. 
- Make a minimal, reversible change so PoR sampling can produce variation while keeping baseline behavior deterministic by default and without touching gate/threshold/correctness logic. 

### Description
- Extended the ModelAdapter interface so `answer()` accepts `temperature: float = 0.0` and `seed: int | None = None`, and updated the OpenAI adapter to forward `temperature` and include `seed` only when provided. 
- Added two backward-compatible CLI flags to the runner: `--baseline-temperature` (default `0.0`) and `--por-temperature` (default `0.4`), and wired baseline calls to use `baseline_temperature` and PoR sampling calls to use `por_temperature` while preserving `--separate-por-call` and `--por-samples` semantics. 
- Updated `benchmarks/simpleqa/README.md` to document the new flags and recommended usage (deterministic baseline, higher-temp PoR sampling). 
- Files changed: `benchmarks/simpleqa/model_adapter.py`, `benchmarks/simpleqa/run_simpleqa_por.py`, `benchmarks/simpleqa/README.md`.

### Testing
- Static compilation check `python -m py_compile benchmarks/simpleqa/model_adapter.py benchmarks/simpleqa/run_simpleqa_por.py` completed successfully. 
- No other automated test changes were run in this PR; runtime behavior preserved for existing flags and output artifact paths/CSV/metric schema remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9065a6bb48326b424c05de22c7bc2)