### PR TITLE
docs: add SimpleQA PoR v2.2 prototype benchmark documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ curl -s http://127.0.0.1:8000/por/complete \
 - Tracked run scales: 35 / 100 / 300 / 1000 tasks
 - Additional visuals and summaries: `reports/README.md`, `docs/`
 
+### SimpleQA-style benchmark note (prototype, PoR v2.2)
+- Local harder subset: 25 examples (`gpt-4o-mini`).
+- Baseline correctness in that run: 96% (24/25).
+- PoR v2.2 accepted-output precision in that run: 100% (24/24 accepted), with `accepted_error_rate=0.0`.
+- Silence tradeoff: 4% (1/25), including one observed wrong answer case blocked by silencing.
+- This is a prototype benchmark observation on a local subset; broader validation on larger/harder sets is still required.
+
 ## Quick public links
 - Repository root: `./`
 - README: `README.md`

--- a/benchmarks/simpleqa/README.md
+++ b/benchmarks/simpleqa/README.md
@@ -184,3 +184,36 @@ PoR is beneficial when:
 
 - `accepted_error_rate` decreases materially relative to baseline,
 - while `silence_rate` stays within an interpretable operational range.
+
+## Observed v2.2 prototype result (local harder subset, 25 examples)
+
+On one local SimpleQA-style harder subset run (`n=25`) using:
+
+- model: `gpt-4o-mini`
+- mode: `v2_2`
+- `baseline_temperature=0.0`
+- `por_temperature=0.4`
+- `por_samples=3`
+- `separate_por_call=true`
+- `self_check_no_penalty=0.30`
+- thresholds: `0.35`, `0.39`, `0.42`, `0.43`
+
+all tested thresholds produced the same observed outcome:
+
+- `total_examples=25`
+- `answered_count=24`
+- `silence_count=1` (`silence_rate=0.04`)
+- `accepted_correct_count=24`
+- `accepted_wrong_count=0`
+- `accepted_precision=1.0` on accepted outputs
+- `accepted_error_rate=0.0`
+- `false_silence_count=0` (`false_silence_rate=0.0`)
+
+Behavioral note from this run: a previously observed wrong answer case (`"The capital of Kazakhstan is Nur-Sultan."`) was silenced in `v2_2` with:
+
+- `self_check_label=NO`
+- `self_check_no_override_applied=True`
+- `risk_v2_2=0.85`
+- `decision_v2_2=SILENCE`
+
+This is a prototype benchmark result on a local subset, not a universal proof. It indicates that in this run, `v2_2` blocked the observed confidently wrong answer with a `4%` silence tradeoff.

--- a/docs/simpleqa_v2_2_note.md
+++ b/docs/simpleqa_v2_2_note.md
@@ -1,0 +1,44 @@
+# SimpleQA v2.2 Prototype Benchmark Note
+
+## Setup (observed run)
+
+- Dataset: local SimpleQA-style harder subset
+- Size: 25 examples
+- Model: `gpt-4o-mini`
+- Mode: PoR `v2_2`
+- Parameters:
+  - `baseline_temperature=0.0`
+  - `por_temperature=0.4`
+  - `por_samples=3`
+  - `separate_por_call=true`
+  - `self_check_no_penalty=0.30`
+- Thresholds tested: `0.35`, `0.39`, `0.42`, `0.43` (same observed outcome at each)
+
+## Observed metrics
+
+- `total_examples=25`
+- `answered_count=24`
+- `silence_count=1`
+- `answer_rate=0.96`
+- `silence_rate=0.04`
+- `accepted_correct_count=24`
+- `accepted_wrong_count=0`
+- `accepted_precision=1.0`
+- `accepted_error_rate=0.0`
+- `false_silence_count=0`
+- `false_silence_rate=0.0`
+
+## Behavioral observation
+
+In this run, a known wrong answer case (`"The capital of Kazakhstan is Nur-Sultan."`) was silenced under v2.2 with:
+
+- `self_check_label=NO`
+- `self_check_no_override_applied=True`
+- `risk_v2_2=0.85`
+- `decision_v2_2=SILENCE`
+
+## Interpretation and caveat
+
+Within this local 25-example subset, v2.2 is the first mode in this sequence that blocked the observed confidently wrong answer while keeping accepted-output precision at 100%, with a 4% silence rate.
+
+This is a prototype benchmark result, not a universal guarantee. Further validation is needed on larger and harder datasets.


### PR DESCRIPTION
### Motivation

- Surface a recent local SimpleQA-style benchmark observation for PoR `v2_2` so readers can audit the run and its caveats.
- Keep the record concise and conservative, documenting exact observed metrics without changing benchmark logic or claims.

### Description

- Added an `Observed v2.2 prototype result` section to `benchmarks/simpleqa/README.md` documenting the run setup, thresholds, per-threshold parity, metrics, and the behavioral note about the silenced wrong answer. 
- Added a short results note in the project `README.md` under a `SimpleQA-style benchmark note (prototype, PoR v2.2)` block summarizing the 25-example run, baseline 96% correctness, 100% accepted-output precision (24/24), and 4% silence tradeoff.
- Created `docs/simpleqa_v2_2_note.md` containing the run setup, observed metrics, the behavioral observation (the silenced Kazakhstan example), interpretation, and explicit caveats that this is a prototype local-subset result.
- No benchmark code, thresholds, evaluation logic, schemas, or core PoR primitives were changed as part of this update; this is documentation-only.

### Testing

- Repository diff/format checks ran and reported no issues after the edits. 
- Confirmed the three documentation files updated or added: `README.md`, `benchmarks/simpleqa/README.md`, and `docs/simpleqa_v2_2_note.md`.
- No automated unit or benchmark tests were modified or executed by these documentation changes; code behavior remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92a7f3e8c8326abd2072e53450617)