### PR TITLE
v0.4 runtime hardening: configurable experimental margin, embedding safeguards, and API error handling

### DIFF
--- a/api/experimental_recovery.py
+++ b/api/experimental_recovery.py
@@ -6,17 +6,33 @@ thesis-level deterministic primitive.
 
 from __future__ import annotations
 
+import os
 from typing import Callable
 
 EXPERIMENTAL_BORDERLINE_MARGIN = 0.02
+EXPERIMENTAL_MARGIN_ENV_VAR = "POR_EXPERIMENTAL_MARGIN"
+
+
+def get_experimental_margin(default: float = EXPERIMENTAL_BORDERLINE_MARGIN) -> float:
+    """[EXPERIMENTAL] Resolve borderline margin from env with safe fallback."""
+    raw = os.getenv(EXPERIMENTAL_MARGIN_ENV_VAR)
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return max(0.0, min(value, 0.5))
 
 
 def is_borderline_silence(
     instability_score: float,
     threshold: float,
-    margin: float = EXPERIMENTAL_BORDERLINE_MARGIN,
+    margin: float | None = None,
 ) -> bool:
     """[EXPERIMENTAL] Return True for boundary-pocket silences."""
+    if margin is None:
+        margin = get_experimental_margin()
     return abs(instability_score - threshold) <= margin
 
 

--- a/api/main.py
+++ b/api/main.py
@@ -7,9 +7,10 @@ Layering in this module:
 """
 
 import json
+import logging
 from typing import List, Optional
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
 from api.core_primitive import (
@@ -18,7 +19,7 @@ from api.core_primitive import (
     fixed_threshold_release_decision,
 )
 from api.experimental_recovery import (
-    EXPERIMENTAL_BORDERLINE_MARGIN,
+    get_experimental_margin,
     maybe_short_regen,
 )
 from api.por_runtime import (
@@ -30,6 +31,7 @@ from api.por_runtime import (
 from api.xai_wrapper import DEFAULT_MODEL, generate_candidate
 
 app = FastAPI(title="silence-as-control")
+LOGGER = logging.getLogger(__name__)
 
 # Runtime default threshold used by API endpoints.
 # It starts from the core fixed threshold (0.39), but can be overridden by
@@ -177,6 +179,15 @@ def score_candidate_runtime(
         decision = "SILENCE"
         notes.append("forced_silence_invalid_json")
 
+    LOGGER.info(
+        "por_runtime_scoring drift=%.4f coherence=%.4f instability=%.4f threshold=%.4f decision=%s",
+        drift,
+        coherence,
+        instability,
+        threshold,
+        decision,
+    )
+
     return {
         "drift": round(drift, 4),
         "coherence": round(coherence, 4),
@@ -205,14 +216,18 @@ def health() -> dict:
 @app.post("/por/evaluate", response_model=EvaluateResponse, response_model_exclude_none=True)
 def evaluate(req: EvaluateRequest) -> EvaluateResponse:
     """Evaluate a provided candidate with core gate + runtime estimators."""
-    threshold = resolve_runtime_threshold(
-        request_threshold=req.threshold,
-        use_adaptive_threshold=req.use_adaptive_threshold,
-        recent_drifts=req.recent_drifts,
-        recent_coherences=req.recent_coherences,
-    )
-    result = score_candidate_runtime(req.prompt, req.candidate, threshold)
-    return EvaluateResponse(**result)
+    try:
+        threshold = resolve_runtime_threshold(
+            request_threshold=req.threshold,
+            use_adaptive_threshold=req.use_adaptive_threshold,
+            recent_drifts=req.recent_drifts,
+            recent_coherences=req.recent_coherences,
+        )
+        result = score_candidate_runtime(req.prompt, req.candidate, threshold)
+        return EvaluateResponse(**result)
+    except Exception:
+        LOGGER.exception("por_evaluate_failed")
+        raise HTTPException(status_code=500, detail="por_evaluate_failed")
 
 
 @app.post("/generate", response_model=LegacyGenerateResponse, response_model_exclude_none=True)
@@ -233,88 +248,92 @@ def legacy_generate(req: LegacyGenerateRequest) -> LegacyGenerateResponse:
 @app.post("/por/complete", response_model=CompleteResponse, response_model_exclude_none=True)
 def complete(req: CompleteRequest) -> CompleteResponse:
     """Generate candidate(s), score with PoR gate, then optionally run experimental recovery."""
-    threshold = resolve_runtime_threshold(
-        request_threshold=req.threshold,
-        use_adaptive_threshold=req.use_adaptive_threshold,
-        recent_drifts=req.recent_drifts,
-        recent_coherences=req.recent_coherences,
-    )
-
-    sample_count = max(1, req.drift_samples)
-    candidates: List[str] = []
-    for _ in range(sample_count):
-        candidates.append(
-            generate_candidate(
-                prompt=req.prompt,
-                model=req.model,
-                system_prompt=req.system_prompt,
-                temperature=req.temperature,
-            )
+    try:
+        threshold = resolve_runtime_threshold(
+            request_threshold=req.threshold,
+            use_adaptive_threshold=req.use_adaptive_threshold,
+            recent_drifts=req.recent_drifts,
+            recent_coherences=req.recent_coherences,
         )
 
-    primary_candidate = candidates[0]
-    result = score_candidate_runtime(
-        prompt=req.prompt,
-        candidate=primary_candidate,
-        threshold=threshold,
-        candidate_samples=candidates,
-    )
-
-    # Experimental lane only: MAYBE_SHORT_REGEN is post-silence and non-core.
-    if result["decision"] == "SILENCE":
-
-        def _regen_once() -> dict:
-            regen_candidate = generate_candidate(
-                prompt=(
-                    "Answer briefly and directly in <= 80 tokens. "
-                    "Avoid uncertainty wording.\n\n"
-                    f"Prompt: {req.prompt}"
-                ),
-                model=req.model,
-                system_prompt=req.system_prompt,
-                temperature=min(req.temperature, 0.2),
-            )
-            regen_result = score_candidate_runtime(
-                prompt=req.prompt,
-                candidate=regen_candidate,
-                threshold=threshold,
-                candidate_samples=[regen_candidate],
-            )
-            regen_result["release_output"] = (
-                regen_candidate if regen_result["decision"] == "PROCEED" else None
-            )
-            regen_result["_regen_candidate"] = regen_candidate
-            return regen_result
-
-        attempted, regen_result = maybe_short_regen(
-            enabled=resolve_experimental_short_regen_flag(req),
-            instability_score=result["instability_score"],
-            threshold=threshold,
-            run_regen=_regen_once,
-        )
-
-        if attempted and regen_result is not None:
-            regen_result["notes"] = regen_result["notes"] + [
-                (
-                    "experimental_maybe_short_regen_attempted"
-                    f":margin={EXPERIMENTAL_BORDERLINE_MARGIN:.2f}"
+        sample_count = max(1, req.drift_samples)
+        candidates: List[str] = []
+        for _ in range(sample_count):
+            candidates.append(
+                generate_candidate(
+                    prompt=req.prompt,
+                    model=req.model,
+                    system_prompt=req.system_prompt,
+                    temperature=req.temperature,
                 )
-            ]
-            if regen_result["decision"] == "PROCEED":
-                result = regen_result
-                candidates[0] = regen_result["_regen_candidate"]
-            else:
-                result["notes"].append("experimental_maybe_short_regen_failed")
+            )
 
-    return CompleteResponse(
-        model=req.model,
-        candidate=candidates[0] if result["decision"] == "PROCEED" else None,
-        drift=result["drift"],
-        coherence=result["coherence"],
-        instability_score=result["instability_score"],
-        threshold=result["threshold"],
-        decision=result["decision"],
-        release_output=result["release_output"],
-        silence_token=result["silence_token"],
-        notes=result["notes"],
-    )
+        primary_candidate = candidates[0]
+        result = score_candidate_runtime(
+            prompt=req.prompt,
+            candidate=primary_candidate,
+            threshold=threshold,
+            candidate_samples=candidates,
+        )
+
+        # Experimental lane only: MAYBE_SHORT_REGEN is post-silence and non-core.
+        if result["decision"] == "SILENCE":
+
+            def _regen_once() -> dict:
+                regen_candidate = generate_candidate(
+                    prompt=(
+                        "Answer briefly and directly in <= 80 tokens. "
+                        "Avoid uncertainty wording.\n\n"
+                        f"Prompt: {req.prompt}"
+                    ),
+                    model=req.model,
+                    system_prompt=req.system_prompt,
+                    temperature=min(req.temperature, 0.2),
+                )
+                regen_result = score_candidate_runtime(
+                    prompt=req.prompt,
+                    candidate=regen_candidate,
+                    threshold=threshold,
+                    candidate_samples=[regen_candidate],
+                )
+                regen_result["release_output"] = (
+                    regen_candidate if regen_result["decision"] == "PROCEED" else None
+                )
+                regen_result["_regen_candidate"] = regen_candidate
+                return regen_result
+
+            attempted, regen_result = maybe_short_regen(
+                enabled=resolve_experimental_short_regen_flag(req),
+                instability_score=result["instability_score"],
+                threshold=threshold,
+                run_regen=_regen_once,
+            )
+
+            if attempted and regen_result is not None:
+                regen_result["notes"] = regen_result["notes"] + [
+                    (
+                        "experimental_maybe_short_regen_attempted"
+                        f":margin={get_experimental_margin():.2f}"
+                    )
+                ]
+                if regen_result["decision"] == "PROCEED":
+                    result = regen_result
+                    candidates[0] = regen_result["_regen_candidate"]
+                else:
+                    result["notes"].append("experimental_maybe_short_regen_failed")
+
+        return CompleteResponse(
+            model=req.model,
+            candidate=candidates[0] if result["decision"] == "PROCEED" else None,
+            drift=result["drift"],
+            coherence=result["coherence"],
+            instability_score=result["instability_score"],
+            threshold=result["threshold"],
+            decision=result["decision"],
+            release_output=result["release_output"],
+            silence_token=result["silence_token"],
+            notes=result["notes"],
+        )
+    except Exception:
+        LOGGER.exception("por_complete_failed")
+        raise HTTPException(status_code=500, detail="por_complete_failed")

--- a/api/por_runtime.py
+++ b/api/por_runtime.py
@@ -21,7 +21,10 @@ RUNTIME_EXTENSION_DEFAULT_THRESHOLD = 0.39
 RUNTIME_GATE_THRESHOLD_DEFAULT = RUNTIME_EXTENSION_DEFAULT_THRESHOLD
 
 THRESHOLD_ENV_VAR = "POR_RUNTIME_GATE_THRESHOLD"
+MAX_EMBEDDING_CHARS_ENV_VAR = "MAX_EMBEDDING_CHARS"
+DEFAULT_MAX_EMBEDDING_CHARS = 4000
 EmbeddingFn = Callable[[str], list[float]]
+CUSTOM_EMBEDDING_FN: EmbeddingFn | None = None
 
 
 @dataclass(frozen=True)
@@ -79,6 +82,31 @@ def get_runtime_threshold(default: float = RUNTIME_EXTENSION_DEFAULT_THRESHOLD) 
     return _clip(value)
 
 
+def get_max_embedding_chars(default: int = DEFAULT_MAX_EMBEDDING_CHARS) -> int:
+    """[RUNTIME] Resolve max chars for local embedding with safe fallback."""
+    raw = os.getenv(MAX_EMBEDDING_CHARS_ENV_VAR)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return max(1, value)
+
+
+def _truncate_for_local_embedding(text: str) -> str:
+    max_chars = get_max_embedding_chars()
+    return text[:max_chars]
+
+
+def _resolve_embedding_fn(embedding_fn: EmbeddingFn | None) -> EmbeddingFn:
+    if embedding_fn is not None:
+        return embedding_fn
+    if CUSTOM_EMBEDDING_FN is not None:
+        return CUSTOM_EMBEDDING_FN
+    return get_embedding
+
+
 def get_embedding(text: str) -> list[float]:
     """[RUNTIME] Deterministic fallback embedding function.
 
@@ -86,7 +114,8 @@ def get_embedding(text: str) -> list[float]:
     Production integrations can inject a stronger embedding function.
     """
     vec = [0.0] * 64
-    for token in text.lower().split():
+    truncated = _truncate_for_local_embedding(text)
+    for token in truncated.lower().split():
         vec[_stable_token_index(token, len(vec))] += 1.0
 
     norm = math.sqrt(sum(v * v for v in vec))
@@ -109,15 +138,16 @@ def cosine_similarity(vec_a: Sequence[float], vec_b: Sequence[float]) -> float:
 def estimate_coherence(
     prompt: str,
     candidate: str,
-    embedding_fn: EmbeddingFn = get_embedding,
+    embedding_fn: EmbeddingFn | None = None,
 ) -> tuple[float, list[str]]:
     """[RUNTIME] Estimate coherence from prompt/candidate embedding similarity."""
     notes: list[str] = []
     if not candidate.strip():
         return 0.0, ["no_candidate_tokens"]
 
-    prompt_vec = embedding_fn(prompt)
-    candidate_vec = embedding_fn(candidate)
+    embed = _resolve_embedding_fn(embedding_fn)
+    prompt_vec = embed(prompt)
+    candidate_vec = embed(candidate)
     cos = cosine_similarity(prompt_vec, candidate_vec)
 
     nonnegative_space = _is_nonnegative_vector(prompt_vec) and _is_nonnegative_vector(
@@ -130,7 +160,7 @@ def estimate_coherence(
 
 def estimate_drift(
     candidate_texts: Sequence[str],
-    embedding_fn: EmbeddingFn = get_embedding,
+    embedding_fn: EmbeddingFn | None = None,
 ) -> tuple[float, list[str]]:
     """[RUNTIME] Estimate drift from multi-sample embedding disagreement."""
     notes: list[str] = []
@@ -139,7 +169,8 @@ def estimate_drift(
         notes.append("single_sample_drift")
         return 0.0, notes
 
-    vectors = [embedding_fn(text) for text in cleaned]
+    embed = _resolve_embedding_fn(embedding_fn)
+    vectors = [embed(text) for text in cleaned]
     pairwise: list[float] = []
     for i in range(len(vectors)):
         for j in range(i + 1, len(vectors)):

--- a/api/xai_wrapper.py
+++ b/api/xai_wrapper.py
@@ -1,8 +1,10 @@
 import os
+import logging
 from openai import OpenAI
 
 XAI_BASE_URL = "https://api.x.ai/v1"
 DEFAULT_MODEL = "grok-4"
+LOGGER = logging.getLogger(__name__)
 
 def get_client() -> OpenAI:
     api_key = os.getenv("XAI_API_KEY")
@@ -18,15 +20,21 @@ def generate_candidate(
     system_prompt: str = "You are a precise technical assistant.",
     model: str = DEFAULT_MODEL,
     temperature: float = 0.0,
+    timeout: float = 30.0,
 ) -> str:
-    client = get_client()
-    resp = client.chat.completions.create(
-        model=model,
-        temperature=temperature,
-        messages=[
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": prompt},
-        ],
-    )
-    content = resp.choices[0].message.content or ""
-    return content.strip()
+    try:
+        client = get_client()
+        resp = client.chat.completions.create(
+            model=model,
+            temperature=temperature,
+            timeout=timeout,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt},
+            ],
+        )
+        content = resp.choices[0].message.content or ""
+        return content.strip()
+    except Exception as exc:
+        LOGGER.exception("xai_generate_candidate_failed")
+        raise RuntimeError("xai_generation_failed") from exc

--- a/src/silence_as_control/control.py
+++ b/src/silence_as_control/control.py
@@ -20,7 +20,11 @@ def por_control(
     threshold=CONTROL_MIN_COHERENCE,
     tolerance=CONTROL_MAX_DRIFT,
 ):
-    """Return output only when deterministic control bounds are satisfied."""
+    """Return output only when deterministic control bounds are satisfied.
+
+    `CONTROL_MIN_COHERENCE` and `CONTROL_MAX_DRIFT` are simplified defaults
+    intended for environments that do not run multi-sample drift estimation.
+    """
     if drift > tolerance or coherence < threshold:
         return control_abstention()
     return {"status": "ok", "output": output}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -259,3 +259,31 @@ def test_api_complete_honors_backward_compatibility_alias_for_short_regen(monkey
     payload = response.json()
     assert payload["decision"] == "SILENCE"
     assert calls["count"] == 1
+
+
+def test_api_evaluate_returns_500_on_internal_failure(monkeypatch):
+    def broken_score(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(api_main, "score_candidate_runtime", broken_score)
+
+    response = client.post(
+        "/por/evaluate",
+        json={"prompt": "p", "candidate": "c"},
+    )
+    assert response.status_code == 500
+    assert response.json()["detail"] == "por_evaluate_failed"
+
+
+def test_api_complete_returns_500_on_internal_failure(monkeypatch):
+    def broken_generate(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(api_main, "generate_candidate", broken_generate)
+
+    response = client.post(
+        "/por/complete",
+        json={"prompt": "p"},
+    )
+    assert response.status_code == 500
+    assert response.json()["detail"] == "por_complete_failed"

--- a/tests/test_experimental_recovery.py
+++ b/tests/test_experimental_recovery.py
@@ -1,11 +1,35 @@
 """Tests for experimental MAYBE_SHORT_REGEN helpers."""
 
-from api.experimental_recovery import is_borderline_silence, maybe_short_regen
+from api.experimental_recovery import (
+    get_experimental_margin,
+    is_borderline_silence,
+    maybe_short_regen,
+)
 
 
 def test_experimental_borderline_check_uses_configured_margin():
     assert is_borderline_silence(0.40, 0.39)
     assert not is_borderline_silence(0.45, 0.39)
+
+
+def test_experimental_margin_env_fallback_and_clamp(monkeypatch):
+    monkeypatch.delenv("POR_EXPERIMENTAL_MARGIN", raising=False)
+    assert get_experimental_margin() == 0.02
+
+    monkeypatch.setenv("POR_EXPERIMENTAL_MARGIN", "invalid")
+    assert get_experimental_margin() == 0.02
+
+    monkeypatch.setenv("POR_EXPERIMENTAL_MARGIN", "-1")
+    assert get_experimental_margin() == 0.0
+
+    monkeypatch.setenv("POR_EXPERIMENTAL_MARGIN", "1.2")
+    assert get_experimental_margin() == 0.5
+
+
+def test_experimental_borderline_check_reads_margin_from_env(monkeypatch):
+    monkeypatch.setenv("POR_EXPERIMENTAL_MARGIN", "0.005")
+    assert not is_borderline_silence(0.40, 0.39)
+    assert is_borderline_silence(0.394, 0.39)
 
 
 def test_experimental_short_regen_runs_only_when_enabled_and_borderline():

--- a/tests/test_integration_api.py
+++ b/tests/test_integration_api.py
@@ -1,0 +1,115 @@
+"""Integration tests for API endpoints with deterministic/mocked runtime behavior."""
+
+from fastapi.testclient import TestClient
+
+import api.main as api_main
+from api.main import app
+
+
+client = TestClient(app)
+
+
+def test_integration_por_evaluate_deterministic_payload():
+    response = client.post(
+        "/por/evaluate",
+        json={
+            "prompt": "explain recursion",
+            "candidate": "recursion is when a function calls itself",
+            "threshold": 0.39,
+            "use_adaptive_threshold": False,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["threshold"] == 0.39
+    assert payload["decision"] in {"PROCEED", "SILENCE"}
+    assert 0.0 <= payload["instability_score"] <= 1.0
+
+
+def test_integration_por_complete_with_mocked_generate_candidate(monkeypatch):
+    monkeypatch.setattr(api_main, "generate_candidate", lambda **kwargs: "deterministic candidate")
+
+    response = client.post(
+        "/por/complete",
+        json={
+            "prompt": "hello",
+            "threshold": 1.0,
+            "drift_samples": 1,
+            "enable_experimental_short_regen": False,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["decision"] == "PROCEED"
+    assert payload["candidate"] == "deterministic candidate"
+
+
+def test_integration_experimental_margin_applies_only_when_enabled(monkeypatch):
+    candidates = ["primary", "regen"]
+
+    def fake_generate_candidate(**kwargs):
+        return candidates.pop(0)
+
+    call_index = {"count": 0}
+
+    def fake_score(prompt, candidate, threshold, candidate_samples=None):
+        call_index["count"] += 1
+        if call_index["count"] == 1:
+            return {
+                "drift": 0.41,
+                "coherence": 0.78,
+                "instability_score": 0.405,
+                "threshold": threshold,
+                "decision": "SILENCE",
+                "release_output": None,
+                "silence_token": api_main.SILENCE_TOKEN,
+                "notes": ["initial_silence"],
+            }
+        return {
+            "drift": 0.1,
+            "coherence": 0.95,
+            "instability_score": 0.075,
+            "threshold": threshold,
+            "decision": "PROCEED",
+            "release_output": candidate,
+            "silence_token": None,
+            "notes": ["regen_success"],
+        }
+
+    monkeypatch.setenv("POR_EXPERIMENTAL_MARGIN", "0.02")
+    monkeypatch.setattr(api_main, "generate_candidate", fake_generate_candidate)
+    monkeypatch.setattr(api_main, "score_candidate_runtime", fake_score)
+
+    disabled = client.post(
+        "/por/complete",
+        json={
+            "prompt": "hello",
+            "threshold": 0.39,
+            "drift_samples": 1,
+            "enable_experimental_short_regen": False,
+        },
+    )
+    assert disabled.status_code == 200
+    assert disabled.json()["decision"] == "SILENCE"
+    assert call_index["count"] == 1
+
+    candidates[:] = ["primary", "regen"]
+    call_index["count"] = 0
+
+    enabled = client.post(
+        "/por/complete",
+        json={
+            "prompt": "hello",
+            "threshold": 0.39,
+            "drift_samples": 1,
+            "enable_experimental_short_regen": True,
+        },
+    )
+
+    assert enabled.status_code == 200
+    payload = enabled.json()
+    assert payload["decision"] == "PROCEED"
+    assert any("experimental_maybe_short_regen_attempted" in n for n in payload["notes"])
+    assert call_index["count"] == 2

--- a/tests/test_por_runtime.py
+++ b/tests/test_por_runtime.py
@@ -41,3 +41,39 @@ def test_runtime_fallback_token_hashing_is_deterministic():
 
     assert all(slot == idx for slot in repeated)
     assert 0 <= idx < 64
+
+
+def test_runtime_local_embedding_truncates_by_configured_max_chars(monkeypatch):
+    monkeypatch.setenv("MAX_EMBEDDING_CHARS", "6")
+    vec_a = por_runtime.get_embedding("alpha beta")
+    vec_b = por_runtime.get_embedding("alpha gamma")
+    vec_c = por_runtime.get_embedding("bravo zeta")
+
+    assert vec_a == vec_b
+    assert vec_b != vec_c
+
+
+def test_runtime_estimate_uses_custom_embedding_hook_by_default(monkeypatch):
+    calls = {"count": 0}
+
+    def custom_embedding(text: str) -> list[float]:
+        calls["count"] += 1
+        return [1.0, float(len(text))]
+
+    monkeypatch.setattr(por_runtime, "CUSTOM_EMBEDDING_FN", custom_embedding)
+    coherence, _ = por_runtime.estimate_coherence("p", "candidate")
+    drift, _ = por_runtime.estimate_drift(["a", "b"])
+
+    assert 0.0 <= coherence <= 1.0
+    assert 0.0 <= drift <= 1.0
+    assert calls["count"] == 4
+
+
+def test_runtime_explicit_embedding_fn_overrides_custom_hook(monkeypatch):
+    monkeypatch.setattr(por_runtime, "CUSTOM_EMBEDDING_FN", lambda _: [1.0, 1.0])
+
+    def explicit_embedding(_: str) -> list[float]:
+        return [0.0, 1.0]
+
+    coherence, _ = por_runtime.estimate_coherence("p", "c", embedding_fn=explicit_embedding)
+    assert coherence == 1.0

--- a/tests/test_xai_wrapper.py
+++ b/tests/test_xai_wrapper.py
@@ -1,0 +1,46 @@
+from types import SimpleNamespace
+
+import pytest
+
+from api import xai_wrapper
+
+
+class _FakeCompletions:
+    def __init__(self):
+        self.kwargs = None
+
+    def create(self, **kwargs):
+        self.kwargs = kwargs
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="  result  "))]
+        )
+
+
+class _FakeClient:
+    def __init__(self, completions):
+        self.chat = SimpleNamespace(completions=completions)
+
+
+def test_generate_candidate_passes_timeout_and_returns_trimmed(monkeypatch):
+    completions = _FakeCompletions()
+    monkeypatch.setattr(xai_wrapper, "get_client", lambda: _FakeClient(completions))
+
+    result = xai_wrapper.generate_candidate("hello", timeout=12.5)
+
+    assert result == "result"
+    assert completions.kwargs["timeout"] == 12.5
+
+
+def test_generate_candidate_logs_and_raises_runtime_error_on_failure(monkeypatch):
+    class _BrokenCompletions:
+        def create(self, **kwargs):
+            raise ValueError("boom")
+
+    monkeypatch.setattr(
+        xai_wrapper,
+        "get_client",
+        lambda: _FakeClient(_BrokenCompletions()),
+    )
+
+    with pytest.raises(RuntimeError, match="xai_generation_failed"):
+        xai_wrapper.generate_candidate("hello")


### PR DESCRIPTION
### Motivation
- Introduce small, conservative runtime hardening and configurability to reduce surprises in deployments while preserving the deterministic PoR primitive and benchmark logic.
- Make experimental recovery margin, local embedding behavior, and external-generator calls configurable and safe-by-default to avoid crashes from bad env values or remote client failures.
- Add minimal, auditable observability for runtime scoring and conservative API error propagation so internal failures do not silently return success.

### Description
- Key changes: added a safe env getter for the experimental borderline margin (`POR_EXPERIMENTAL_MARGIN`) with default `0.02` and clamp `[0.0, 0.5]`, local embedding truncation via `MAX_EMBEDDING_CHARS` (default `4000`) plus optional `CUSTOM_EMBEDDING_FN`, wrapped xAI generation calls with `try/except` and a `timeout` parameter (default `30.0`), added structured scoring logs (only `drift`, `coherence`, `instability`, `threshold`, `decision`), and conservative `500` error handling for `/por/evaluate` and `/por/complete`.
- Exact files changed: `api/experimental_recovery.py`, `api/por_runtime.py`, `api/xai_wrapper.py`, `api/main.py`, `src/silence_as_control/control.py`, `tests/test_experimental_recovery.py`, `tests/test_por_runtime.py`, `tests/test_api.py`, `tests/test_integration_api.py` (new), `tests/test_xai_wrapper.py` (new).
- Behavioral guards: core PoR primitive semantics and benchmark logic were not modified; default behavior remains unchanged when env vars/hooks are absent.

### Testing
- Automated tests run: `pytest -q`; result: all tests passed locally (`76 passed`).
- New/updated tests added: `tests/test_integration_api.py` (integration endpoints), `tests/test_xai_wrapper.py` (timeout + failure), and targeted additions in `tests/test_experimental_recovery.py`, `tests/test_por_runtime.py`, and `tests/test_api.py` covering env fallback/clamp, embedding truncation and custom hook usage, and API endpoint error returns; all pass.
- Command to reproduce: run `pytest -q` from repository root; tests do not require external API keys.

This change is suitable for a conservative v0.4 runtime-hardening release because it is limited to runtime/config fixes, is test-covered, preserves core primitives and benchmarks, and keeps defaults backward compatible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eafb7153a08326b4c01b74811b20f1)