### PR TITLE
Benchmark eval: normalize number words & add q057 gravity alias

### DIFF
--- a/benchmarks/simpleqa/metrics.py
+++ b/benchmarks/simpleqa/metrics.py
@@ -41,6 +41,28 @@ _DEGREE_CELSIUS_PATTERN = re.compile(
 _NON_ALNUM_PATTERN = re.compile(r"[^a-z0-9]+")
 _MULTISPACE_PATTERN = re.compile(r"\s+")
 _TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
+_NUMBER_WORD_TO_DIGIT = {
+    "one": "1",
+    "two": "2",
+    "three": "3",
+    "four": "4",
+    "five": "5",
+    "six": "6",
+    "seven": "7",
+    "eight": "8",
+    "nine": "9",
+    "ten": "10",
+    "eleven": "11",
+    "twelve": "12",
+    "thirteen": "13",
+    "fourteen": "14",
+    "fifteen": "15",
+    "sixteen": "16",
+    "seventeen": "17",
+    "eighteen": "18",
+    "nineteen": "19",
+    "twenty": "20",
+}
 
 
 def normalize_text(text: str) -> str:
@@ -48,7 +70,11 @@ def normalize_text(text: str) -> str:
     normalized = unicodedata.normalize("NFKC", text).translate(_SUBSUPER_TRANSLATION).lower()
     normalized = _DEGREE_CELSIUS_PATTERN.sub(r"\1 celsius", normalized)
     normalized = _NON_ALNUM_PATTERN.sub(" ", normalized)
-    return _MULTISPACE_PATTERN.sub(" ", normalized).strip()
+    normalized = _MULTISPACE_PATTERN.sub(" ", normalized).strip()
+    if not normalized:
+        return normalized
+    tokens = [_NUMBER_WORD_TO_DIGIT.get(token, token) for token in normalized.split(" ")]
+    return " ".join(tokens)
 
 
 def _token_set(text: str) -> set[str]:

--- a/data/simpleqa_clean_100.jsonl
+++ b/data/simpleqa_clean_100.jsonl
@@ -54,7 +54,7 @@
 {"id": "q054", "question": "What is the fifth planet from the Sun?", "answer": "Jupiter"}
 {"id": "q055", "question": "What galaxy contains our Solar System?", "answer": "Milky Way"}
 {"id": "q056", "question": "What star is at the center of the Solar System?", "answer": "Sun"}
-{"id": "q057", "question": "What force keeps planets in orbit around the Sun?", "answer": "Gravity"}
+{"id": "q057", "question": "What force keeps planets in orbit around the Sun?", "answer": "Gravity", "answers": ["Gravity", "gravitational force"]}
 {"id": "q058", "question": "What gas do humans primarily inhale from air for respiration?", "answer": "Oxygen"}
 {"id": "q059", "question": "What gas do humans primarily exhale as a metabolic waste product?", "answer": "Carbon dioxide"}
 {"id": "q060", "question": "What part of the cell contains most genetic material in eukaryotes?", "answer": "Nucleus"}

--- a/tests/test_simpleqa_eval_hardening.py
+++ b/tests/test_simpleqa_eval_hardening.py
@@ -34,6 +34,16 @@ def test_is_correct_single_letter_symbol_does_not_expand_to_word() -> None:
     assert not is_correct("oxygen", ["O"])
 
 
+def test_is_correct_normalizes_number_words_for_short_numeric_references() -> None:
+    assert is_correct("There are seven continents on Earth.", ["7"])
+    assert is_correct("A triangle has three sides.", ["3"])
+    assert is_correct("A hexagon has six sides.", ["6"])
+
+
+def test_is_correct_number_word_normalization_is_not_overly_permissive() -> None:
+    assert not is_correct("There are seven continents on Earth.", ["8"])
+
+
 def test_error_audit_rows_include_expected_fields() -> None:
     rows = [
         {
@@ -186,3 +196,11 @@ def test_clean_dataset_loads_with_expected_schema_and_size() -> None:
     assert examples[0].example_id
     assert examples[0].question
     assert examples[0].reference_answers
+
+
+def test_clean_dataset_q057_supports_canonical_gravity_alternatives() -> None:
+    dataset_path = Path("data/simpleqa_clean_100.jsonl")
+    examples = load_simpleqa_dataset(dataset_path)
+    q057 = next(example for example in examples if example.example_id == "q057")
+    assert "Gravity" in q057.reference_answers
+    assert "gravitational force" in q057.reference_answers


### PR DESCRIPTION
### Motivation
- Fix evaluator surface-form mismatches in the clean_100 benchmark where number words produced correct factual answers but did not match short numeric references (e.g. `seven` vs `7`).
- Address one q057 case where the evaluator lacked a stable canonical alternative (`Gravity` vs `gravitational force`) without changing PoR runtime or gate logic.
- Keep changes strictly benchmark-local, deterministic, and conservative so scoring reflects surface equivalence rather than adding semantic fuzziness.

### Description
- Add deterministic number-word → digit normalization (`one`…`twenty`) inside the SimpleQA normalization path in `benchmarks/simpleqa/metrics.py` so short numeric reference tokens compare correctly after normalization.
- Update `data/simpleqa_clean_100.jsonl` only for `q057` to include canonical aliases via an `answers` field: `["Gravity", "gravitational force"]`.
- Add targeted tests in `tests/test_simpleqa_eval_hardening.py` that assert `seven`↔`7`, `three`↔`3`, `six`↔`6`, a negative overmatch guard, and that the dataset loader exposes the `q057` aliases.
- Changes are confined to evaluation normalization, the benchmark dataset, and tests, with no modifications to PoR primitive code, v1/v2/v2_1/v2_2 gate logic, thresholds, or weights.

### Testing
- Run the hardened unit tests with `pytest -q tests/test_simpleqa_eval_hardening.py`, which completed successfully: `13 passed`.
- To reproduce the benchmark run used for inspection, execute `python benchmarks/simpleqa/run_simpleqa_por.py --dataset-path data/simpleqa_clean_100.jsonl --provider openai --model gpt-4o-mini --por-mode v2_2 --max-examples 100 --thresholds 0.35 0.39 0.42 0.43 --por-samples 3 --baseline-temperature 0.0 --por-temperature 0.4 --output-dir results/simpleqa`.
- To inspect deduped problem cases after a run, use `Import-Csv results/simpleqa/simpleqa_problem_cases_deduped.csv | Format-Table example_id,silence_flag,effective_decision,correctness_label,final_answer_or_effective_answer -AutoSize` (PowerShell) or the included Python CSV snippet in the README for bash environments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c910eb108326b6296eeb11d9188d)