### PR TITLE
Add optional PoR v2.2 self-check NO penalty mode for SimpleQA

### DIFF
--- a/benchmarks/simpleqa/README.md
+++ b/benchmarks/simpleqa/README.md
@@ -7,11 +7,12 @@ It is designed to test the Silence-as-Control hypothesis:
 - baseline: always answers,
 - PoR-gated: generates multiple candidates, computes drift across that candidate set, then answers only when instability is below threshold (otherwise silences).
 
-It supports three PoR gate modes:
+It supports four PoR gate modes:
 
 - **PoR v1 (default)**: drift + coherence -> instability -> threshold decision.
 - **PoR v2 (experimental)**: keeps v1 signals and adds semantic agreement + self-check risk before thresholding.
 - **PoR v2.1 (experimental)**: keeps v2 signals and adds contradiction challenge risk before thresholding.
+- **PoR v2.2 (experimental)**: keeps v2.1 and adds a strong additive risk penalty when `self_check = NO`.
 
 ## Why SimpleQA
 
@@ -92,8 +93,13 @@ PoR mode:
   - model is asked to challenge the primary candidate,
   - response is mapped to `NO_CONTRADICTION` / `WEAK_CHALLENGE` / `STRONG_CHALLENGE`,
   - contradiction risk is combined with v2 signals.
+- `--por-mode v2_2`: experimental prototype extending v2.1 with stronger handling of `self_check = NO`:
+  - computes `risk_v2_2 = risk_v2_1 + self_check_no_penalty` when `self_check_label == "NO"`,
+  - otherwise `risk_v2_2 = risk_v2_1`,
+  - then thresholds `risk_v2_2` for release-control decision.
+- `--self-check-no-penalty` (default `0.30`): additive penalty used only in `v2_2`.
 
-v2.1 is designed to probe confidently wrong but internally consistent answers. It remains experimental and does **not** replace the core PoR primitive.
+v2.1/v2.2 are designed to probe confidently wrong but internally consistent answers. v2.2 specifically tests whether internal model rejection should act as a stronger release-control signal. Both remain experimental and do **not** replace the core PoR primitive.
 
 ## Output artifacts
 
@@ -124,9 +130,13 @@ Per-example rows include:
 - `contradiction_risk`,
 - `risk_v2_1`,
 - `decision_v2_1`,
-- `effective_decision` (the decision used for final output; equals v1 in v1 mode, v2 in v2 mode, and v2.1 in v2_1 mode).
+- `self_check_no_penalty`,
+- `self_check_no_override_applied`,
+- `risk_v2_2`,
+- `decision_v2_2`,
+- `effective_decision` (the decision used for final output; equals v1 in v1 mode, v2 in v2 mode, v2.1 in v2_1 mode, and v2.2 in v2_2 mode).
 
-For `v2_1`, `effective_decision` equals `decision_v2_1`.
+For `v2_1`, `effective_decision` equals `decision_v2_1`. For `v2_2`, `effective_decision` equals `decision_v2_2`.
 
 ## Metric definitions
 

--- a/benchmarks/simpleqa/por_v2.py
+++ b/benchmarks/simpleqa/por_v2.py
@@ -68,3 +68,18 @@ def compute_risk_v2_1(
 
 def por_v2_1_decision(risk_v2_1: float, threshold: float) -> str:
     return "PROCEED" if risk_v2_1 <= threshold else "SILENCE"
+
+
+def compute_risk_v2_2(
+    *,
+    risk_v2_1: float,
+    self_check_label: str,
+    self_check_no_penalty: float,
+) -> tuple[float, bool]:
+    no_override_applied = self_check_label.strip().upper() == "NO"
+    risk_v2_2 = risk_v2_1 + self_check_no_penalty if no_override_applied else risk_v2_1
+    return risk_v2_2, no_override_applied
+
+
+def por_v2_2_decision(risk_v2_2: float, threshold: float) -> str:
+    return "PROCEED" if risk_v2_2 <= threshold else "SILENCE"

--- a/benchmarks/simpleqa/run_simpleqa_por.py
+++ b/benchmarks/simpleqa/run_simpleqa_por.py
@@ -26,8 +26,10 @@ from benchmarks.simpleqa.por_v2 import (
     agreement_score_to_risk,
     compute_risk_v2,
     compute_risk_v2_1,
+    compute_risk_v2_2,
     por_v2_decision,
     por_v2_1_decision,
+    por_v2_2_decision,
     self_check_label_to_risk,
 )
 from benchmarks.simpleqa.por_adapter import evaluate_por_gate
@@ -84,9 +86,15 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--por-mode",
-        choices=["v1", "v2", "v2_1"],
+        choices=["v1", "v2", "v2_1", "v2_2"],
         default="v1",
-        help="PoR gating mode: v1 (default), experimental v2, or experimental v2_1.",
+        help="PoR gating mode: v1 (default), experimental v2, v2_1, or v2_2.",
+    )
+    parser.add_argument(
+        "--self-check-no-penalty",
+        type=float,
+        default=0.30,
+        help="Additive risk penalty in v2_2 when self_check_label == NO.",
     )
     return parser.parse_args()
 
@@ -151,6 +159,10 @@ def run() -> None:
         "contradiction_risk",
         "risk_v2_1",
         "decision_v2_1",
+        "self_check_no_penalty",
+        "self_check_no_override_applied",
+        "risk_v2_2",
+        "decision_v2_2",
         "effective_decision",
         "por_decision",
         "final_output",
@@ -202,6 +214,10 @@ def run() -> None:
                     "contradiction_risk": "",
                     "risk_v2_1": "",
                     "decision_v2_1": "",
+                    "self_check_no_penalty": "",
+                    "self_check_no_override_applied": "",
+                    "risk_v2_2": "",
+                    "decision_v2_2": "",
                     "effective_decision": "ERROR",
                     "por_decision": "ERROR",
                     "final_output": "",
@@ -243,6 +259,10 @@ def run() -> None:
                 "contradiction_risk": "",
                 "risk_v2_1": "",
                 "decision_v2_1": "",
+                "self_check_no_penalty": "",
+                "self_check_no_override_applied": "",
+                "risk_v2_2": "",
+                "decision_v2_2": "",
                 "effective_decision": "PROCEED",
                 "por_decision": "PROCEED",
                 "final_output": baseline_answer,
@@ -293,6 +313,10 @@ def run() -> None:
                     "contradiction_risk": "",
                     "risk_v2_1": "",
                     "decision_v2_1": "",
+                    "self_check_no_penalty": "",
+                    "self_check_no_override_applied": "",
+                    "risk_v2_2": "",
+                    "decision_v2_2": "",
                     "effective_decision": "ERROR",
                     "por_decision": "ERROR",
                     "final_output": "",
@@ -334,6 +358,10 @@ def run() -> None:
                     "contradiction_risk": "",
                     "risk_v2_1": "",
                     "decision_v2_1": "",
+                    "self_check_no_penalty": "",
+                    "self_check_no_override_applied": "",
+                    "risk_v2_2": "",
+                    "decision_v2_2": "",
                     "effective_decision": "ERROR",
                     "por_decision": "ERROR",
                     "final_output": "",
@@ -356,7 +384,7 @@ def run() -> None:
             self_check_risk = ""
             contradiction_label = ""
             contradiction_risk = ""
-            if args.por_mode in ("v2", "v2_1"):
+            if args.por_mode in ("v2", "v2_1", "v2_2"):
                 try:
                     self_check_label = adapter.self_check(ex.question, por_candidate)
                 except ModelAdapterError as exc:
@@ -386,6 +414,10 @@ def run() -> None:
                         "contradiction_risk": "",
                         "risk_v2_1": "",
                         "decision_v2_1": "",
+                        "self_check_no_penalty": "",
+                        "self_check_no_override_applied": "",
+                        "risk_v2_2": "",
+                        "decision_v2_2": "",
                         "effective_decision": "ERROR",
                         "por_decision": "ERROR",
                         "final_output": "",
@@ -401,7 +433,7 @@ def run() -> None:
                     continue
                 self_check_risk = self_check_label_to_risk(self_check_label)
 
-            if args.por_mode == "v2_1":
+            if args.por_mode in ("v2_1", "v2_2"):
                 try:
                     contradiction_text = adapter.contradiction_check(ex.question, por_candidate)
                     contradiction_result = parse_contradiction_response(contradiction_text)
@@ -434,6 +466,10 @@ def run() -> None:
                         "contradiction_risk": "",
                         "risk_v2_1": "",
                         "decision_v2_1": "",
+                        "self_check_no_penalty": "",
+                        "self_check_no_override_applied": "",
+                        "risk_v2_2": "",
+                        "decision_v2_2": "",
                         "effective_decision": "ERROR",
                         "por_decision": "ERROR",
                         "final_output": "",
@@ -460,6 +496,10 @@ def run() -> None:
                 decision_v2 = ""
                 risk_v2_1 = ""
                 decision_v2_1 = ""
+                self_check_no_penalty = ""
+                self_check_no_override_applied = ""
+                risk_v2_2 = ""
+                decision_v2_2 = ""
                 effective_decision = eval_result.por_decision
                 if args.por_mode == "v2":
                     risk_v2 = compute_risk_v2(
@@ -469,7 +509,7 @@ def run() -> None:
                     )
                     decision_v2 = por_v2_decision(risk_v2=risk_v2, threshold=threshold)
                     effective_decision = decision_v2
-                if args.por_mode == "v2_1":
+                if args.por_mode in ("v2_1", "v2_2"):
                     risk_v2_1 = compute_risk_v2_1(
                         instability_v1=eval_result.instability_score,
                         agreement_risk=agreement_risk,
@@ -478,6 +518,16 @@ def run() -> None:
                     )
                     decision_v2_1 = por_v2_1_decision(risk_v2_1=risk_v2_1, threshold=threshold)
                     effective_decision = decision_v2_1
+                if args.por_mode == "v2_2":
+                    self_check_no_penalty = args.self_check_no_penalty
+                    risk_v2_2, no_override_applied = compute_risk_v2_2(
+                        risk_v2_1=float(risk_v2_1),
+                        self_check_label=str(self_check_label),
+                        self_check_no_penalty=args.self_check_no_penalty,
+                    )
+                    self_check_no_override_applied = no_override_applied
+                    decision_v2_2 = por_v2_2_decision(risk_v2_2=risk_v2_2, threshold=threshold)
+                    effective_decision = decision_v2_2
                 silence_flag = effective_decision == "SILENCE"
                 final_output = "" if silence_flag else por_candidate
                 correctness_label = "wrong" if silence_flag else ("correct" if candidate_correct else "wrong")
@@ -510,6 +560,10 @@ def run() -> None:
                     "contradiction_risk": contradiction_risk,
                     "risk_v2_1": risk_v2_1,
                     "decision_v2_1": decision_v2_1,
+                    "self_check_no_penalty": self_check_no_penalty,
+                    "self_check_no_override_applied": self_check_no_override_applied,
+                    "risk_v2_2": risk_v2_2,
+                    "decision_v2_2": decision_v2_2,
                     "effective_decision": effective_decision,
                     "por_decision": eval_result.por_decision,
                     "final_output": final_output,
@@ -568,6 +622,7 @@ def run() -> None:
             "baseline_temperature": args.baseline_temperature,
             "por_temperature": args.por_temperature,
             "por_mode": args.por_mode,
+            "self_check_no_penalty": args.self_check_no_penalty,
             "experimental_short_regen_enabled": False,
         },
         "baseline": asdict(baseline_metrics),

--- a/tests/test_simpleqa_benchmark_harness.py
+++ b/tests/test_simpleqa_benchmark_harness.py
@@ -63,6 +63,7 @@ def test_por_mode_default_and_choices(monkeypatch) -> None:
     )
     args = _parse_args()
     assert args.por_mode == "v1"
+    assert args.self_check_no_penalty == 0.30
 
     monkeypatch.setattr(
         "sys.argv",
@@ -93,3 +94,21 @@ def test_por_mode_default_and_choices(monkeypatch) -> None:
     )
     args_v2_1 = _parse_args()
     assert args_v2_1.por_mode == "v2_1"
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "run_simpleqa_por.py",
+            "--dataset-path",
+            "dummy.jsonl",
+            "--model",
+            "gpt-4o-mini",
+            "--por-mode",
+            "v2_2",
+            "--self-check-no-penalty",
+            "0.35",
+        ],
+    )
+    args_v2_2 = _parse_args()
+    assert args_v2_2.por_mode == "v2_2"
+    assert args_v2_2.self_check_no_penalty == 0.35

--- a/tests/test_simpleqa_por_v2.py
+++ b/tests/test_simpleqa_por_v2.py
@@ -5,6 +5,8 @@ from benchmarks.simpleqa.por_v2 import (
     PoRV2Weights,
     compute_risk_v2,
     compute_risk_v2_1,
+    compute_risk_v2_2,
+    por_v2_2_decision,
     self_check_label_to_risk,
 )
 from benchmarks.simpleqa.semantic_agreement import semantic_agreement_score
@@ -63,3 +65,28 @@ def test_compute_risk_v2_1_weighted_sum() -> None:
         ),
     )
     assert risk == pytest.approx(0.43)
+
+
+def test_compute_risk_v2_2_applies_no_penalty() -> None:
+    risk, applied = compute_risk_v2_2(
+        risk_v2_1=0.41,
+        self_check_label="NO",
+        self_check_no_penalty=0.30,
+    )
+    assert risk == pytest.approx(0.71)
+    assert applied is True
+
+
+def test_compute_risk_v2_2_no_penalty_when_not_no() -> None:
+    risk, applied = compute_risk_v2_2(
+        risk_v2_1=0.41,
+        self_check_label="YES",
+        self_check_no_penalty=0.30,
+    )
+    assert risk == pytest.approx(0.41)
+    assert applied is False
+
+
+def test_por_v2_2_decision_thresholding() -> None:
+    assert por_v2_2_decision(risk_v2_2=0.40, threshold=0.42) == "PROCEED"
+    assert por_v2_2_decision(risk_v2_2=0.43, threshold=0.42) == "SILENCE"


### PR DESCRIPTION
### Motivation
- v2.1 shows useful self_check = NO signals that are currently underweighted, allowing some wrong but internally stable answers to be released. 
- Provide a minimal, inspectable experimental extension that makes `self_check = NO` a stronger gating signal without changing existing PoR primitives or default behavior. 

### Description
- Add `compute_risk_v2_2(...)` and `por_v2_2_decision(...)` in `benchmarks/simpleqa/por_v2.py` implementing the rule `risk_v2_2 = risk_v2_1 + self_check_no_penalty` when `self_check_label == "NO"` and returning whether the override was applied. 
- Extend `benchmarks/simpleqa/run_simpleqa_por.py` to accept `--por-mode v2_2` (keeping `v1` as default) and a tunable `--self-check-no-penalty` flag (default `0.30`), wire v2.2 computation into the evaluation loop, and add backward-compatible CSV/JSON output fields `self_check_no_penalty`, `self_check_no_override_applied`, `risk_v2_2`, and `decision_v2_2`. 
- Update `benchmarks/simpleqa/README.md` to document the v2.2 purpose, exact penalty rule, CLI flag, and experimental status while preserving descriptions of v1/v2/v2_1. 
- Add lightweight unit tests in `tests/test_simpleqa_por_v2.py` and CLI parsing checks in `tests/test_simpleqa_benchmark_harness.py` to cover v2.2 risk computation, decision thresholding, and CLI parsing. 

### Testing
- Ran `pytest -q tests/test_simpleqa_por_v2.py tests/test_simpleqa_benchmark_harness.py`, which executed the new and existing unit tests and reported `12 passed`.
- New tests include checks that `compute_risk_v2_2` applies the additive penalty only when `self_check_label == "NO"` and that `por_v2_2_decision` thresholds correctly, and they passed. 
- No other automated test suites were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9206ebdec8326a164d749baf395a5)