### PR TITLE
Relax celsius matching, add temperature/decimal answer variants, and test decimal-in-sentence

### DIFF
--- a/benchmarks/simpleqa/metrics.py
+++ b/benchmarks/simpleqa/metrics.py
@@ -95,7 +95,7 @@ def is_correct(answer: str, references: list[str]) -> bool:
         norm_ref = normalize_text(ref)
         if not norm_ref:
             continue
-        if ("celsius" in norm_ref) != ("celsius" in norm_answer):
+        if "celsius" in norm_ref and "celsius" not in norm_answer:
             continue
 
         if norm_answer == norm_ref:

--- a/data/simpleqa_messy_100.jsonl
+++ b/data/simpleqa_messy_100.jsonl
@@ -89,10 +89,10 @@
 {"id": "q089", "question": "How many zeros are in one million written in digits?", "answers": ["6", "six"]}
 {"id": "q090", "question": "How many centimeters are in one meter?", "answers": ["100", "one hundred"]}
 {"id": "q091", "question": "Which instrument measures atmospheric pressure?", "answer": "barometer"}
-{"id": "q092", "question": "What is the pH of a neutral aqueous solution at 25°C?", "answers": ["7", "seven"]}
+{"id": "q092", "question": "What is the pH of a neutral aqueous solution at 25°C?", "answers": ["7", "seven", "7.0"]}
 {"id": "q093", "question": "Which gas is most abundant in Earth's atmosphere?", "answer": "nitrogen"}
-{"id": "q094", "question": "What is the freezing point of water in degrees Celsius?", "answers": ["0", "zero"]}
-{"id": "q095", "question": "What is the boiling point of water at standard atmospheric pressure in °C?", "answers": ["100", "one hundred"]}
+{"id": "q094", "question": "What is the freezing point of water in degrees Celsius?", "answers": ["0", "zero", "0 degrees Celsius"]}
+{"id": "q095", "question": "What is the boiling point of water at standard atmospheric pressure in °C?", "answers": ["100", "one hundred", "100 degrees Celsius"]}
 {"id": "q096", "question": "What is the SI unit of electric current?", "answers": ["ampere", "A"]}
 {"id": "q097", "question": "What is the SI unit of force?", "answer": "newton"}
 {"id": "q098", "question": "What is the SI unit of energy?", "answer": "joule"}

--- a/tests/test_simpleqa_eval_hardening.py
+++ b/tests/test_simpleqa_eval_hardening.py
@@ -17,6 +17,10 @@ def test_is_correct_supports_formula_and_unit_normalization() -> None:
     assert is_correct("The capital of France is Paris.", ["Paris"])
 
 
+def test_is_correct_matches_decimal_reference_inside_sentence() -> None:
+    assert is_correct("The pH of a neutral aqueous solution at 25°C is 7.0.", ["7.0"])
+
+
 def test_is_correct_does_not_overmatch_short_symbol_inside_word() -> None:
     assert not is_correct("August is often hot.", ["Au"])
 


### PR DESCRIPTION
### Motivation
- Allow answers that include a Celsius unit to match references that omit the unit while still preventing unit-less answers from matching unit-specific references.
- Add common answer variants for temperature and pH (decimal and explicit unit phrasing) to improve matching coverage.
- Harden evaluation by adding a test that ensures decimal references inside sentences are matched.

### Description
- Updated `benchmarks/simpleqa/metrics.py` to change the Celsius-presence check in `is_correct` from a symmetric XOR filter to an asymmetric check: `if "celsius" in norm_ref and "celsius" not in norm_answer: continue`.
- Added additional acceptable answer variants to `data/simpleqa_messy_100.jsonl` for `q092`, `q094`, and `q095` (including `"7.0"`, `"0 degrees Celsius"`, and `"100 degrees Celsius"`).
- Added a new unit test `test_is_correct_matches_decimal_reference_inside_sentence` in `tests/test_simpleqa_eval_hardening.py` to verify decimal references are detected inside sentences.

### Testing
- Ran the updated test module `tests/test_simpleqa_eval_hardening.py` using `pytest`, and the new and existing tests passed.
- The new test `test_is_correct_matches_decimal_reference_inside_sentence` asserts that `is_correct("The pH of a neutral aqueous solution at 25°C is 7.0.", ["7.0"])` returns true and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e87c7b8c832682649f2326fab49d)