### PR TITLE
Add Ollama local provider to SimpleQA PoR benchmark runner

### DIFF
--- a/benchmarks/simpleqa/README.md
+++ b/benchmarks/simpleqa/README.md
@@ -100,6 +100,22 @@ Environment variables for OpenAI-compatible adapter:
 - `OPENAI_API_KEY` (required)
 - `OPENAI_BASE_URL` (optional)
 
+Ollama local-model run example (no API key required):
+
+```bash
+python benchmarks/simpleqa/run_simpleqa_por.py \
+  --dataset-path data/simpleqa_messy_100.jsonl \
+  --provider ollama \
+  --ollama-model qwen2.5:0.5b \
+  --ollama-url http://localhost:11434 \
+  --por-mode v1 \
+  --thresholds 0.35 0.39 0.42 0.43 \
+  --por-samples 3 \
+  --baseline-temperature 0.0 \
+  --por-temperature 0.4 \
+  --output-dir results/simpleqa_ollama
+```
+
 Temperature controls:
 
 - `--baseline-temperature` defaults to `0.0` (deterministic baseline behavior).

--- a/benchmarks/simpleqa/model_adapter.py
+++ b/benchmarks/simpleqa/model_adapter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+import httpx
 
 
 class ModelAdapterError(RuntimeError):
@@ -139,10 +140,102 @@ class OpenAIChatAdapter(ModelAdapter):
             raise ModelAdapterError(f"Model contradiction-check failed: {exc}") from exc
 
 
-def build_model_adapter(provider: str, model: str) -> ModelAdapter:
+@dataclass
+class OllamaAdapter(ModelAdapter):
+    """Local Ollama API adapter using /api/generate."""
+
+    model: str
+    base_url: str = "http://localhost:11434"
+    timeout: float = 60.0
+
+    def _generate(self, prompt: str, temperature: float) -> str:
+        url = f"{self.base_url.rstrip('/')}/api/generate"
+        payload = {
+            "model": self.model,
+            "prompt": prompt,
+            "stream": False,
+            "options": {"temperature": temperature},
+        }
+        try:
+            with httpx.Client(timeout=self.timeout) as client:
+                response = client.post(url, json=payload)
+                response.raise_for_status()
+                body = response.json()
+        except httpx.TimeoutException as exc:
+            raise ModelAdapterError(
+                f"Ollama request timed out after {self.timeout:.1f}s at {url}"
+            ) from exc
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code
+            response_text = (exc.response.text or "").strip()
+            if len(response_text) > 200:
+                response_text = f"{response_text[:200]}..."
+            raise ModelAdapterError(
+                f"Ollama HTTP {status_code} from {url}: {response_text}"
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise ModelAdapterError(f"Ollama request failed for {url}: {exc}") from exc
+        except ValueError as exc:
+            raise ModelAdapterError(f"Ollama returned invalid JSON from {url}") from exc
+
+        text = str(body.get("response", "")).strip()
+        if not text:
+            raise ModelAdapterError("Ollama response missing non-empty 'response' field.")
+        return text
+
+    def answer(
+        self,
+        question: str,
+        temperature: float = 0.0,
+        seed: int | None = None,
+    ) -> str:
+        _ = seed
+        prompt = (
+            "Answer briefly and directly. If uncertain, provide your best factual answer.\n\n"
+            f"Question: {question}"
+        )
+        return self._generate(prompt, temperature=temperature)
+
+    def self_check(self, question: str, proposed_answer: str) -> str:
+        prompt = (
+            f"Question: {question}\n"
+            f"Proposed answer: {proposed_answer}\n\n"
+            "Is the proposed answer factually correct?\n"
+            "Reply with exactly one token:\n"
+            "YES\nNO\nUNSURE"
+        )
+        text = self._generate(prompt, temperature=0.0).upper()
+        if text.startswith("YES"):
+            return "YES"
+        if text.startswith("NO"):
+            return "NO"
+        return "UNSURE"
+
+    def contradiction_check(self, question: str, proposed_answer: str) -> str:
+        prompt = (
+            f"Question: {question}\n"
+            f"Proposed answer: {proposed_answer}\n\n"
+            "Your task:\n"
+            "Try to challenge the proposed answer.\n"
+            "If you think it may be wrong, provide the strongest short alternative factual answer or contradiction.\n"
+            "If you think it is correct, reply ONLY:\n"
+            "NO_CONTRADICTION"
+        )
+        return self._generate(prompt, temperature=0.0)
+
+
+def build_model_adapter(
+    provider: str,
+    model: str,
+    *,
+    ollama_url: str = "http://localhost:11434",
+    ollama_timeout: float = 60.0,
+) -> ModelAdapter:
     provider_normalized = provider.strip().lower()
     if provider_normalized == "openai":
         return OpenAIChatAdapter(model=model)
+    if provider_normalized == "ollama":
+        return OllamaAdapter(model=model, base_url=ollama_url, timeout=ollama_timeout)
     raise ModelAdapterError(
-        f"Unsupported provider '{provider}'. Supported providers: openai."
+        f"Unsupported provider '{provider}'. Supported providers: openai, ollama."
     )

--- a/benchmarks/simpleqa/run_simpleqa_por.py
+++ b/benchmarks/simpleqa/run_simpleqa_por.py
@@ -58,7 +58,10 @@ def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run SimpleQA PoR benchmark harness.")
     parser.add_argument("--dataset-path", required=True, help="Path to local SimpleQA file (.json/.jsonl/.csv).")
     parser.add_argument("--provider", default="openai", help="Model provider (default: openai).")
-    parser.add_argument("--model", required=True, help="Model name for the selected provider.")
+    parser.add_argument("--model", default="", help="Model name for the selected provider.")
+    parser.add_argument("--ollama-model", default="", help="Ollama model name (e.g. qwen2.5:0.5b).")
+    parser.add_argument("--ollama-url", default="http://localhost:11434", help="Ollama base URL.")
+    parser.add_argument("--ollama-timeout", type=float, default=60.0, help="Timeout in seconds for Ollama requests.")
     parser.add_argument("--max-examples", type=int, default=None)
     parser.add_argument("--thresholds", type=float, nargs="+", default=[0.35, 0.39, 0.42, 0.43])
     parser.add_argument("--output-dir", default="results/simpleqa")
@@ -228,6 +231,12 @@ def _write_csv(path: Path, fieldnames: list[str], rows: list[dict[str, Any]]) ->
 
 def run() -> None:
     args = _parse_args()
+    provider = args.provider.strip().lower()
+    selected_model = args.model.strip()
+    if provider == "ollama":
+        selected_model = args.ollama_model.strip() or selected_model
+    if not selected_model:
+        raise SystemExit("A model is required. Use --model (or --ollama-model for --provider ollama).")
     try:
         por_samples = validate_por_samples(args.por_samples)
         validated_self_check_no_penalty = validate_self_check_no_penalty(args.self_check_no_penalty)
@@ -252,7 +261,12 @@ def run() -> None:
         max_examples=args.max_examples,
     )
 
-    adapter = build_model_adapter(provider=args.provider, model=args.model)
+    adapter = build_model_adapter(
+        provider=args.provider,
+        model=selected_model,
+        ollama_url=args.ollama_url,
+        ollama_timeout=args.ollama_timeout,
+    )
 
     rows: list[dict[str, Any]] = []
     fieldnames = [

--- a/tests/test_simpleqa_benchmark_harness.py
+++ b/tests/test_simpleqa_benchmark_harness.py
@@ -121,3 +121,24 @@ def test_por_mode_default_and_choices(monkeypatch) -> None:
     args_v2_2 = _parse_args()
     assert args_v2_2.por_mode == "v2_2"
     assert args_v2_2.self_check_no_penalty == 0.35
+
+
+def test_parse_args_accepts_ollama_options(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "run_simpleqa_por.py",
+            "--dataset-path",
+            "dummy.jsonl",
+            "--provider",
+            "ollama",
+            "--ollama-model",
+            "qwen2.5:0.5b",
+            "--ollama-url",
+            "http://localhost:11434",
+        ],
+    )
+    args = _parse_args()
+    assert args.provider == "ollama"
+    assert args.ollama_model == "qwen2.5:0.5b"
+    assert args.ollama_url == "http://localhost:11434"

--- a/tests/test_simpleqa_ollama_adapter.py
+++ b/tests/test_simpleqa_ollama_adapter.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import httpx
+
+from benchmarks.simpleqa.model_adapter import ModelAdapterError, build_model_adapter
+
+
+class _DummyResponse:
+    def __init__(self, payload: dict[str, str]) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, str]:
+        return self._payload
+
+
+class _DummyClient:
+    def __init__(self, response_payload: dict[str, str]) -> None:
+        self.response_payload = response_payload
+        self.last_url = ""
+        self.last_json: dict[str, object] = {}
+
+    def __enter__(self) -> "_DummyClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    def post(self, url: str, json: dict[str, object]) -> _DummyResponse:
+        self.last_url = url
+        self.last_json = json
+        return _DummyResponse(self.response_payload)
+
+
+class _TimeoutClient:
+    def __enter__(self) -> "_TimeoutClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    def post(self, url: str, json: dict[str, object]) -> _DummyResponse:
+        raise httpx.TimeoutException("timed out")
+
+
+def test_ollama_adapter_answer_uses_generate_endpoint(monkeypatch) -> None:
+    dummy_client = _DummyClient({"response": "Paris"})
+
+    def _client_factory(*args, **kwargs):
+        return dummy_client
+
+    monkeypatch.setattr("benchmarks.simpleqa.model_adapter.httpx.Client", _client_factory)
+
+    adapter = build_model_adapter(
+        provider="ollama",
+        model="qwen2.5:0.5b",
+        ollama_url="http://localhost:11434",
+        ollama_timeout=5.0,
+    )
+    answer = adapter.answer("What is the capital of France?")
+
+    assert answer == "Paris"
+    assert dummy_client.last_url == "http://localhost:11434/api/generate"
+    assert dummy_client.last_json["model"] == "qwen2.5:0.5b"
+    assert dummy_client.last_json["stream"] is False
+
+
+def test_ollama_adapter_timeout_is_clear(monkeypatch) -> None:
+    def _client_factory(*args, **kwargs):
+        return _TimeoutClient()
+
+    monkeypatch.setattr("benchmarks.simpleqa.model_adapter.httpx.Client", _client_factory)
+
+    adapter = build_model_adapter(
+        provider="ollama",
+        model="qwen2.5:0.5b",
+        ollama_url="http://localhost:11434",
+        ollama_timeout=1.5,
+    )
+
+    try:
+        adapter.answer("Any question")
+    except ModelAdapterError as exc:
+        assert "timed out" in str(exc).lower()
+        assert "1.5s" in str(exc)
+    else:
+        raise AssertionError("Expected timeout ModelAdapterError")


### PR DESCRIPTION
### Motivation
- Enable running the existing SimpleQA PoR benchmark with local Ollama models (starting with `qwen2.5:0.5b`) while preserving existing OpenAI behavior and output artifact names.
- Provide clear timeout and error handling for local HTTP-based model calls so CI and users get actionable messages when Ollama is unavailable or returns unexpected payloads.

### Description
- Added `OllamaAdapter` to `benchmarks/simpleqa/model_adapter.py` which calls `POST {ollama_url}/api/generate` with `stream: false`, uses `httpx` with a configurable timeout, and raises `ModelAdapterError` with concise messages on HTTP, JSON, or timeout failures.
- Extended `build_model_adapter` to accept `provider='ollama'` and pass `ollama_url`/`ollama_timeout` through the runner, preserving the existing `openai` adapter behavior.
- Added CLI options to the runner in `benchmarks/simpleqa/run_simpleqa_por.py`: `--ollama-model`, `--ollama-url`, and `--ollama-timeout`, changed model-selection logic so `--ollama-model` is used when `--provider ollama` (falling back to `--model`), and kept all output artifact filenames identical.
- Added usage documentation snippet to `benchmarks/simpleqa/README.md` showing the exact command to run `qwen2.5:0.5b` on `messy_100`, and added tests in `tests/test_simpleqa_ollama_adapter.py` plus a CLI-arg parsing assertion in `tests/test_simpleqa_benchmark_harness.py`.
- Files changed: `benchmarks/simpleqa/model_adapter.py`, `benchmarks/simpleqa/run_simpleqa_por.py`, `benchmarks/simpleqa/README.md`, `tests/test_simpleqa_benchmark_harness.py`, and new `tests/test_simpleqa_ollama_adapter.py`.
- Exact run command (example) to run `qwen2.5:0.5b` on the messy_100 dataset: `python benchmarks/simpleqa/run_simpleqa_por.py --dataset-path data/simpleqa_messy_100.jsonl --provider ollama --ollama-model qwen2.5:0.5b --ollama-url http://localhost:11434 --por-mode v1 --thresholds 0.35 0.39 0.42 0.43 --por-samples 3 --baseline-temperature 0.0 --por-temperature 0.4 --output-dir results/simpleqa_ollama`.
- Test command to run the new tests locally: `pytest -q tests/test_simpleqa_benchmark_harness.py tests/test_simpleqa_ollama_adapter.py`.

### Testing
- Ran `pytest -q tests/test_simpleqa_benchmark_harness.py tests/test_simpleqa_ollama_adapter.py` and all tests passed (`8 passed`).
- The new adapter tests mock `httpx.Client` and simulate both a valid `/api/generate` response and a timeout to ensure clear error messages without requiring a live Ollama server in CI.
- No existing OpenAI provider tests or behaviors were modified and their assertions still pass under the same test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0adc5f39c83269b8dcab83f34ff0c)