### PR TITLE
Add SimpleQA/Ollama evidence docs and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ curl -s http://127.0.0.1:8000/por/complete \
   -d '{"prompt":"Explain recursion in one sentence","threshold":0.39,"drift_samples":3,"enable_experimental_short_regen":true}'
 ```
 
+
+## Recent local Ollama evidence
+- PR #131 (Qwen3 4B, SimpleQA/Ollama, 100 examples, PoR v2): at 0.43, 84% coverage with 0 accepted wrong (100% accepted precision) in this run.
+- PR #132 (Qwen3 8B, SimpleQA/Ollama, 100 examples, PoR v2): at 0.42/0.43, 93% coverage with 1 accepted wrong (98.92% accepted precision) in this run.
+- In this evidence slice, Qwen3 4B @ 0.43 acts as a practical zero-accepted-failure anchor, while Qwen3 8B @ 0.42/0.43 is a high-coverage boundary.
+- This supports the repository thesis: stronger generation does not automatically mean safer release behavior at a fixed threshold.
+- See `docs/threshold_regime_contract.md` and `docs/evidence_map.md` for scoped interpretation and artifact navigation.
+
 ## Evidence
 - Run artifacts: `reports/`, `wiki/runs/`, `wiki/meta/Evidence_Map.md`
 - Boundary-pocket artifacts: `reports/borderline_pocket_labels.csv`, `reports/borderline_maybe_short_regen.csv`

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,5 +6,7 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - `runtime_extensions.md` — optional runtime deployment helpers.
 - `experimental_features.md` — optional non-core MAYBE_SHORT_REGEN behavior.
 - `api_walkthrough.md` — broader API walkthrough.
+- `threshold_regime_contract.md` — scoped threshold interpretation contract for SimpleQA/Ollama evidence.
+- `evidence_map.md` — claim-to-artifact navigation for core/runtime/benchmark surfaces.
 
 For paper/preprint context, see `../paper/README.md`.

--- a/docs/evidence_map.md
+++ b/docs/evidence_map.md
@@ -1,0 +1,57 @@
+# Evidence Map
+
+This map is a navigation layer for claims and evidence artifacts.
+
+## Core claim
+
+**Generation != release.**
+
+Silence-as-Control (PoR) is a release-control layer: generation quality and release safety are related but not identical.
+
+## Core primitive files
+
+- `src/silence_as_control/control.py`
+- `api/core_primitive.py`
+
+These define the primitive thresholded release behavior (`PROCEED` / `SILENCE`).
+
+## Runtime / API files
+
+- `api/por_runtime.py`
+- `api/main.py`
+- `api/experimental_recovery.py` (explicitly experimental lane)
+
+These define deployment-facing surfaces around, but not replacing, the primitive contract.
+
+## Benchmark / evaluation files
+
+- `eval_simpleqa_ollama.py`
+- `benchmark/eval_100_milestone.py`
+- `benchmark/eval_100_messy.py`
+
+These files produce evaluation outputs used for threshold-behavior inspection.
+
+## Result artifact directories (recent local SimpleQA/Ollama)
+
+- Qwen3 4B run artifacts: `results/simpleqa_ollama_qwen3_4b_100_v2_retry/`
+- Qwen3 8B run artifacts: `results/simpleqa_ollama_qwen3_8b_100_v2/`
+
+Treat these directories as the primary source for PR #131 / #132 run summaries.
+
+## Claim -> artifact mapping (short)
+
+- Claim: PoR is release control, not generation improvement.
+  - Evidence: primitive rule implementation and architecture split docs.
+  - Files: `src/silence_as_control/control.py`, `api/core_primitive.py`, `docs/architecture.md`.
+
+- Claim: Threshold behavior is regime/scoped, not universal.
+  - Evidence: threshold contract + run-specific artifacts.
+  - Files: `docs/threshold_regime_contract.md`, `results/simpleqa_ollama_qwen3_4b_100_v2_retry/`, `results/simpleqa_ollama_qwen3_8b_100_v2/`.
+
+- Claim: Qwen3 4B reached zero accepted wrong at selected thresholds in this 100-example run.
+  - Evidence: PR #131 artifacts and summary tables.
+  - Files: `results/simpleqa_ollama_qwen3_4b_100_v2_retry/`.
+
+- Claim: Qwen3 8B reached higher coverage but retained 1 accepted wrong at high-coverage boundary.
+  - Evidence: PR #132 artifacts and summary tables.
+  - Files: `results/simpleqa_ollama_qwen3_8b_100_v2/`.

--- a/docs/threshold_regime_contract.md
+++ b/docs/threshold_regime_contract.md
@@ -1,0 +1,73 @@
+# Threshold Regime Contract
+
+This document defines how to interpret threshold results in this repository.
+
+## Core contract
+
+Thresholds are **behavior-control dials**, not universal constants.
+
+A threshold observation is only valid inside its exact evaluation scope:
+
+- model variant,
+- dataset slice,
+- benchmark path,
+- PoR mode/runtime configuration.
+
+Changing any of those can change coverage, silence, and accepted-wrong behavior.
+
+## Regime language (conservative)
+
+Use these terms as operational labels, not universal guarantees:
+
+- **Conservative regime**: lower coverage, stronger release caution.
+- **Practical regime**: useful coverage with controlled accepted-wrong risk in a specific run.
+- **Transitional regime**: near a behavior shift; monitor accepted-wrong and false-silence balance closely.
+- **High-coverage boundary**: aggressive coverage edge in a specific run; may still carry accepted wrong outputs.
+
+## Interpreting 0.35 / 0.39 / 0.42 / 0.43 in current local SimpleQA/Ollama runs
+
+Scope for this section:
+
+- dataset: 100-example local SimpleQA batch,
+- benchmark path: repository SimpleQA/Ollama evaluation flow,
+- mode: PoR v2,
+- model families: Qwen3 4B and Qwen3 8B local Ollama runs from PR #131 and PR #132.
+
+Interpretation guidance:
+
+- **0.35**: conservative-to-practical transition in these runs; lower coverage with stronger abstention.
+- **0.39**: practical coverage increase while still keeping accepted-wrong tightly controlled in these runs.
+- **0.42**: practical/high-coverage transition; strong coverage, but model-specific risk profile matters.
+- **0.43**: high-coverage boundary in these runs; should be read with accepted-wrong counts, not coverage alone.
+
+Do not transfer these labels outside this exact scope without rerunning evidence.
+
+## Qwen3 4B anchor (this run only)
+
+In the PR #131 run (Qwen3 4B, 100-example SimpleQA/Ollama, PoR v2), threshold **0.43** produced:
+
+- 84% answer coverage,
+- 16% silence,
+- 84 accepted correct,
+- 0 accepted wrong,
+- 100% accepted precision.
+
+Therefore, **Qwen3 4B @ 0.43** is a **practical zero-accepted-failure anchor for this specific run**.
+It is not a universal safety claim across datasets, prompts, or deployment modes.
+
+## Qwen3 8B boundary (this run only)
+
+In the PR #132 run (Qwen3 8B, 100-example SimpleQA/Ollama, PoR v2), thresholds **0.42/0.43** produced:
+
+- 93% answer coverage,
+- 7% silence,
+- 92 accepted correct,
+- 1 accepted wrong,
+- 98.92% accepted precision.
+
+Therefore, **Qwen3 8B @ 0.42/0.43** is a **high-coverage boundary**, not a zero-accepted-failure anchor, in this run.
+
+## Non-claim reminder
+
+A stronger generation model does **not** automatically imply safer release behavior at a fixed threshold.
+Release safety is an observed property of **model + gate + threshold + benchmark scope**.

--- a/reports/README.md
+++ b/reports/README.md
@@ -75,3 +75,12 @@ Keep this directory disciplined:
 - Prefer small, auditable artifacts.
 - Do not add generated noise files or scratch outputs.
 - Keep filenames explicit about run context (task count, threshold, or lane purpose).
+
+
+## Navigation note
+
+For conservative claim-to-artifact mapping, see `docs/evidence_map.md` and `docs/threshold_regime_contract.md`.
+Recent local SimpleQA/Ollama artifact directories are:
+
+- `results/simpleqa_ollama_qwen3_4b_100_v2_retry/`
+- `results/simpleqa_ollama_qwen3_8b_100_v2/`

--- a/results/simpleqa_ollama_qwen3_4b_100_v2_retry/README.md
+++ b/results/simpleqa_ollama_qwen3_4b_100_v2_retry/README.md
@@ -1,0 +1,11 @@
+# Qwen3 4B SimpleQA/Ollama Artifacts (100, PoR v2, retry)
+
+This directory contains the evidence artifacts referenced by PR #131.
+
+Scope:
+- model: Qwen3 4B (Ollama)
+- dataset: local 100-example SimpleQA batch
+- mode: PoR v2
+- run context: retry flow as tracked in this directory
+
+Interpretation note: treat findings as scoped to this run context, not universal behavior.

--- a/results/simpleqa_ollama_qwen3_8b_100_v2/README.md
+++ b/results/simpleqa_ollama_qwen3_8b_100_v2/README.md
@@ -1,0 +1,10 @@
+# Qwen3 8B SimpleQA/Ollama Artifacts (100, PoR v2)
+
+This directory contains the evidence artifacts referenced by PR #132.
+
+Scope:
+- model: Qwen3 8B (Ollama)
+- dataset: local 100-example SimpleQA batch
+- mode: PoR v2
+
+Interpretation note: treat findings as scoped to this run context, not universal behavior.


### PR DESCRIPTION
### Motivation
- Provide navigation and scoped interpretation for recent local SimpleQA/Ollama evaluation runs and threshold observations.
- Make run artifacts and claim-to-artifact mappings discoverable to reduce misinterpretation of threshold numbers across contexts.
- Surface run-specific README files and links so reports and top-level docs reference the evidence used in recent evaluations.

### Description
- Add `docs/evidence_map.md` to map core claims to artifact files and to reference PR #131/ #132 run directories and summaries.
- Add `docs/threshold_regime_contract.md` to define a scope-aware interpretation of threshold values and to record the Qwen3 4B/8B run statistics for the noted runs.
- Update `README.md`, `docs/README.md`, and `reports/README.md` to include links and a short summary of recent Ollama evidence, and add `results/...` README files for the Qwen3 4B and Qwen3 8B runs.

### Testing
- No automated tests were run because this change is documentation-only.
- No runtime or unit tests were modified by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f491ea838c8326ac80fdfb91c136fa)