### PR TITLE
Add experimental PoR v2_2 mode with self-check NO penalty and CLI flag

### DIFF
--- a/benchmarks/simpleqa/README.md
+++ b/benchmarks/simpleqa/README.md
@@ -7,11 +7,12 @@ It is designed to test the Silence-as-Control hypothesis:
 - baseline: always answers,
 - PoR-gated: generates multiple candidates, computes drift across that candidate set, then answers only when instability is below threshold (otherwise silences).
 
-It supports three PoR gate modes:
+It supports four PoR gate modes:
 
 - **PoR v1 (default)**: drift + coherence -> instability -> threshold decision.
 - **PoR v2 (experimental)**: keeps v1 signals and adds semantic agreement + self-check risk before thresholding.
 - **PoR v2.1 (experimental)**: keeps v2 signals and adds contradiction challenge risk before thresholding.
+- **PoR v2.2 (experimental)**: keeps v2.1 and adds a strong additive risk penalty when `self_check = NO`.
 
 ## Why SimpleQA
 
@@ -92,8 +93,13 @@ PoR mode:
   - model is asked to challenge the primary candidate,
   - response is mapped to `NO_CONTRADICTION` / `WEAK_CHALLENGE` / `STRONG_CHALLENGE`,
   - contradiction risk is combined with v2 signals.
+- `--por-mode v2_2`: experimental prototype extending v2.1 with stronger handling of `self_check = NO`:
+  - computes `risk_v2_2 = risk_v2_1 + self_check_no_penalty` when `self_check_label == "NO"`,
+  - otherwise `risk_v2_2 = risk_v2_1`,
+  - then thresholds `risk_v2_2` for release-control decision.
+- `--self-check-no-penalty` (default `0.30`): additive penalty used only in `v2_2`.
 
-v2.1 is designed to probe confidently wrong but internally consistent answers. It remains experimental and does **not** replace the core PoR primitive.
+v2.1/v2.2 are designed to probe confidently wrong but internally consistent answers. v2.2 specifically tests whether internal model rejection should act as a stronger release-control signal. Both remain experimental and do **not** replace the core PoR primitive.
 
 ## Output artifacts
 
@@ -124,9 +130,13 @@ Per-example rows include:
 - `contradiction_risk`,
 - `risk_v2_1`,
 - `decision_v2_1`,
-- `effective_decision` (the decision used for final output; equals v1 in v1 mode, v2 in v2 mode, and v2.1 in v2_1 mode).
+- `self_check_no_penalty`,
+- `self_check_no_override_applied`,
+- `risk_v2_2`,
+- `decision_v2_2`,
+- `effective_decision` (the decision used for final output; equals v1 in v1 mode, v2 in v2 mode, v2.1 in v2_1 mode, and v2.2 in v2_2 mode).
 
-For `v2_1`, `effective_decision` equals `decision_v2_1`.
+For `v2_1`, `effective_decision` equals `decision_v2_1`. For `v2_2`, `effective_decision` equals `decision_v2_2`.
 
 ## Metric definitions
 

--- a/benchmarks/simpleqa/por_v2.py
+++ b/benchmarks/simpleqa/por_v2.py
@@ -68,3 +68,20 @@ def compute_risk_v2_1(
 
 def por_v2_1_decision(risk_v2_1: float, threshold: float) -> str:
     return "PROCEED" if risk_v2_1 <= threshold else "SILENCE"
+
+
+def compute_risk_v2_2(
+    *,
+    risk_v2_1: float,
+    self_check_label: str,
+    self_check_no_penalty: float,
+) -> tuple[float, bool]:
+    if self_check_no_penalty < 0:
+        raise ValueError("self_check_no_penalty must be >= 0. Negative values invert risk behavior.")
+    no_override_applied = self_check_label.strip().upper() == "NO"
+    risk_v2_2 = risk_v2_1 + self_check_no_penalty if no_override_applied else risk_v2_1
+    return risk_v2_2, no_override_applied
+
+
+def por_v2_2_decision(risk_v2_2: float, threshold: float) -> str:
+    return "PROCEED" if risk_v2_2 <= threshold else "SILENCE"

--- a/benchmarks/simpleqa/run_simpleqa_por.py
+++ b/benchmarks/simpleqa/run_simpleqa_por.py
@@ -26,8 +26,10 @@ from benchmarks.simpleqa.por_v2 import (
     agreement_score_to_risk,
     compute_risk_v2,
     compute_risk_v2_1,
+    compute_risk_v2_2,
     por_v2_decision,
     por_v2_1_decision,
+    por_v2_2_decision,
     self_check_label_to_risk,
 )
 from benchmarks.simpleqa.por_adapter import evaluate_por_gate
@@ -42,6 +44,12 @@ def threshold_to_key(threshold: float) -> str:
 def validate_por_samples(value: int) -> int:
     if value < 2:
         raise ValueError("--por-samples must be >= 2 to compute multi-sample drift.")
+    return value
+
+
+def validate_self_check_no_penalty(value: float) -> float:
+    if value < 0:
+        raise ValueError("self_check_no_penalty must be >= 0. Negative values invert risk behavior.")
     return value
 
 
@@ -84,9 +92,15 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--por-mode",
-        choices=["v1", "v2", "v2_1"],
+        choices=["v1", "v2", "v2_1", "v2_2"],
         default="v1",
-        help="PoR gating mode: v1 (default), experimental v2, or experimental v2_1.",
+        help="PoR gating mode: v1 (default), experimental v2, v2_1, or v2_2.",
+    )
+    parser.add_argument(
+        "--self-check-no-penalty",
+        type=float,
+        default=0.30,
+        help="Additive risk penalty in v2_2 when self_check_label == NO.",
     )
     return parser.parse_args()
 
@@ -103,6 +117,7 @@ def run() -> None:
     args = _parse_args()
     try:
         por_samples = validate_por_samples(args.por_samples)
+        validated_self_check_no_penalty = validate_self_check_no_penalty(args.self_check_no_penalty)
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc
     out_dir = Path(args.output_dir)
@@ -151,6 +166,10 @@ def run() -> None:
         "contradiction_risk",
         "risk_v2_1",
         "decision_v2_1",
+        "self_check_no_penalty",
+        "self_check_no_override_applied",
+        "risk_v2_2",
+        "decision_v2_2",
         "effective_decision",
         "por_decision",
         "final_output",
@@ -202,6 +221,10 @@ def run() -> None:
                     "contradiction_risk": "",
                     "risk_v2_1": "",
                     "decision_v2_1": "",
+                    "self_check_no_penalty": "",
+                    "self_check_no_override_applied": "",
+                    "risk_v2_2": "",
+                    "decision_v2_2": "",
                     "effective_decision": "ERROR",
                     "por_decision": "ERROR",
                     "final_output": "",
@@ -243,6 +266,10 @@ def run() -> None:
                 "contradiction_risk": "",
                 "risk_v2_1": "",
                 "decision_v2_1": "",
+                "self_check_no_penalty": "",
+                "self_check_no_override_applied": "",
+                "risk_v2_2": "",
+                "decision_v2_2": "",
                 "effective_decision": "PROCEED",
                 "por_decision": "PROCEED",
                 "final_output": baseline_answer,
@@ -293,6 +320,10 @@ def run() -> None:
                     "contradiction_risk": "",
                     "risk_v2_1": "",
                     "decision_v2_1": "",
+                    "self_check_no_penalty": "",
+                    "self_check_no_override_applied": "",
+                    "risk_v2_2": "",
+                    "decision_v2_2": "",
                     "effective_decision": "ERROR",
                     "por_decision": "ERROR",
                     "final_output": "",
@@ -334,6 +365,10 @@ def run() -> None:
                     "contradiction_risk": "",
                     "risk_v2_1": "",
                     "decision_v2_1": "",
+                    "self_check_no_penalty": "",
+                    "self_check_no_override_applied": "",
+                    "risk_v2_2": "",
+                    "decision_v2_2": "",
                     "effective_decision": "ERROR",
                     "por_decision": "ERROR",
                     "final_output": "",
@@ -356,7 +391,7 @@ def run() -> None:
             self_check_risk = ""
             contradiction_label = ""
             contradiction_risk = ""
-            if args.por_mode in ("v2", "v2_1"):
+            if args.por_mode in ("v2", "v2_1", "v2_2"):
                 try:
                     self_check_label = adapter.self_check(ex.question, por_candidate)
                 except ModelAdapterError as exc:
@@ -386,6 +421,10 @@ def run() -> None:
                         "contradiction_risk": "",
                         "risk_v2_1": "",
                         "decision_v2_1": "",
+                        "self_check_no_penalty": "",
+                        "self_check_no_override_applied": "",
+                        "risk_v2_2": "",
+                        "decision_v2_2": "",
                         "effective_decision": "ERROR",
                         "por_decision": "ERROR",
                         "final_output": "",
@@ -401,7 +440,7 @@ def run() -> None:
                     continue
                 self_check_risk = self_check_label_to_risk(self_check_label)
 
-            if args.por_mode == "v2_1":
+            if args.por_mode in ("v2_1", "v2_2"):
                 try:
                     contradiction_text = adapter.contradiction_check(ex.question, por_candidate)
                     contradiction_result = parse_contradiction_response(contradiction_text)
@@ -434,6 +473,10 @@ def run() -> None:
                         "contradiction_risk": "",
                         "risk_v2_1": "",
                         "decision_v2_1": "",
+                        "self_check_no_penalty": "",
+                        "self_check_no_override_applied": "",
+                        "risk_v2_2": "",
+                        "decision_v2_2": "",
                         "effective_decision": "ERROR",
                         "por_decision": "ERROR",
                         "final_output": "",
@@ -460,6 +503,10 @@ def run() -> None:
                 decision_v2 = ""
                 risk_v2_1 = ""
                 decision_v2_1 = ""
+                self_check_no_penalty = ""
+                self_check_no_override_applied = ""
+                risk_v2_2 = ""
+                decision_v2_2 = ""
                 effective_decision = eval_result.por_decision
                 if args.por_mode == "v2":
                     risk_v2 = compute_risk_v2(
@@ -469,7 +516,7 @@ def run() -> None:
                     )
                     decision_v2 = por_v2_decision(risk_v2=risk_v2, threshold=threshold)
                     effective_decision = decision_v2
-                if args.por_mode == "v2_1":
+                if args.por_mode in ("v2_1", "v2_2"):
                     risk_v2_1 = compute_risk_v2_1(
                         instability_v1=eval_result.instability_score,
                         agreement_risk=agreement_risk,
@@ -478,6 +525,16 @@ def run() -> None:
                     )
                     decision_v2_1 = por_v2_1_decision(risk_v2_1=risk_v2_1, threshold=threshold)
                     effective_decision = decision_v2_1
+                if args.por_mode == "v2_2":
+                    self_check_no_penalty = validated_self_check_no_penalty
+                    risk_v2_2, no_override_applied = compute_risk_v2_2(
+                        risk_v2_1=float(risk_v2_1),
+                        self_check_label=str(self_check_label),
+                        self_check_no_penalty=self_check_no_penalty,
+                    )
+                    self_check_no_override_applied = no_override_applied
+                    decision_v2_2 = por_v2_2_decision(risk_v2_2=risk_v2_2, threshold=threshold)
+                    effective_decision = decision_v2_2
                 silence_flag = effective_decision == "SILENCE"
                 final_output = "" if silence_flag else por_candidate
                 correctness_label = "wrong" if silence_flag else ("correct" if candidate_correct else "wrong")
@@ -510,6 +567,10 @@ def run() -> None:
                     "contradiction_risk": contradiction_risk,
                     "risk_v2_1": risk_v2_1,
                     "decision_v2_1": decision_v2_1,
+                    "self_check_no_penalty": self_check_no_penalty,
+                    "self_check_no_override_applied": self_check_no_override_applied,
+                    "risk_v2_2": risk_v2_2,
+                    "decision_v2_2": decision_v2_2,
                     "effective_decision": effective_decision,
                     "por_decision": eval_result.por_decision,
                     "final_output": final_output,
@@ -568,6 +629,7 @@ def run() -> None:
             "baseline_temperature": args.baseline_temperature,
             "por_temperature": args.por_temperature,
             "por_mode": args.por_mode,
+            "self_check_no_penalty": validated_self_check_no_penalty,
             "experimental_short_regen_enabled": False,
         },
         "baseline": asdict(baseline_metrics),

--- a/tests/test_simpleqa_benchmark_harness.py
+++ b/tests/test_simpleqa_benchmark_harness.py
@@ -1,7 +1,7 @@
 from benchmarks.simpleqa.run_simpleqa_por import _parse_args
 from benchmarks.simpleqa.metrics import compute_threshold_metrics
 from benchmarks.simpleqa.por_adapter import evaluate_por_gate
-from benchmarks.simpleqa.run_simpleqa_por import validate_por_samples
+from benchmarks.simpleqa.run_simpleqa_por import validate_por_samples, validate_self_check_no_penalty
 
 
 def test_validate_por_samples_rejects_lt_2() -> None:
@@ -11,6 +11,15 @@ def test_validate_por_samples_rejects_lt_2() -> None:
         assert ">= 2" in str(exc)
     else:
         raise AssertionError("Expected ValueError for por_samples < 2")
+
+
+def test_validate_self_check_no_penalty_rejects_negative() -> None:
+    try:
+        validate_self_check_no_penalty(-0.1)
+    except ValueError as exc:
+        assert "must be >= 0" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for negative self_check_no_penalty")
 
 
 def test_threshold_metrics_preserve_precision_buckets() -> None:
@@ -63,6 +72,7 @@ def test_por_mode_default_and_choices(monkeypatch) -> None:
     )
     args = _parse_args()
     assert args.por_mode == "v1"
+    assert args.self_check_no_penalty == 0.30
 
     monkeypatch.setattr(
         "sys.argv",
@@ -93,3 +103,21 @@ def test_por_mode_default_and_choices(monkeypatch) -> None:
     )
     args_v2_1 = _parse_args()
     assert args_v2_1.por_mode == "v2_1"
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "run_simpleqa_por.py",
+            "--dataset-path",
+            "dummy.jsonl",
+            "--model",
+            "gpt-4o-mini",
+            "--por-mode",
+            "v2_2",
+            "--self-check-no-penalty",
+            "0.35",
+        ],
+    )
+    args_v2_2 = _parse_args()
+    assert args_v2_2.por_mode == "v2_2"
+    assert args_v2_2.self_check_no_penalty == 0.35

--- a/tests/test_simpleqa_por_v2.py
+++ b/tests/test_simpleqa_por_v2.py
@@ -5,6 +5,8 @@ from benchmarks.simpleqa.por_v2 import (
     PoRV2Weights,
     compute_risk_v2,
     compute_risk_v2_1,
+    compute_risk_v2_2,
+    por_v2_2_decision,
     self_check_label_to_risk,
 )
 from benchmarks.simpleqa.semantic_agreement import semantic_agreement_score
@@ -63,3 +65,37 @@ def test_compute_risk_v2_1_weighted_sum() -> None:
         ),
     )
     assert risk == pytest.approx(0.43)
+
+
+def test_compute_risk_v2_2_applies_no_penalty() -> None:
+    risk, applied = compute_risk_v2_2(
+        risk_v2_1=0.41,
+        self_check_label="NO",
+        self_check_no_penalty=0.30,
+    )
+    assert risk == pytest.approx(0.71)
+    assert applied is True
+
+
+def test_compute_risk_v2_2_no_penalty_when_not_no() -> None:
+    risk, applied = compute_risk_v2_2(
+        risk_v2_1=0.41,
+        self_check_label="YES",
+        self_check_no_penalty=0.30,
+    )
+    assert risk == pytest.approx(0.41)
+    assert applied is False
+
+
+def test_por_v2_2_decision_thresholding() -> None:
+    assert por_v2_2_decision(risk_v2_2=0.40, threshold=0.42) == "PROCEED"
+    assert por_v2_2_decision(risk_v2_2=0.43, threshold=0.42) == "SILENCE"
+
+
+def test_compute_risk_v2_2_rejects_negative_penalty() -> None:
+    with pytest.raises(ValueError, match="must be >= 0"):
+        compute_risk_v2_2(
+            risk_v2_1=0.41,
+            self_check_label="NO",
+            self_check_no_penalty=-0.1,
+        )


### PR DESCRIPTION
### Motivation

- Introduce an experimental PoR mode that treats a model-internal rejection (`self_check = NO`) as a stronger release-control signal by applying an additive risk penalty. 
- Expose the penalty as a configurable CLI parameter so experiments can tune the override behavior without changing core PoR primitives.

### Description

- Add `compute_risk_v2_2` and `por_v2_2_decision` to `benchmarks/simpleqa/por_v2.py`, including input validation that rejects negative penalty values and returning whether the override was applied. 
- Wire the new mode into the runner by adding `--por-mode v2_2` and a new `--self-check-no-penalty` CLI flag with validation via `validate_self_check_no_penalty`, and propagate the parameter into `run_simpleqa_por.py` workflow and output payload. 
- Extend CSV/row schema and README to include `self_check_no_penalty`, `self_check_no_override_applied`, `risk_v2_2`, and `decision_v2_2`, and make `v2_2` participate in the per-threshold evaluation flow. 
- Update tests to cover the new CLI default/choices and to unit-test `compute_risk_v2_2`, `por_v2_2_decision`, and `validate_self_check_no_penalty` behaviors.

### Testing

- Ran unit tests in `tests/test_simpleqa_por_v2.py` which include `test_compute_risk_v2_2_*` and `test_por_v2_2_decision`, and they passed. 
- Ran unit tests in `tests/test_simpleqa_benchmark_harness.py` which include `test_validate_self_check_no_penalty_rejects_negative` and CLI parsing checks for `--self-check-no-penalty`, and they passed. 
- Existing PoR-related tests such as `test_por_gate_uses_multi_sample_drift` and threshold metric tests were executed and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9206ebdec8326a164d749baf395a5)