### PR TITLE
Add optional PoR v2.1 contradiction challenge mode to SimpleQA benchmark

### DIFF
--- a/benchmarks/simpleqa/README.md
+++ b/benchmarks/simpleqa/README.md
@@ -7,10 +7,11 @@ It is designed to test the Silence-as-Control hypothesis:
 - baseline: always answers,
 - PoR-gated: generates multiple candidates, computes drift across that candidate set, then answers only when instability is below threshold (otherwise silences).
 
-It supports two PoR gate modes:
+It supports three PoR gate modes:
 
 - **PoR v1 (default)**: drift + coherence -> instability -> threshold decision.
 - **PoR v2 (experimental)**: keeps v1 signals and adds semantic agreement + self-check risk before thresholding.
+- **PoR v2.1 (experimental)**: keeps v2 signals and adds contradiction challenge risk before thresholding.
 
 ## Why SimpleQA
 
@@ -87,6 +88,12 @@ PoR mode:
   - v1 instability,
   - semantic agreement risk from multi-sample candidate overlap,
   - compact self-check label (`YES` / `NO` / `UNSURE`) mapped to risk.
+- `--por-mode v2_1`: experimental prototype extending v2 with a short contradiction challenge check:
+  - model is asked to challenge the primary candidate,
+  - response is mapped to `NO_CONTRADICTION` / `WEAK_CHALLENGE` / `STRONG_CHALLENGE`,
+  - contradiction risk is combined with v2 signals.
+
+v2.1 is designed to probe confidently wrong but internally consistent answers. It remains experimental and does **not** replace the core PoR primitive.
 
 ## Output artifacts
 
@@ -113,7 +120,13 @@ Per-example rows include:
 - `self_check_risk`,
 - `risk_v2`,
 - `decision_v2`,
-- `effective_decision` (the decision used for final output; equals v1 in v1 mode, v2 in v2 mode).
+- `contradiction_label`,
+- `contradiction_risk`,
+- `risk_v2_1`,
+- `decision_v2_1`,
+- `effective_decision` (the decision used for final output; equals v1 in v1 mode, v2 in v2 mode, and v2.1 in v2_1 mode).
+
+For `v2_1`, `effective_decision` equals `decision_v2_1`.
 
 ## Metric definitions
 

--- a/benchmarks/simpleqa/contradiction_check.py
+++ b/benchmarks/simpleqa/contradiction_check.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ContradictionCheckResult:
+    label: str
+    risk: float
+
+
+_UNCERTAINTY_CUES = (
+    "maybe",
+    "might be",
+    "not sure",
+    "uncertain",
+)
+
+
+def parse_contradiction_response(response: str) -> ContradictionCheckResult:
+    """Map contradiction probe response into deterministic label + risk."""
+    normalized = response.strip()
+    normalized_lower = normalized.lower()
+
+    if normalized == "NO_CONTRADICTION":
+        return ContradictionCheckResult(label="NO_CONTRADICTION", risk=0.0)
+
+    if any(cue in normalized_lower for cue in _UNCERTAINTY_CUES):
+        return ContradictionCheckResult(label="WEAK_CHALLENGE", risk=0.5)
+
+    if normalized:
+        return ContradictionCheckResult(label="STRONG_CHALLENGE", risk=1.0)
+
+    return ContradictionCheckResult(label="WEAK_CHALLENGE", risk=0.5)
+

--- a/benchmarks/simpleqa/model_adapter.py
+++ b/benchmarks/simpleqa/model_adapter.py
@@ -22,6 +22,9 @@ class ModelAdapter:
     def self_check(self, question: str, proposed_answer: str) -> str:
         raise NotImplementedError
 
+    def contradiction_check(self, question: str, proposed_answer: str) -> str:
+        raise NotImplementedError
+
 
 @dataclass
 class OpenAIChatAdapter(ModelAdapter):
@@ -110,6 +113,30 @@ class OpenAIChatAdapter(ModelAdapter):
             return "UNSURE"
         except Exception as exc:  # noqa: BLE001
             raise ModelAdapterError(f"Model self-check failed: {exc}") from exc
+
+    def contradiction_check(self, question: str, proposed_answer: str) -> str:
+        prompt = (
+            f"Question: {question}\n"
+            f"Proposed answer: {proposed_answer}\n\n"
+            "Your task:\n"
+            "Try to challenge the proposed answer.\n"
+            "If you think it may be wrong, provide the strongest short alternative factual answer or contradiction.\n"
+            "If you think it is correct, reply ONLY:\n"
+            "NO_CONTRADICTION"
+        )
+        try:
+            resp = self._client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": "You are a strict factual challenger."},
+                    {"role": "user", "content": prompt},
+                ],
+                temperature=0.0,
+                max_tokens=24,
+            )
+            return (resp.choices[0].message.content or "").strip()
+        except Exception as exc:  # noqa: BLE001
+            raise ModelAdapterError(f"Model contradiction-check failed: {exc}") from exc
 
 
 def build_model_adapter(provider: str, model: str) -> ModelAdapter:

--- a/benchmarks/simpleqa/por_v2.py
+++ b/benchmarks/simpleqa/por_v2.py
@@ -10,6 +10,14 @@ class PoRV2Weights:
     self_check_weight: float = 0.3
 
 
+@dataclass(frozen=True)
+class PoRV2_1Weights:
+    instability_weight: float = 0.3
+    agreement_weight: float = 0.2
+    self_check_weight: float = 0.2
+    contradiction_weight: float = 0.3
+
+
 def self_check_label_to_risk(label: str) -> float:
     normalized = label.strip().upper()
     if normalized == "YES":
@@ -40,3 +48,23 @@ def compute_risk_v2(
 
 def por_v2_decision(risk_v2: float, threshold: float) -> str:
     return "PROCEED" if risk_v2 <= threshold else "SILENCE"
+
+
+def compute_risk_v2_1(
+    *,
+    instability_v1: float,
+    agreement_risk: float,
+    self_check_risk: float,
+    contradiction_risk: float,
+    weights: PoRV2_1Weights = PoRV2_1Weights(),
+) -> float:
+    return (
+        (weights.instability_weight * instability_v1)
+        + (weights.agreement_weight * agreement_risk)
+        + (weights.self_check_weight * self_check_risk)
+        + (weights.contradiction_weight * contradiction_risk)
+    )
+
+
+def por_v2_1_decision(risk_v2_1: float, threshold: float) -> str:
+    return "PROCEED" if risk_v2_1 <= threshold else "SILENCE"

--- a/benchmarks/simpleqa/run_simpleqa_por.py
+++ b/benchmarks/simpleqa/run_simpleqa_por.py
@@ -19,12 +19,15 @@ from benchmarks.simpleqa.metrics import (
     compute_threshold_metrics,
     is_correct,
 )
+from benchmarks.simpleqa.contradiction_check import parse_contradiction_response
 from benchmarks.simpleqa.model_adapter import ModelAdapterError, build_model_adapter
 from benchmarks.simpleqa.plot_results import build_threshold_tradeoff_plot
 from benchmarks.simpleqa.por_v2 import (
     agreement_score_to_risk,
     compute_risk_v2,
+    compute_risk_v2_1,
     por_v2_decision,
+    por_v2_1_decision,
     self_check_label_to_risk,
 )
 from benchmarks.simpleqa.por_adapter import evaluate_por_gate
@@ -81,9 +84,9 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--por-mode",
-        choices=["v1", "v2"],
+        choices=["v1", "v2", "v2_1"],
         default="v1",
-        help="PoR gating mode: v1 (default) or experimental v2.",
+        help="PoR gating mode: v1 (default), experimental v2, or experimental v2_1.",
     )
     return parser.parse_args()
 
@@ -144,6 +147,10 @@ def run() -> None:
         "self_check_risk",
         "risk_v2",
         "decision_v2",
+        "contradiction_label",
+        "contradiction_risk",
+        "risk_v2_1",
+        "decision_v2_1",
         "effective_decision",
         "por_decision",
         "final_output",
@@ -191,6 +198,10 @@ def run() -> None:
                     "self_check_risk": "",
                     "risk_v2": "",
                     "decision_v2": "",
+                    "contradiction_label": "",
+                    "contradiction_risk": "",
+                    "risk_v2_1": "",
+                    "decision_v2_1": "",
                     "effective_decision": "ERROR",
                     "por_decision": "ERROR",
                     "final_output": "",
@@ -228,6 +239,10 @@ def run() -> None:
                 "self_check_risk": "",
                 "risk_v2": "",
                 "decision_v2": "",
+                "contradiction_label": "",
+                "contradiction_risk": "",
+                "risk_v2_1": "",
+                "decision_v2_1": "",
                 "effective_decision": "PROCEED",
                 "por_decision": "PROCEED",
                 "final_output": baseline_answer,
@@ -274,6 +289,10 @@ def run() -> None:
                     "self_check_risk": "",
                     "risk_v2": "",
                     "decision_v2": "",
+                    "contradiction_label": "",
+                    "contradiction_risk": "",
+                    "risk_v2_1": "",
+                    "decision_v2_1": "",
                     "effective_decision": "ERROR",
                     "por_decision": "ERROR",
                     "final_output": "",
@@ -311,6 +330,10 @@ def run() -> None:
                     "self_check_risk": "",
                     "risk_v2": "",
                     "decision_v2": "",
+                    "contradiction_label": "",
+                    "contradiction_risk": "",
+                    "risk_v2_1": "",
+                    "decision_v2_1": "",
                     "effective_decision": "ERROR",
                     "por_decision": "ERROR",
                     "final_output": "",
@@ -331,7 +354,9 @@ def run() -> None:
             agreement_risk = agreement_score_to_risk(agreement_score)
             self_check_label = ""
             self_check_risk = ""
-            if args.por_mode == "v2":
+            contradiction_label = ""
+            contradiction_risk = ""
+            if args.por_mode in ("v2", "v2_1"):
                 try:
                     self_check_label = adapter.self_check(ex.question, por_candidate)
                 except ModelAdapterError as exc:
@@ -357,6 +382,10 @@ def run() -> None:
                         "self_check_risk": "",
                         "risk_v2": "",
                         "decision_v2": "",
+                        "contradiction_label": "",
+                        "contradiction_risk": "",
+                        "risk_v2_1": "",
+                        "decision_v2_1": "",
                         "effective_decision": "ERROR",
                         "por_decision": "ERROR",
                         "final_output": "",
@@ -372,6 +401,53 @@ def run() -> None:
                     continue
                 self_check_risk = self_check_label_to_risk(self_check_label)
 
+            if args.por_mode == "v2_1":
+                try:
+                    contradiction_text = adapter.contradiction_check(ex.question, por_candidate)
+                    contradiction_result = parse_contradiction_response(contradiction_text)
+                    contradiction_label = contradiction_result.label
+                    contradiction_risk = contradiction_result.risk
+                except ModelAdapterError as exc:
+                    err_row = {
+                        "example_id": ex.example_id,
+                        "question": ex.question,
+                        "reference_answers": ex.reference_answers,
+                        "baseline_answer": baseline_answer,
+                        "por_candidate": por_candidate,
+                        "por_candidates_json": por_candidates,
+                        "por_primary_candidate": por_candidate,
+                        "por_sample_count": len(por_candidates),
+                        "por_mode": args.por_mode,
+                        "threshold": "",
+                        "threshold_label": "contradiction_check_error",
+                        "threshold_value": "",
+                        "drift": "",
+                        "coherence": "",
+                        "instability_score": "",
+                        "semantic_agreement_score": agreement_score,
+                        "semantic_agreement_risk": agreement_risk,
+                        "self_check_label": self_check_label,
+                        "self_check_risk": self_check_risk,
+                        "risk_v2": "",
+                        "decision_v2": "",
+                        "contradiction_label": "",
+                        "contradiction_risk": "",
+                        "risk_v2_1": "",
+                        "decision_v2_1": "",
+                        "effective_decision": "ERROR",
+                        "por_decision": "ERROR",
+                        "final_output": "",
+                        "correctness_label": "wrong",
+                        "silence_flag": True,
+                        "false_silence_flag": False,
+                        "accepted_error_flag": False,
+                        "error": str(exc),
+                    }
+                    rows.append(err_row)
+                    writer.writerow({k: _to_csv_value(v) for k, v in err_row.items()})
+                    csv_file.flush()
+                    continue
+
             for threshold in args.thresholds:
                 threshold_key = threshold_to_key(threshold)
                 eval_result = evaluate_por_gate(
@@ -382,6 +458,8 @@ def run() -> None:
                 )
                 risk_v2 = ""
                 decision_v2 = ""
+                risk_v2_1 = ""
+                decision_v2_1 = ""
                 effective_decision = eval_result.por_decision
                 if args.por_mode == "v2":
                     risk_v2 = compute_risk_v2(
@@ -391,6 +469,15 @@ def run() -> None:
                     )
                     decision_v2 = por_v2_decision(risk_v2=risk_v2, threshold=threshold)
                     effective_decision = decision_v2
+                if args.por_mode == "v2_1":
+                    risk_v2_1 = compute_risk_v2_1(
+                        instability_v1=eval_result.instability_score,
+                        agreement_risk=agreement_risk,
+                        self_check_risk=float(self_check_risk),
+                        contradiction_risk=float(contradiction_risk),
+                    )
+                    decision_v2_1 = por_v2_1_decision(risk_v2_1=risk_v2_1, threshold=threshold)
+                    effective_decision = decision_v2_1
                 silence_flag = effective_decision == "SILENCE"
                 final_output = "" if silence_flag else por_candidate
                 correctness_label = "wrong" if silence_flag else ("correct" if candidate_correct else "wrong")
@@ -419,6 +506,10 @@ def run() -> None:
                     "self_check_risk": self_check_risk,
                     "risk_v2": risk_v2,
                     "decision_v2": decision_v2,
+                    "contradiction_label": contradiction_label,
+                    "contradiction_risk": contradiction_risk,
+                    "risk_v2_1": risk_v2_1,
+                    "decision_v2_1": decision_v2_1,
                     "effective_decision": effective_decision,
                     "por_decision": eval_result.por_decision,
                     "final_output": final_output,

--- a/tests/test_simpleqa_benchmark_harness.py
+++ b/tests/test_simpleqa_benchmark_harness.py
@@ -1,3 +1,4 @@
+from benchmarks.simpleqa.run_simpleqa_por import _parse_args
 from benchmarks.simpleqa.metrics import compute_threshold_metrics
 from benchmarks.simpleqa.por_adapter import evaluate_por_gate
 from benchmarks.simpleqa.run_simpleqa_por import validate_por_samples
@@ -47,3 +48,48 @@ def test_por_gate_uses_multi_sample_drift() -> None:
         threshold=0.39,
     )
     assert result.drift > 0.0
+
+
+def test_por_mode_default_and_choices(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "run_simpleqa_por.py",
+            "--dataset-path",
+            "dummy.jsonl",
+            "--model",
+            "gpt-4o-mini",
+        ],
+    )
+    args = _parse_args()
+    assert args.por_mode == "v1"
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "run_simpleqa_por.py",
+            "--dataset-path",
+            "dummy.jsonl",
+            "--model",
+            "gpt-4o-mini",
+            "--por-mode",
+            "v2",
+        ],
+    )
+    args_v2 = _parse_args()
+    assert args_v2.por_mode == "v2"
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "run_simpleqa_por.py",
+            "--dataset-path",
+            "dummy.jsonl",
+            "--model",
+            "gpt-4o-mini",
+            "--por-mode",
+            "v2_1",
+        ],
+    )
+    args_v2_1 = _parse_args()
+    assert args_v2_1.por_mode == "v2_1"

--- a/tests/test_simpleqa_por_v2.py
+++ b/tests/test_simpleqa_por_v2.py
@@ -1,6 +1,10 @@
+import pytest
+from benchmarks.simpleqa.contradiction_check import parse_contradiction_response
 from benchmarks.simpleqa.por_v2 import (
+    PoRV2_1Weights,
     PoRV2Weights,
     compute_risk_v2,
+    compute_risk_v2_1,
     self_check_label_to_risk,
 )
 from benchmarks.simpleqa.semantic_agreement import semantic_agreement_score
@@ -34,3 +38,28 @@ def test_compute_risk_v2_weighted_sum() -> None:
         weights=PoRV2Weights(instability_weight=0.4, agreement_weight=0.3, self_check_weight=0.3),
     )
     assert risk == 0.52
+
+
+def test_contradiction_check_mapping() -> None:
+    assert parse_contradiction_response("NO_CONTRADICTION").label == "NO_CONTRADICTION"
+    assert parse_contradiction_response("NO_CONTRADICTION").risk == 0.0
+    assert parse_contradiction_response("Might be Astana").label == "WEAK_CHALLENGE"
+    assert parse_contradiction_response("Might be Astana").risk == 0.5
+    assert parse_contradiction_response("Astana").label == "STRONG_CHALLENGE"
+    assert parse_contradiction_response("Astana").risk == 1.0
+
+
+def test_compute_risk_v2_1_weighted_sum() -> None:
+    risk = compute_risk_v2_1(
+        instability_v1=0.2,
+        agreement_risk=0.1,
+        self_check_risk=1.0,
+        contradiction_risk=0.5,
+        weights=PoRV2_1Weights(
+            instability_weight=0.3,
+            agreement_weight=0.2,
+            self_check_weight=0.2,
+            contradiction_weight=0.3,
+        ),
+    )
+    assert risk == pytest.approx(0.43)


### PR DESCRIPTION
### Motivation
- Address a failure mode where confidently wrong answers remain internally consistent by adding an adversarial self-challenge signal (contradiction check) to the experimental PoR flow.
- Provide a minimal, benchmark-local, opt-in extension (v2_1) that augments v2 without changing v1/v2 defaults or core PoR primitives.

### Description
- Add a compact contradiction parser `benchmarks/simpleqa/contradiction_check.py` that maps model responses to `NO_CONTRADICTION` / `WEAK_CHALLENGE` / `STRONG_CHALLENGE` with risks `0.0/0.5/1.0`.
- Extend the model adapter interface with `contradiction_check(...)` and implement it for the OpenAI adapter using a short deterministic prompt (`temperature=0.0`, `max_tokens=24`) without modifying existing `answer(...)` or `self_check(...)` behavior.
- Add v2.1 scoring helpers to `benchmarks/simpleqa/por_v2.py` (`PoRV2_1Weights`, `compute_risk_v2_1`, `por_v2_1_decision`) and integrate contradiction risk into the weighted risk composition (instability/agreement/self-check/contradiction).
- Wire the runtime and CLI in `benchmarks/simpleqa/run_simpleqa_por.py` to accept `--por-mode v1|v2|v2_1` (default remains `v1`), call the contradiction check when `v2_1` is selected, and emit backward-compatible per-example output fields: `contradiction_label`, `contradiction_risk`, `risk_v2_1`, and `decision_v2_1`.
- Update `benchmarks/simpleqa/README.md` to document v2.1 as experimental and add small, lightweight tests to `tests/test_simpleqa_por_v2.py` and `tests/test_simpleqa_benchmark_harness.py` covering parsing, weighting, and CLI choices.

Files changed:
- benchmarks/simpleqa/contradiction_check.py (new)
- benchmarks/simpleqa/model_adapter.py
- benchmarks/simpleqa/por_v2.py
- benchmarks/simpleqa/run_simpleqa_por.py
- benchmarks/simpleqa/README.md
- tests/test_simpleqa_por_v2.py
- tests/test_simpleqa_benchmark_harness.py

### Testing
- Ran the new/updated unit tests with `pytest -q tests/test_simpleqa_por_v2.py tests/test_simpleqa_benchmark_harness.py` and all tests passed (`9 passed`).
- Tests exercise the contradiction parsing mapping, the `v2.1` weighted risk computation, and CLI `--por-mode` default/choices, and they succeeded without adding external dependencies or network calls in test time.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9192002088326a5421633fcb4b24e)