### PR TITLE
simpleqa: improve answer normalization, add clean dataset and error-audit artifacts with tests

### DIFF
--- a/benchmarks/simpleqa/README.md
+++ b/benchmarks/simpleqa/README.md
@@ -32,6 +32,8 @@ This harness preserves repository layer boundaries:
 
 This benchmark evaluates **release-control tradeoffs**, not model-generation improvement.
 
+Correctness matching and normalization in this folder are **benchmark-evaluation logic only**. They are not part of the PoR runtime primitive claim.
+
 ## Files
 
 - `benchmarks/simpleqa/run_simpleqa_por.py` — end-to-end runner
@@ -56,11 +58,17 @@ Defaults:
 - `answers`
 - `id`
 
+Clean benchmark set included for reproducibility:
+
+- `data/simpleqa_clean_100.jsonl` (100 curated, stable factual QA examples)
+
+This clean set is intended to reduce ambiguous/time-sensitive cases so release-control behavior is easier to interpret.
+
 ## Run
 
 ```bash
 python benchmarks/simpleqa/run_simpleqa_por.py \
-  --dataset-path /path/to/simpleqa.jsonl \
+  --dataset-path data/simpleqa_clean_100.jsonl \
   --provider openai \
   --model gpt-4o-mini \
   --por-mode v1 \
@@ -70,6 +78,21 @@ python benchmarks/simpleqa/run_simpleqa_por.py \
   --baseline-temperature 0.0 \
   --por-temperature 0.4 \
   --output-dir results/simpleqa
+```
+
+Exploratory threshold sweep example (analysis-only, not a recommended operating policy):
+
+```bash
+python benchmarks/simpleqa/run_simpleqa_por.py \
+  --dataset-path data/simpleqa_clean_100.jsonl \
+  --provider openai \
+  --model gpt-4o-mini \
+  --por-mode v2_2 \
+  --thresholds 0.10 0.20 0.30 0.40 0.50 0.60 0.70 0.80 \
+  --por-samples 3 \
+  --baseline-temperature 0.0 \
+  --por-temperature 0.4 \
+  --output-dir results/simpleqa_exploratory
 ```
 
 Environment variables for OpenAI-compatible adapter:
@@ -113,6 +136,16 @@ The run writes:
    - `results/simpleqa/simpleqa_threshold_summary.csv`
 4. Plot:
    - `results/simpleqa/simpleqa_threshold_tradeoff.png`
+5. Error-audit CSV (one row per example-threshold):
+   - `results/simpleqa/simpleqa_error_audit.csv`
+6. Deduped problem-case CSV (one representative row per example id for accepted-wrong or false-silence):
+   - `results/simpleqa/simpleqa_problem_cases_deduped.csv`
+
+Quick inspection command (PowerShell):
+
+```powershell
+Import-Csv results/simpleqa/simpleqa_problem_cases_deduped.csv | Format-Table example_id,silence_flag,effective_decision,correctness_label,final_answer_or_effective_answer -AutoSize
+```
 
 Per-example rows include:
 
@@ -173,6 +206,11 @@ Default correctness is deterministic normalized exact-match:
 - whitespace squashed
 
 No hidden judge heuristics are used by default.
+
+Normalization is still conservative/deterministic and now additionally covers common benchmark forms like:
+
+- unicode sub/superscripts (`H₂O` -> `H2O`, `CO₂` -> `CO2`)
+- degree-Celsius formatting variants (`100°C`, `100 °C`, `100 degrees Celsius`)
 
 ## Threshold precision
 

--- a/benchmarks/simpleqa/metrics.py
+++ b/benchmarks/simpleqa/metrics.py
@@ -1,31 +1,83 @@
 from __future__ import annotations
 
 import re
-import string
+import unicodedata
 from dataclasses import dataclass
 from typing import Any
+
+_SUBSUPER_TRANSLATION = str.maketrans(
+    {
+        "₀": "0",
+        "₁": "1",
+        "₂": "2",
+        "₃": "3",
+        "₄": "4",
+        "₅": "5",
+        "₆": "6",
+        "₇": "7",
+        "₈": "8",
+        "₉": "9",
+        "⁰": "0",
+        "¹": "1",
+        "²": "2",
+        "³": "3",
+        "⁴": "4",
+        "⁵": "5",
+        "⁶": "6",
+        "⁷": "7",
+        "⁸": "8",
+        "⁹": "9",
+        "⁺": "+",
+        "⁻": "-",
+        "₊": "+",
+        "₋": "-",
+    }
+)
+
+_DEGREE_CELSIUS_PATTERN = re.compile(
+    r"(-?\d+(?:\.\d+)?)\s*(?:°\s*c|degrees?\s*celsius|degree\s*celsius|celsius)\b",
+    flags=re.IGNORECASE,
+)
+_NON_ALNUM_PATTERN = re.compile(r"[^a-z0-9]+")
+_MULTISPACE_PATTERN = re.compile(r"\s+")
+_TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
 
 
 def normalize_text(text: str) -> str:
     """Deterministic normalization used for default SimpleQA exact matching."""
-    lowered = text.lower().strip()
-    no_punct = lowered.translate(str.maketrans("", "", string.punctuation))
-    squashed = re.sub(r"\s+", " ", no_punct)
-    return squashed
+    normalized = unicodedata.normalize("NFKC", text).translate(_SUBSUPER_TRANSLATION).lower()
+    normalized = _DEGREE_CELSIUS_PATTERN.sub(r"\1 celsius", normalized)
+    normalized = _NON_ALNUM_PATTERN.sub(" ", normalized)
+    return _MULTISPACE_PATTERN.sub(" ", normalized).strip()
+
+
+def _token_set(text: str) -> set[str]:
+    return set(_TOKEN_PATTERN.findall(text))
+
+
+def _is_short_token_reference(norm_ref: str) -> bool:
+    return bool(re.fullmatch(r"[a-z0-9]{1,3}", norm_ref))
 
 
 def is_correct(answer: str, references: list[str]) -> bool:
     norm_answer = normalize_text(answer)
     if not norm_answer:
         return False
+    answer_tokens = _token_set(norm_answer)
 
     for ref in references:
         norm_ref = normalize_text(ref)
         if not norm_ref:
             continue
+        if ("celsius" in norm_ref) != ("celsius" in norm_answer):
+            continue
 
         if norm_answer == norm_ref:
             return True
+        if _is_short_token_reference(norm_ref):
+            if norm_ref in answer_tokens:
+                return True
+            continue
         if norm_ref in norm_answer:
             return True
         if norm_answer in norm_ref:

--- a/benchmarks/simpleqa/run_simpleqa_por.py
+++ b/benchmarks/simpleqa/run_simpleqa_por.py
@@ -18,6 +18,7 @@ from benchmarks.simpleqa.metrics import (
     compute_baseline_metrics,
     compute_threshold_metrics,
     is_correct,
+    normalize_text,
 )
 from benchmarks.simpleqa.contradiction_check import parse_contradiction_response
 from benchmarks.simpleqa.model_adapter import ModelAdapterError, build_model_adapter
@@ -113,6 +114,118 @@ def _to_csv_value(v: Any) -> str:
     return str(v)
 
 
+def _normalized_references(references: Any) -> list[str]:
+    if not isinstance(references, list):
+        return []
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for ref in references:
+        norm_ref = normalize_text(str(ref))
+        if norm_ref and norm_ref not in seen:
+            seen.add(norm_ref)
+            normalized.append(norm_ref)
+    return normalized
+
+
+def _effective_answer_for_problem_case(row: dict[str, Any]) -> str:
+    final_output = str(row.get("final_output", "") or "").strip()
+    if final_output:
+        return final_output
+    primary_candidate = str(row.get("por_primary_candidate", "") or "").strip()
+    if primary_candidate:
+        return primary_candidate
+    return str(row.get("baseline_answer", "") or "").strip()
+
+
+def _build_error_audit_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    audit_rows: list[dict[str, Any]] = []
+    for row in rows:
+        if row.get("threshold_label") == "baseline":
+            continue
+        effective_answer = _effective_answer_for_problem_case(row)
+        audit_rows.append(
+            {
+                "example_id": row.get("example_id", ""),
+                "threshold": row.get("threshold", ""),
+                "question": row.get("question", ""),
+                "reference_answers": row.get("reference_answers", []),
+                "baseline_answer": row.get("baseline_answer", ""),
+                "primary_candidate": row.get("por_primary_candidate", ""),
+                "final_answer_or_effective_answer": effective_answer,
+                "normalized_reference_answers": _normalized_references(row.get("reference_answers", [])),
+                "normalized_final_answer": normalize_text(str(effective_answer)),
+                "correctness_label": row.get("correctness_label", ""),
+                "silence_flag": row.get("silence_flag", ""),
+                "false_silence_flag": row.get("false_silence_flag", ""),
+                "self_check_label": row.get("self_check_label", ""),
+                "contradiction_label": row.get("contradiction_label", ""),
+                "semantic_agreement_score": row.get("semantic_agreement_score", ""),
+                "drift": row.get("drift", ""),
+                "coherence": row.get("coherence", ""),
+                "instability_v1": row.get("instability_score", ""),
+                "risk_v2": row.get("risk_v2", ""),
+                "risk_v2_1": row.get("risk_v2_1", ""),
+                "risk_v2_2": row.get("risk_v2_2", ""),
+                "self_check_no_override_applied": row.get("self_check_no_override_applied", ""),
+                "decision_v1": row.get("por_decision", ""),
+                "decision_v2": row.get("decision_v2", ""),
+                "decision_v2_1": row.get("decision_v2_1", ""),
+                "decision_v2_2": row.get("decision_v2_2", ""),
+                "effective_decision": row.get("effective_decision", ""),
+            }
+        )
+    return audit_rows
+
+
+def _build_problem_cases_deduped_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    problem_rows = [
+        row
+        for row in rows
+        if row.get("threshold_label") not in {"baseline", "por_candidate_error", "self_check_error", "contradiction_check_error"}
+        and (
+            row.get("false_silence_flag", False)
+            or (
+                row.get("effective_decision") == "PROCEED"
+                and row.get("correctness_label") == "wrong"
+            )
+        )
+    ]
+    problem_rows.sort(key=lambda r: (str(r.get("example_id", "")), str(r.get("threshold", ""))))
+
+    deduped: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for row in problem_rows:
+        example_id = str(row.get("example_id", ""))
+        if example_id in seen_ids:
+            continue
+        seen_ids.add(example_id)
+        deduped.append(
+            {
+                "example_id": example_id,
+                "question": row.get("question", ""),
+                "reference_answers": row.get("reference_answers", []),
+                "baseline_answer": row.get("baseline_answer", ""),
+                "primary_candidate": row.get("por_primary_candidate", ""),
+                "final_answer_or_effective_answer": _effective_answer_for_problem_case(row),
+                "correctness_label": row.get("correctness_label", ""),
+                "silence_flag": row.get("silence_flag", ""),
+                "false_silence_flag": row.get("false_silence_flag", ""),
+                "self_check_label": row.get("self_check_label", ""),
+                "risk_v2_2": row.get("risk_v2_2", ""),
+                "effective_decision": row.get("effective_decision", ""),
+            }
+        )
+    return deduped
+
+
+def _write_csv(path: Path, fieldnames: list[str], rows: list[dict[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({k: _to_csv_value(v) for k, v in row.items()})
+
+
 def run() -> None:
     args = _parse_args()
     try:
@@ -126,6 +239,8 @@ def run() -> None:
     per_example_csv = out_dir / "simpleqa_por_results.csv"
     metrics_json = out_dir / "simpleqa_por_metrics.json"
     threshold_summary_csv = out_dir / "simpleqa_threshold_summary.csv"
+    error_audit_csv = out_dir / "simpleqa_error_audit.csv"
+    deduped_problem_cases_csv = out_dir / "simpleqa_problem_cases_deduped.csv"
     tradeoff_plot = out_dir / "simpleqa_threshold_tradeoff.png"
 
     examples = load_simpleqa_dataset(
@@ -585,6 +700,60 @@ def run() -> None:
 
             csv_file.flush()
 
+    error_audit_rows = _build_error_audit_rows(rows)
+    _write_csv(
+        error_audit_csv,
+        fieldnames=[
+            "example_id",
+            "threshold",
+            "question",
+            "reference_answers",
+            "baseline_answer",
+            "primary_candidate",
+            "final_answer_or_effective_answer",
+            "normalized_reference_answers",
+            "normalized_final_answer",
+            "correctness_label",
+            "silence_flag",
+            "false_silence_flag",
+            "self_check_label",
+            "contradiction_label",
+            "semantic_agreement_score",
+            "drift",
+            "coherence",
+            "instability_v1",
+            "risk_v2",
+            "risk_v2_1",
+            "risk_v2_2",
+            "self_check_no_override_applied",
+            "decision_v1",
+            "decision_v2",
+            "decision_v2_1",
+            "decision_v2_2",
+            "effective_decision",
+        ],
+        rows=error_audit_rows,
+    )
+    deduped_problem_rows = _build_problem_cases_deduped_rows(rows)
+    _write_csv(
+        deduped_problem_cases_csv,
+        fieldnames=[
+            "example_id",
+            "question",
+            "reference_answers",
+            "baseline_answer",
+            "primary_candidate",
+            "final_answer_or_effective_answer",
+            "correctness_label",
+            "silence_flag",
+            "false_silence_flag",
+            "self_check_label",
+            "risk_v2_2",
+            "effective_decision",
+        ],
+        rows=deduped_problem_rows,
+    )
+
     baseline_metrics = compute_baseline_metrics(rows)
     threshold_metrics = [compute_threshold_metrics(rows, t) for t in args.thresholds]
 
@@ -636,6 +805,8 @@ def run() -> None:
         "thresholds": [asdict(tm) for tm in threshold_metrics],
         "artifacts": {
             "per_example_csv": str(per_example_csv),
+            "error_audit_csv": str(error_audit_csv),
+            "problem_cases_deduped_csv": str(deduped_problem_cases_csv),
             "threshold_summary_csv": str(threshold_summary_csv),
             "tradeoff_plot": str(plot_path),
         },
@@ -645,6 +816,8 @@ def run() -> None:
 
     print("Done.")
     print(f"- {per_example_csv}")
+    print(f"- {error_audit_csv}")
+    print(f"- {deduped_problem_cases_csv}")
     print(f"- {threshold_summary_csv}")
     print(f"- {metrics_json}")
     print(f"- {plot_path}")

--- a/data/simpleqa_clean_100.jsonl
+++ b/data/simpleqa_clean_100.jsonl
@@ -1,0 +1,100 @@
+{"id": "q001", "question": "What is the capital of France?", "answer": "Paris"}
+{"id": "q002", "question": "What is the capital of Japan?", "answer": "Tokyo"}
+{"id": "q003", "question": "What is the capital of Italy?", "answer": "Rome"}
+{"id": "q004", "question": "What is the capital of Spain?", "answer": "Madrid"}
+{"id": "q005", "question": "What is the capital of Germany?", "answer": "Berlin"}
+{"id": "q006", "question": "What is the capital of Canada?", "answer": "Ottawa"}
+{"id": "q007", "question": "What is the capital of Australia?", "answer": "Canberra"}
+{"id": "q008", "question": "What is the capital of Brazil?", "answer": "Brasília"}
+{"id": "q009", "question": "What is the capital of India?", "answer": "New Delhi"}
+{"id": "q010", "question": "What is the capital of Egypt?", "answer": "Cairo"}
+{"id": "q011", "question": "What is the capital of Argentina?", "answer": "Buenos Aires"}
+{"id": "q012", "question": "What is the capital of Mexico?", "answer": "Mexico City"}
+{"id": "q013", "question": "What is the capital of South Korea?", "answer": "Seoul"}
+{"id": "q014", "question": "What is the capital of China?", "answer": "Beijing"}
+{"id": "q015", "question": "What is the capital of Russia?", "answer": "Moscow"}
+{"id": "q016", "question": "What is the capital of Portugal?", "answer": "Lisbon"}
+{"id": "q017", "question": "What is the capital of Greece?", "answer": "Athens"}
+{"id": "q018", "question": "What is the capital of Norway?", "answer": "Oslo"}
+{"id": "q019", "question": "What is the capital of Sweden?", "answer": "Stockholm"}
+{"id": "q020", "question": "What is the capital of Finland?", "answer": "Helsinki"}
+{"id": "q021", "question": "What is the chemical formula for water?", "answer": "H2O"}
+{"id": "q022", "question": "What is the chemical formula for carbon dioxide?", "answer": "CO2"}
+{"id": "q023", "question": "What is the chemical symbol for gold?", "answer": "Au"}
+{"id": "q024", "question": "What is the chemical symbol for sodium?", "answer": "Na"}
+{"id": "q025", "question": "What is the chemical symbol for iron?", "answer": "Fe"}
+{"id": "q026", "question": "What is the chemical symbol for silver?", "answer": "Ag"}
+{"id": "q027", "question": "What is the chemical symbol for potassium?", "answer": "K"}
+{"id": "q028", "question": "What is the chemical symbol for helium?", "answer": "He"}
+{"id": "q029", "question": "What is the chemical symbol for oxygen?", "answer": "O"}
+{"id": "q030", "question": "What is the chemical symbol for nitrogen?", "answer": "N"}
+{"id": "q031", "question": "At standard atmospheric pressure, water boils at what temperature in Celsius?", "answer": "100°C"}
+{"id": "q032", "question": "At standard atmospheric pressure, water freezes at what temperature in Celsius?", "answer": "0°C"}
+{"id": "q033", "question": "How many days are in a leap year?", "answer": "366"}
+{"id": "q034", "question": "How many continents are there on Earth?", "answer": "7"}
+{"id": "q035", "question": "How many hours are in a day?", "answer": "24"}
+{"id": "q036", "question": "How many minutes are in an hour?", "answer": "60"}
+{"id": "q037", "question": "How many seconds are in a minute?", "answer": "60"}
+{"id": "q038", "question": "How many sides does a triangle have?", "answer": "3"}
+{"id": "q039", "question": "How many sides does a hexagon have?", "answer": "6"}
+{"id": "q040", "question": "How many centimeters are in a meter?", "answer": "100"}
+{"id": "q041", "question": "Who wrote the play Hamlet?", "answer": "William Shakespeare"}
+{"id": "q042", "question": "Who wrote Pride and Prejudice?", "answer": "Jane Austen"}
+{"id": "q043", "question": "Who wrote 1984?", "answer": "George Orwell"}
+{"id": "q044", "question": "Who wrote The Odyssey?", "answer": "Homer"}
+{"id": "q045", "question": "Who wrote Don Quixote?", "answer": "Miguel de Cervantes"}
+{"id": "q046", "question": "Who painted the Mona Lisa?", "answer": "Leonardo da Vinci"}
+{"id": "q047", "question": "Who composed The Four Seasons?", "answer": "Antonio Vivaldi"}
+{"id": "q048", "question": "Who composed the Moonlight Sonata?", "answer": "Ludwig van Beethoven"}
+{"id": "q049", "question": "Who developed the theory of relativity?", "answer": "Albert Einstein"}
+{"id": "q050", "question": "Who proposed the three laws of motion?", "answer": "Isaac Newton"}
+{"id": "q051", "question": "What planet is known as the Red Planet?", "answer": "Mars"}
+{"id": "q052", "question": "What is the largest planet in the Solar System?", "answer": "Jupiter"}
+{"id": "q053", "question": "What is the third planet from the Sun?", "answer": "Earth"}
+{"id": "q054", "question": "What is the fifth planet from the Sun?", "answer": "Jupiter"}
+{"id": "q055", "question": "What galaxy contains our Solar System?", "answer": "Milky Way"}
+{"id": "q056", "question": "What star is at the center of the Solar System?", "answer": "Sun"}
+{"id": "q057", "question": "What force keeps planets in orbit around the Sun?", "answer": "Gravity"}
+{"id": "q058", "question": "What gas do humans primarily inhale from air for respiration?", "answer": "Oxygen"}
+{"id": "q059", "question": "What gas do humans primarily exhale as a metabolic waste product?", "answer": "Carbon dioxide"}
+{"id": "q060", "question": "What part of the cell contains most genetic material in eukaryotes?", "answer": "Nucleus"}
+{"id": "q061", "question": "What is the hardest natural substance commonly cited on the Mohs scale?", "answer": "Diamond"}
+{"id": "q062", "question": "What is the largest ocean on Earth?", "answer": "Pacific Ocean"}
+{"id": "q063", "question": "What ocean lies between Africa and Australia?", "answer": "Indian Ocean"}
+{"id": "q064", "question": "On which continent is the Sahara Desert located?", "answer": "Africa"}
+{"id": "q065", "question": "Through which continent does the Amazon River primarily flow?", "answer": "South America"}
+{"id": "q066", "question": "Mount Everest is in which mountain range?", "answer": "Himalayas"}
+{"id": "q067", "question": "Which U.S. state is known as the Aloha State?", "answer": "Hawaii"}
+{"id": "q068", "question": "Which country has the maple leaf on its national flag?", "answer": "Canada"}
+{"id": "q069", "question": "Which country is famous for the city of Venice?", "answer": "Italy"}
+{"id": "q070", "question": "Which country is famous for the city of Kyoto?", "answer": "Japan"}
+{"id": "q071", "question": "In which year did World War II end?", "answer": "1945"}
+{"id": "q072", "question": "In which year did World War I begin?", "answer": "1914"}
+{"id": "q073", "question": "In which year did the United States Declaration of Independence occur?", "answer": "1776"}
+{"id": "q074", "question": "In which year did the Berlin Wall fall?", "answer": "1989"}
+{"id": "q075", "question": "In which year did the first human land on the Moon?", "answer": "1969"}
+{"id": "q076", "question": "Who was the first person to walk on the Moon?", "answer": "Neil Armstrong"}
+{"id": "q077", "question": "Who was the first President of the United States?", "answer": "George Washington"}
+{"id": "q078", "question": "Who was known as the Maid of Orléans?", "answer": "Joan of Arc"}
+{"id": "q079", "question": "Which empire built Machu Picchu?", "answer": "Inca"}
+{"id": "q080", "question": "What ancient civilization built the pyramids of Giza?", "answer": "Ancient Egyptians"}
+{"id": "q081", "question": "What is the SI unit of electric current?", "answers": ["ampere", "A"]}
+{"id": "q082", "question": "What is the SI unit of force?", "answer": "newton"}
+{"id": "q083", "question": "What is the SI unit of energy?", "answer": "joule"}
+{"id": "q084", "question": "What is the SI unit of power?", "answer": "watt"}
+{"id": "q085", "question": "What is the SI unit of frequency?", "answers": ["hertz", "Hz"]}
+{"id": "q086", "question": "What is the SI unit of resistance?", "answer": "ohm"}
+{"id": "q087", "question": "What is the SI unit of temperature?", "answer": "kelvin"}
+{"id": "q088", "question": "What is the SI unit of luminous intensity?", "answer": "candela"}
+{"id": "q089", "question": "What is the SI unit of amount of substance?", "answer": "mole"}
+{"id": "q090", "question": "What is the SI unit of time?", "answer": "second"}
+{"id": "q091", "question": "What is 2 + 2?", "answer": "4"}
+{"id": "q092", "question": "What is 10 × 10?", "answer": "100"}
+{"id": "q093", "question": "What is the square root of 81?", "answer": "9"}
+{"id": "q094", "question": "What is 15 divided by 3?", "answer": "5"}
+{"id": "q095", "question": "What is 7 × 8?", "answer": "56"}
+{"id": "q096", "question": "What is the Roman numeral for 5?", "answer": "V"}
+{"id": "q097", "question": "What is the Roman numeral for 10?", "answer": "X"}
+{"id": "q098", "question": "What is the binary representation of decimal 2?", "answer": "10"}
+{"id": "q099", "question": "What is the hexadecimal representation of decimal 15?", "answer": "F"}
+{"id": "q100", "question": "How many letters are in the English alphabet?", "answer": "26"}

--- a/tests/test_simpleqa_eval_hardening.py
+++ b/tests/test_simpleqa_eval_hardening.py
@@ -1,0 +1,188 @@
+from pathlib import Path
+
+from benchmarks.simpleqa.dataset_loader import load_simpleqa_dataset
+from benchmarks.simpleqa.metrics import is_correct
+from benchmarks.simpleqa.run_simpleqa_por import (
+    _build_error_audit_rows,
+    _build_problem_cases_deduped_rows,
+)
+
+
+def test_is_correct_supports_formula_and_unit_normalization() -> None:
+    assert is_correct("Water is H₂O.", ["H2O"])
+    assert is_correct("carbon dioxide is CO₂", ["CO2"])
+    assert is_correct("100 degrees Celsius", ["100°C"])
+    assert is_correct("0 degrees Celsius", ["0°C"])
+    assert is_correct("The symbol is Au.", ["Au"])
+    assert is_correct("The capital of France is Paris.", ["Paris"])
+
+
+def test_is_correct_does_not_overmatch_short_symbol_inside_word() -> None:
+    assert not is_correct("August is often hot.", ["Au"])
+
+
+def test_is_correct_requires_celsius_unit_not_just_number() -> None:
+    assert not is_correct("100", ["100°C"])
+
+
+def test_is_correct_does_not_map_co2_to_carbon_monoxide() -> None:
+    assert not is_correct("carbon monoxide", ["CO2"])
+
+
+def test_is_correct_single_letter_symbol_does_not_expand_to_word() -> None:
+    # Conservative benchmark behavior: symbol references require token-level symbol match.
+    assert not is_correct("oxygen", ["O"])
+
+
+def test_error_audit_rows_include_expected_fields() -> None:
+    rows = [
+        {
+            "example_id": "q001",
+            "threshold_label": "0.4",
+            "threshold": "0.4",
+            "question": "Boiling point of water in celsius?",
+            "reference_answers": ["100°C"],
+            "baseline_answer": "100°C",
+            "por_primary_candidate": "100 degrees Celsius",
+            "final_output": "100 degrees Celsius",
+            "correctness_label": "correct",
+            "silence_flag": False,
+            "false_silence_flag": False,
+            "self_check_label": "YES",
+            "contradiction_label": "NO_CONTRADICTION",
+            "semantic_agreement_score": 1.0,
+            "drift": 0.0,
+            "coherence": 1.0,
+            "instability_score": 0.0,
+            "risk_v2": 0.0,
+            "risk_v2_1": 0.0,
+            "risk_v2_2": 0.0,
+            "self_check_no_override_applied": False,
+            "por_decision": "PROCEED",
+            "decision_v2": "PROCEED",
+            "decision_v2_1": "PROCEED",
+            "decision_v2_2": "PROCEED",
+            "effective_decision": "PROCEED",
+        }
+    ]
+    audit_rows = _build_error_audit_rows(rows)
+    assert len(audit_rows) == 1
+    assert "normalized_reference_answers" in audit_rows[0]
+    assert "normalized_final_answer" in audit_rows[0]
+    assert audit_rows[0]["normalized_final_answer"] == "100 celsius"
+
+
+def test_error_audit_rows_use_effective_answer_fallback() -> None:
+    rows = [
+        {
+            "example_id": "q060",
+            "threshold_label": "0.42",
+            "threshold": "0.42",
+            "question": "Q",
+            "reference_answers": ["A"],
+            "baseline_answer": "baseline-ans",
+            "por_primary_candidate": "candidate-ans",
+            "final_output": "",
+            "correctness_label": "wrong",
+            "silence_flag": True,
+            "false_silence_flag": True,
+            "self_check_label": "NO",
+            "effective_decision": "SILENCE",
+        }
+    ]
+    audit_rows = _build_error_audit_rows(rows)
+    assert len(audit_rows) == 1
+    assert audit_rows[0]["final_answer_or_effective_answer"] == "candidate-ans"
+    assert audit_rows[0]["normalized_final_answer"] == "candidate ans"
+
+
+def test_problem_cases_dedupes_example_ids() -> None:
+    rows = [
+        {
+            "example_id": "q021",
+            "threshold_label": "0.35",
+            "threshold": "0.35",
+            "question": "Q",
+            "reference_answers": ["A"],
+            "baseline_answer": "B0",
+            "por_primary_candidate": "B",
+            "final_output": "B",
+            "correctness_label": "wrong",
+            "silence_flag": False,
+            "false_silence_flag": False,
+            "self_check_label": "YES",
+            "risk_v2_2": 0.2,
+            "effective_decision": "PROCEED",
+        },
+        {
+            "example_id": "q021",
+            "threshold_label": "0.43",
+            "threshold": "0.43",
+            "question": "Q",
+            "reference_answers": ["A"],
+            "baseline_answer": "B0",
+            "por_primary_candidate": "B",
+            "final_output": "B",
+            "correctness_label": "wrong",
+            "silence_flag": False,
+            "false_silence_flag": False,
+            "self_check_label": "YES",
+            "risk_v2_2": 0.2,
+            "effective_decision": "PROCEED",
+        },
+    ]
+    deduped_rows = _build_problem_cases_deduped_rows(rows)
+    assert len(deduped_rows) == 1
+    assert deduped_rows[0]["example_id"] == "q021"
+    assert deduped_rows[0]["primary_candidate"] == "B"
+
+
+def test_problem_cases_use_fallback_answer_fields_for_silence_rows() -> None:
+    rows = [
+        {
+            "example_id": "q060",
+            "threshold_label": "0.42",
+            "threshold": "0.42",
+            "question": "Q1",
+            "reference_answers": ["A1"],
+            "baseline_answer": "baseline-1",
+            "por_primary_candidate": "candidate-1",
+            "final_output": "",
+            "correctness_label": "wrong",
+            "silence_flag": True,
+            "false_silence_flag": True,
+            "self_check_label": "NO",
+            "risk_v2_2": 0.9,
+            "effective_decision": "SILENCE",
+        },
+        {
+            "example_id": "q061",
+            "threshold_label": "0.42",
+            "threshold": "0.42",
+            "question": "Q2",
+            "reference_answers": ["A2"],
+            "baseline_answer": "baseline-2",
+            "por_primary_candidate": "",
+            "final_output": "",
+            "correctness_label": "wrong",
+            "silence_flag": True,
+            "false_silence_flag": True,
+            "self_check_label": "NO",
+            "risk_v2_2": 0.9,
+            "effective_decision": "SILENCE",
+        },
+    ]
+    deduped_rows = _build_problem_cases_deduped_rows(rows)
+    assert len(deduped_rows) == 2
+    by_id = {row["example_id"]: row for row in deduped_rows}
+    assert by_id["q060"]["final_answer_or_effective_answer"] == "candidate-1"
+    assert by_id["q061"]["final_answer_or_effective_answer"] == "baseline-2"
+
+
+def test_clean_dataset_loads_with_expected_schema_and_size() -> None:
+    dataset_path = Path("data/simpleqa_clean_100.jsonl")
+    examples = load_simpleqa_dataset(dataset_path)
+    assert len(examples) == 100
+    assert examples[0].example_id
+    assert examples[0].question
+    assert examples[0].reference_answers


### PR DESCRIPTION
### Motivation

- Reduce brittle exact-match behavior by normalizing common benchmark forms like unicode subscripts/superscripts and Celsius variants.
- Provide a small reproducible clean dataset for stable SimpleQA runs and examples.
- Add per-run audit artifacts to simplify error analysis and surface problem cases (accepted-wrong / false-silence) for investigators.

### Description

- Enhanced normalization in `benchmarks/simpleqa/metrics.py` by adding `unicodedata` NFKC normalization, translation of sub/superscript digits and signs, and a `°C` / "degrees Celsius" normalization; added tokenization helpers and conservative short-token handling in `is_correct`.
- Added `data/simpleqa_clean_100.jsonl` as a curated 100-example SimpleQA dataset for reproducible runs and updated `README.md` to use it in examples and document new artifacts and exploratory commands.
- Extended `benchmarks/simpleqa/run_simpleqa_por.py` with `normalize_text` import and new helpers: `_normalized_references`, `_effective_answer_for_problem_case`, `_build_error_audit_rows`, `_build_problem_cases_deduped_rows`, and `_write_csv`, and wired these to produce `simpleqa_error_audit.csv` and `simpleqa_problem_cases_deduped.csv` and include them in the run `payload` and console output.
- Updated README to describe new output CSVs and added an exploratory threshold sweep example.

### Testing

- Added unit tests in `tests/test_simpleqa_eval_hardening.py` covering normalization behavior, matching conservatism for short tokens, error-audit row construction, deduplication, and loading the clean dataset.
- Ran the new tests with `pytest tests/test_simpleqa_eval_hardening.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b62fa978832690b7514f1d29ccda)