### PR TITLE
Add optional PoR v2 prototype mode to SimpleQA benchmark

### DIFF
--- a/benchmarks/simpleqa/README.md
+++ b/benchmarks/simpleqa/README.md
@@ -7,6 +7,11 @@ It is designed to test the Silence-as-Control hypothesis:
 - baseline: always answers,
 - PoR-gated: generates multiple candidates, computes drift across that candidate set, then answers only when instability is below threshold (otherwise silences).
 
+It supports two PoR gate modes:
+
+- **PoR v1 (default)**: drift + coherence -> instability -> threshold decision.
+- **PoR v2 (experimental)**: keeps v1 signals and adds semantic agreement + self-check risk before thresholding.
+
 ## Why SimpleQA
 
 SimpleQA gives short factual QA examples with canonical answers, making it suitable for measuring:
@@ -56,6 +61,7 @@ python benchmarks/simpleqa/run_simpleqa_por.py \
   --dataset-path /path/to/simpleqa.jsonl \
   --provider openai \
   --model gpt-4o-mini \
+  --por-mode v1 \
   --max-examples 200 \
   --thresholds 0.35 0.39 0.42 0.43 \
   --por-samples 3 \
@@ -74,6 +80,14 @@ Temperature controls:
 - `--baseline-temperature` defaults to `0.0` (deterministic baseline behavior).
 - `--por-temperature` defaults to `0.4`, allowing PoR candidate samples to vary and expose instability/drift.
 
+PoR mode:
+
+- `--por-mode v1` (default): existing benchmark behavior.
+- `--por-mode v2`: experimental prototype combining:
+  - v1 instability,
+  - semantic agreement risk from multi-sample candidate overlap,
+  - compact self-check label (`YES` / `NO` / `UNSURE`) mapped to risk.
+
 ## Output artifacts
 
 The run writes:
@@ -91,7 +105,15 @@ Per-example rows include:
 
 - `por_candidates_json` (all PoR candidates used for drift),
 - `por_primary_candidate` (candidate[0], used for coherence and release output),
-- `por_sample_count`.
+- `por_sample_count`,
+- `por_mode`,
+- `semantic_agreement_score`,
+- `semantic_agreement_risk`,
+- `self_check_label`,
+- `self_check_risk`,
+- `risk_v2`,
+- `decision_v2`,
+- `effective_decision` (the decision used for final output; equals v1 in v1 mode, v2 in v2 mode).
 
 ## Metric definitions
 

--- a/benchmarks/simpleqa/model_adapter.py
+++ b/benchmarks/simpleqa/model_adapter.py
@@ -19,6 +19,9 @@ class ModelAdapter:
     ) -> str:
         raise NotImplementedError
 
+    def self_check(self, question: str, proposed_answer: str) -> str:
+        raise NotImplementedError
+
 
 @dataclass
 class OpenAIChatAdapter(ModelAdapter):
@@ -81,6 +84,32 @@ class OpenAIChatAdapter(ModelAdapter):
             return text
         except Exception as exc:  # noqa: BLE001
             raise ModelAdapterError(f"Model call failed: {exc}") from exc
+
+    def self_check(self, question: str, proposed_answer: str) -> str:
+        prompt = (
+            f"Question: {question}\n"
+            f"Proposed answer: {proposed_answer}\n\n"
+            "Is the proposed answer factually correct?\n"
+            "Reply with exactly one token:\n"
+            "YES\nNO\nUNSURE"
+        )
+        try:
+            resp = self._client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": "You are a strict factual verifier."},
+                    {"role": "user", "content": prompt},
+                ],
+                temperature=0.0,
+            )
+            text = (resp.choices[0].message.content or "").strip().upper()
+            if text.startswith("YES"):
+                return "YES"
+            if text.startswith("NO"):
+                return "NO"
+            return "UNSURE"
+        except Exception as exc:  # noqa: BLE001
+            raise ModelAdapterError(f"Model self-check failed: {exc}") from exc
 
 
 def build_model_adapter(provider: str, model: str) -> ModelAdapter:

--- a/benchmarks/simpleqa/por_v2.py
+++ b/benchmarks/simpleqa/por_v2.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PoRV2Weights:
+    instability_weight: float = 0.4
+    agreement_weight: float = 0.3
+    self_check_weight: float = 0.3
+
+
+def self_check_label_to_risk(label: str) -> float:
+    normalized = label.strip().upper()
+    if normalized == "YES":
+        return 0.0
+    if normalized == "NO":
+        return 1.0
+    return 0.5
+
+
+def agreement_score_to_risk(score: float) -> float:
+    bounded = max(0.0, min(1.0, score))
+    return 1.0 - bounded
+
+
+def compute_risk_v2(
+    *,
+    instability_v1: float,
+    agreement_risk: float,
+    self_check_risk: float,
+    weights: PoRV2Weights = PoRV2Weights(),
+) -> float:
+    return (
+        (weights.instability_weight * instability_v1)
+        + (weights.agreement_weight * agreement_risk)
+        + (weights.self_check_weight * self_check_risk)
+    )
+
+
+def por_v2_decision(risk_v2: float, threshold: float) -> str:
+    return "PROCEED" if risk_v2 <= threshold else "SILENCE"

--- a/benchmarks/simpleqa/run_simpleqa_por.py
+++ b/benchmarks/simpleqa/run_simpleqa_por.py
@@ -21,7 +21,14 @@ from benchmarks.simpleqa.metrics import (
 )
 from benchmarks.simpleqa.model_adapter import ModelAdapterError, build_model_adapter
 from benchmarks.simpleqa.plot_results import build_threshold_tradeoff_plot
+from benchmarks.simpleqa.por_v2 import (
+    agreement_score_to_risk,
+    compute_risk_v2,
+    por_v2_decision,
+    self_check_label_to_risk,
+)
 from benchmarks.simpleqa.por_adapter import evaluate_por_gate
+from benchmarks.simpleqa.semantic_agreement import semantic_agreement_score
 
 
 def threshold_to_key(threshold: float) -> str:
@@ -72,6 +79,12 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         help="If set, PoR samples are all newly generated; otherwise baseline answer is reused as sample[0].",
     )
+    parser.add_argument(
+        "--por-mode",
+        choices=["v1", "v2"],
+        default="v1",
+        help="PoR gating mode: v1 (default) or experimental v2.",
+    )
     return parser.parse_args()
 
 
@@ -118,12 +131,20 @@ def run() -> None:
         "por_candidates_json",
         "por_primary_candidate",
         "por_sample_count",
+        "por_mode",
         "threshold",
         "threshold_label",
         "threshold_value",
         "drift",
         "coherence",
         "instability_score",
+        "semantic_agreement_score",
+        "semantic_agreement_risk",
+        "self_check_label",
+        "self_check_risk",
+        "risk_v2",
+        "decision_v2",
+        "effective_decision",
         "por_decision",
         "final_output",
         "correctness_label",
@@ -157,12 +178,20 @@ def run() -> None:
                     "por_candidates_json": [],
                     "por_primary_candidate": "",
                     "por_sample_count": 0,
+                    "por_mode": args.por_mode,
                     "threshold": "",
                     "threshold_label": "baseline",
                     "threshold_value": "",
                     "drift": "",
                     "coherence": "",
                     "instability_score": "",
+                    "semantic_agreement_score": "",
+                    "semantic_agreement_risk": "",
+                    "self_check_label": "",
+                    "self_check_risk": "",
+                    "risk_v2": "",
+                    "decision_v2": "",
+                    "effective_decision": "ERROR",
                     "por_decision": "ERROR",
                     "final_output": "",
                     "correctness_label": "wrong",
@@ -186,12 +215,20 @@ def run() -> None:
                 "por_candidates_json": [baseline_answer],
                 "por_primary_candidate": baseline_answer,
                 "por_sample_count": 1,
+                "por_mode": args.por_mode,
                 "threshold": "",
                 "threshold_label": "baseline",
                 "threshold_value": "",
                 "drift": "",
                 "coherence": "",
                 "instability_score": "",
+                "semantic_agreement_score": "",
+                "semantic_agreement_risk": "",
+                "self_check_label": "",
+                "self_check_risk": "",
+                "risk_v2": "",
+                "decision_v2": "",
+                "effective_decision": "PROCEED",
                 "por_decision": "PROCEED",
                 "final_output": baseline_answer,
                 "correctness_label": "correct" if baseline_correct else "wrong",
@@ -224,12 +261,20 @@ def run() -> None:
                     "por_candidates_json": por_candidates,
                     "por_primary_candidate": "",
                     "por_sample_count": len(por_candidates),
+                    "por_mode": args.por_mode,
                     "threshold": "",
                     "threshold_label": "por_candidate_error",
                     "threshold_value": "",
                     "drift": "",
                     "coherence": "",
                     "instability_score": "",
+                    "semantic_agreement_score": "",
+                    "semantic_agreement_risk": "",
+                    "self_check_label": "",
+                    "self_check_risk": "",
+                    "risk_v2": "",
+                    "decision_v2": "",
+                    "effective_decision": "ERROR",
                     "por_decision": "ERROR",
                     "final_output": "",
                     "correctness_label": "wrong",
@@ -253,12 +298,20 @@ def run() -> None:
                     "por_candidates_json": por_candidates,
                     "por_primary_candidate": "",
                     "por_sample_count": len(por_candidates),
+                    "por_mode": args.por_mode,
                     "threshold": "",
                     "threshold_label": "por_candidate_error",
                     "threshold_value": "",
                     "drift": "",
                     "coherence": "",
                     "instability_score": "",
+                    "semantic_agreement_score": "",
+                    "semantic_agreement_risk": "",
+                    "self_check_label": "",
+                    "self_check_risk": "",
+                    "risk_v2": "",
+                    "decision_v2": "",
+                    "effective_decision": "ERROR",
                     "por_decision": "ERROR",
                     "final_output": "",
                     "correctness_label": "wrong",
@@ -274,6 +327,50 @@ def run() -> None:
 
             por_candidate = por_candidates[0]
             candidate_correct = is_correct(por_candidate, ex.reference_answers)
+            agreement_score = semantic_agreement_score(por_candidates)
+            agreement_risk = agreement_score_to_risk(agreement_score)
+            self_check_label = ""
+            self_check_risk = ""
+            if args.por_mode == "v2":
+                try:
+                    self_check_label = adapter.self_check(ex.question, por_candidate)
+                except ModelAdapterError as exc:
+                    err_row = {
+                        "example_id": ex.example_id,
+                        "question": ex.question,
+                        "reference_answers": ex.reference_answers,
+                        "baseline_answer": baseline_answer,
+                        "por_candidate": por_candidate,
+                        "por_candidates_json": por_candidates,
+                        "por_primary_candidate": por_candidate,
+                        "por_sample_count": len(por_candidates),
+                        "por_mode": args.por_mode,
+                        "threshold": "",
+                        "threshold_label": "self_check_error",
+                        "threshold_value": "",
+                        "drift": "",
+                        "coherence": "",
+                        "instability_score": "",
+                        "semantic_agreement_score": agreement_score,
+                        "semantic_agreement_risk": agreement_risk,
+                        "self_check_label": "",
+                        "self_check_risk": "",
+                        "risk_v2": "",
+                        "decision_v2": "",
+                        "effective_decision": "ERROR",
+                        "por_decision": "ERROR",
+                        "final_output": "",
+                        "correctness_label": "wrong",
+                        "silence_flag": True,
+                        "false_silence_flag": False,
+                        "accepted_error_flag": False,
+                        "error": str(exc),
+                    }
+                    rows.append(err_row)
+                    writer.writerow({k: _to_csv_value(v) for k, v in err_row.items()})
+                    csv_file.flush()
+                    continue
+                self_check_risk = self_check_label_to_risk(self_check_label)
 
             for threshold in args.thresholds:
                 threshold_key = threshold_to_key(threshold)
@@ -283,7 +380,18 @@ def run() -> None:
                     candidate_samples=por_candidates,
                     threshold=threshold,
                 )
-                silence_flag = eval_result.por_decision == "SILENCE"
+                risk_v2 = ""
+                decision_v2 = ""
+                effective_decision = eval_result.por_decision
+                if args.por_mode == "v2":
+                    risk_v2 = compute_risk_v2(
+                        instability_v1=eval_result.instability_score,
+                        agreement_risk=agreement_risk,
+                        self_check_risk=float(self_check_risk),
+                    )
+                    decision_v2 = por_v2_decision(risk_v2=risk_v2, threshold=threshold)
+                    effective_decision = decision_v2
+                silence_flag = effective_decision == "SILENCE"
                 final_output = "" if silence_flag else por_candidate
                 correctness_label = "wrong" if silence_flag else ("correct" if candidate_correct else "wrong")
                 false_silence_flag = silence_flag and candidate_correct
@@ -298,12 +406,20 @@ def run() -> None:
                     "por_candidates_json": por_candidates,
                     "por_primary_candidate": por_candidate,
                     "por_sample_count": len(por_candidates),
+                    "por_mode": args.por_mode,
                     "threshold": threshold_key,
                     "threshold_label": threshold_key,
                     "threshold_value": threshold,
                     "drift": eval_result.drift,
                     "coherence": eval_result.coherence,
                     "instability_score": eval_result.instability_score,
+                    "semantic_agreement_score": agreement_score,
+                    "semantic_agreement_risk": agreement_risk,
+                    "self_check_label": self_check_label,
+                    "self_check_risk": self_check_risk,
+                    "risk_v2": risk_v2,
+                    "decision_v2": decision_v2,
+                    "effective_decision": effective_decision,
                     "por_decision": eval_result.por_decision,
                     "final_output": final_output,
                     "correctness_label": correctness_label,
@@ -360,6 +476,7 @@ def run() -> None:
             "por_samples": por_samples,
             "baseline_temperature": args.baseline_temperature,
             "por_temperature": args.por_temperature,
+            "por_mode": args.por_mode,
             "experimental_short_regen_enabled": False,
         },
         "baseline": asdict(baseline_metrics),

--- a/benchmarks/simpleqa/semantic_agreement.py
+++ b/benchmarks/simpleqa/semantic_agreement.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+from itertools import combinations
+
+_TOKEN_RE = re.compile(r"\b[\w']+\b", flags=re.UNICODE)
+_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "be",
+    "by",
+    "for",
+    "from",
+    "in",
+    "is",
+    "it",
+    "of",
+    "on",
+    "or",
+    "that",
+    "the",
+    "to",
+    "was",
+    "were",
+    "with",
+}
+_LEMMA_MAP = {
+    "wrote": "write",
+    "written": "write",
+    "writes": "write",
+}
+
+
+def _normalize_token(token: str) -> str:
+    token = unicodedata.normalize("NFKC", token.lower().strip())
+    if not token:
+        return ""
+    if token in _LEMMA_MAP:
+        return _LEMMA_MAP[token]
+    return token
+
+
+def _content_token_set(text: str) -> set[str]:
+    tokens = {_normalize_token(t) for t in _TOKEN_RE.findall(text)}
+    return {t for t in tokens if t and t not in _STOPWORDS}
+
+
+def pairwise_semantic_similarity(a: str, b: str) -> float:
+    """Lightweight lexical-factual similarity in [0, 1]."""
+    set_a = _content_token_set(a)
+    set_b = _content_token_set(b)
+
+    if not set_a and not set_b:
+        return 1.0
+    if not set_a or not set_b:
+        return 0.0
+
+    intersection = set_a.intersection(set_b)
+    union = set_a.union(set_b)
+    return len(intersection) / len(union)
+
+
+def semantic_agreement_score(candidates: list[str]) -> float:
+    """Mean pairwise similarity across candidate answers in [0, 1]."""
+    if not candidates:
+        return 0.0
+    if len(candidates) == 1:
+        return 1.0
+
+    similarities = [pairwise_semantic_similarity(a, b) for a, b in combinations(candidates, 2)]
+    return sum(similarities) / len(similarities)

--- a/tests/test_simpleqa_por_v2.py
+++ b/tests/test_simpleqa_por_v2.py
@@ -1,0 +1,36 @@
+from benchmarks.simpleqa.por_v2 import (
+    PoRV2Weights,
+    compute_risk_v2,
+    self_check_label_to_risk,
+)
+from benchmarks.simpleqa.semantic_agreement import semantic_agreement_score
+
+
+def test_semantic_agreement_higher_for_rephrased_equivalent_fact() -> None:
+    equivalent = [
+        "Gabriel García Márquez wrote One Hundred Years of Solitude.",
+        "One Hundred Years of Solitude was written by Gabriel García Márquez.",
+    ]
+    conflicting = [
+        "The capital of Kazakhstan is Astana.",
+        "The capital of Kazakhstan is Nur-Sultan.",
+    ]
+
+    assert semantic_agreement_score(equivalent) > semantic_agreement_score(conflicting)
+
+
+def test_self_check_risk_mapping() -> None:
+    assert self_check_label_to_risk("YES") == 0.0
+    assert self_check_label_to_risk("NO") == 1.0
+    assert self_check_label_to_risk("UNSURE") == 0.5
+    assert self_check_label_to_risk("maybe") == 0.5
+
+
+def test_compute_risk_v2_weighted_sum() -> None:
+    risk = compute_risk_v2(
+        instability_v1=0.25,
+        agreement_risk=0.4,
+        self_check_risk=1.0,
+        weights=PoRV2Weights(instability_weight=0.4, agreement_weight=0.3, self_check_weight=0.3),
+    )
+    assert risk == 0.52


### PR DESCRIPTION
### Motivation
- Address PoR v1 failure modes by adding lightweight semantic agreement and a compact self-check signal so the benchmark can better distinguish confidently wrong stable answers and semantically equivalent rephrasings. 
- Keep the existing PoR v1 primitive and benchmark behavior unchanged by making the new behavior opt-in. 
- Keep the implementation minimal, local to the SimpleQA harness, and dependency-light so it can be used for quick experiments. 

### Description
- Add a small deterministic semantic agreement helper `benchmarks/simpleqa/semantic_agreement.py` that computes mean pairwise lexical/ factual overlap (token normalization, stopword removal, small lemma map). 
- Add `benchmarks/simpleqa/por_v2.py` which maps `YES/NO/UNSURE` self-check labels to numeric risk, converts agreement score to risk, and computes `risk_v2` as a weighted sum (default weights: 0.4 instability, 0.3 agreement, 0.3 self-check) and a thresholded `por_v2` decision. 
- Extend `benchmarks/simpleqa/model_adapter.py` with a constrained `self_check` call that prompts the model to reply with exactly one token (`YES`/`NO`/`UNSURE`) and fallbacks unrecognized replies to `UNSURE`. 
- Add an opt-in CLI flag `--por-mode v1|v2` (default `v1`) in `benchmarks/simpleqa/run_simpleqa_por.py` and compute semantic agreement, run self-check, compute `risk_v2`, and use `decision_v2` as the effective decision only when `--por-mode v2` is selected, preserving all v1 outputs and logic otherwise. 
- Extend per-example CSV output fields (backward-compatible) with `por_mode`, `semantic_agreement_score`, `semantic_agreement_risk`, `self_check_label`, `self_check_risk`, `risk_v2`, `decision_v2`, and `effective_decision`, and add a brief README note documenting the experimental mode. 
- Add focused unit tests `tests/test_simpleqa_por_v2.py` covering semantic-agreement directionality, self-check mapping, and the weighted risk computation. 

### Testing
- Ran the benchmark harness unit tests plus the new v2 tests with: `python -m pytest tests/test_simpleqa_benchmark_harness.py tests/test_simpleqa_por_v2.py`. 
- Result: all tests passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91227c1b48326baf5c0b108142a21)