### PR TITLE
docs: add Use / Integration section to README with offer and CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,24 @@ It does **not** improve model weights. It controls release behavior.
 
 **Same model. Different decision.**
 
+## Use / Integration
+PoR is useful as:
+- a release gate before final LLM output,
+- abstention/silence control when output is unstable,
+- a reliability layer in agent or API pipelines.
+
+Most relevant for:
+- LLM app builders,
+- agent developers,
+- API/inference layer engineers,
+- teams that care more about avoiding accepted wrong outputs than maximizing raw coverage.
+
+**Offer**
+
+I help teams integrate release-control/abstention gating into LLM pipelines, evaluate accepted-wrong-output and threshold behavior, and set up benchmark/audit flows for model release control.
+
+Open a GitHub issue if you want integration help, audit/evaluation support, or benchmark setup.
+
 ## What this repo is
 - A research-engineering implementation of Proof-of-Resonance (PoR) release control.
 - A deterministic core primitive with explicit `PROCEED` / `SILENCE` outcomes.


### PR DESCRIPTION
### Motivation
- Add a compact, technically honest entry point near the top of the README to explain practical PoR uses, target audience, a concrete founder/service offer, and a low-friction CTA.

### Description
- Inserted a `## Use / Integration` section immediately after the opening tagline that lists practical PoR uses, intended users, a bolded **Offer** statement, and a GitHub Issues CTA, without modifying any other content or tone in the README; affected file: `README.md`.
- Exact diff, the final inserted README block, and a short rationale are included below.

```diff
diff --git a/README.md b/README.md
index 9aadcfa..53df52c 100644
--- a/README.md
+++ b/README.md
@@ -9,6 +9,24 @@ It does **not** improve model weights. It controls release behavior.
 
 **Same model. Different decision.**
 
+## Use / Integration
+PoR is useful as:
+- a release gate before final LLM output,
+- abstention/silence control when output is unstable,
+- a reliability layer in agent or API pipelines.
+
+Most relevant for:
+- LLM app builders,
+- agent developers,
+- API/inference layer engineers,
+- teams that care more about avoiding accepted wrong outputs than maximizing raw coverage.
+
+**Offer**
+
+I help teams integrate release-control/abstention gating into LLM pipelines, evaluate accepted-wrong-output and threshold behavior, and set up benchmark/audit flows for model release control.
+
+Open a GitHub issue if you want integration help, audit/evaluation support, or benchmark setup.
+
 ## What this repo is
 - A research-engineering implementation of Proof-of-Resonance (PoR) release control.
 - A deterministic core primitive with explicit `PROCEED` / `SILENCE` outcomes.
```

Final inserted README block:

```markdown
## Use / Integration
PoR is useful as:
- a release gate before final LLM output,
- abstention/silence control when output is unstable,
- a reliability layer in agent or API pipelines.

Most relevant for:
- LLM app builders,
- agent developers,
- API/inference layer engineers,
- teams that care more about avoiding accepted wrong outputs than maximizing raw coverage.

**Offer**

I help teams integrate release-control/abstention gating into LLM pipelines, evaluate accepted-wrong-output and threshold behavior, and set up benchmark/audit flows for model release control.

Open a GitHub issue if you want integration help, audit/evaluation support, or benchmark setup.
```

Why this is stronger than a generic CTA (2–4 sentences):
This section gives immediate operational context so an engineer can quickly assess relevance by showing where PoR fits in a pipeline and what it prevents (accepted wrong outputs). The offer is concrete and engineering-focused (integration, evaluation, benchmarks) and the CTA is low-friction (`GitHub issue`), which aligns with a technical repo workflow rather than sales copy.

### Testing
- Ran repository verification steps: `git diff -- README.md`, `git add README.md && git commit -m "docs: add use/integration section with offer and CTA"`, and the PR creation helper; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea18d7528c8326b6c224cbe43e3fff)