### PR TITLE
Docs: streamline wiki pages, add quick links and recent evaluation summaries

### DIFF
--- a/wiki/Evaluation-Summary.md
+++ b/wiki/Evaluation-Summary.md
@@ -1,44 +1,31 @@
 # Evaluation Summary
 
-## What the repository already demonstrates
+This page is a readable summary of recent results. Canonical evidence remains in `docs/` and committed artifacts.
 
-- Multiple repeated runs are committed at different scales and thresholds (`reports/eval_*.jsonl`).
-- In documented safe modes (notably 0.35 and 0.39 operating points), accepted precision/risk capture reached 100% in tracked summaries.
-- Baseline-vs-PoR comparison is visible through `no_control_success` vs `with_control_success` fields and run pages.
-- Drift separation between success/failure cohorts is repeatedly observed in reports and plots.
+## Recent local Ollama evidence (100 SimpleQA examples)
 
-## Why baseline vs PoR matters
+### Qwen3 4B / PoR v2
 
-The project’s core change is release policy:
-- baseline: release by default,
-- PoR: evaluate and decide release.
+- Threshold: `0.43`
+- Answer coverage: `84%`
+- Silence: `16%`
+- Accepted wrong: `0`
+- Accepted precision: `100%`
 
-This makes tradeoffs explicit:
-- lower accepted-risk exposure in safe regimes,
-- at the cost of non-zero silence rate.
+### Qwen3 8B / PoR v2
 
-## Silence rate / coverage tradeoff
+- Threshold: `0.42/0.43`
+- Answer coverage: `93%`
+- Silence: `7%`
+- Accepted wrong: `1`
+- Accepted precision: `98.92%`
 
-In the mapped 1000-task artifacts, silence is explicitly:
-- 46.5% at threshold 0.35 (`eval_run5_1000_threshold_035.jsonl`)
-- 45.6% at threshold 0.39 (`eval_run6_1000_threshold_039.jsonl`)
-- 43.7% at threshold 0.42 (`eval_run5_1000_threshold_042.jsonl`)
-- 45.0% at threshold 0.43 (`eval_run5_1000_threshold_043.jsonl`)
+## Conservative interpretation
 
-This indicates consistent withholding behavior rather than always-output behavior.
-Coverage therefore depends on chosen threshold regime.
+- Qwen3 4B is a practical zero-accepted-failure anchor for that run.
+- Qwen3 8B is a high-coverage boundary, not a zero-failure anchor.
+- A stronger model does not automatically imply safer release behavior at a fixed threshold.
 
-## Evidence discipline
+## Scope note
 
-This summary intentionally follows committed artifacts and run docs.
-It does not claim universal optimality or deployment-complete proof beyond recorded runs.
-
-## Primary evidence files
-
-- `reports/eval_run4_300_threshold_035.jsonl`
-- `reports/eval_run5_1000_threshold_035.jsonl`
-- `reports/eval_run6_1000_threshold_039.jsonl`
-- `reports/eval_run5_1000_threshold_042.jsonl`
-- `reports/eval_run5_1000_threshold_043.jsonl`
-- `wiki/runs/Run_4_300_tasks.md`
-- `wiki/runs/Run_6_1000_tasks.md`
+These statements are run-scoped and repository-scoped. They should not be generalized as universal safety guarantees.

--- a/wiki/Evidence-Map.md
+++ b/wiki/Evidence-Map.md
@@ -1,8 +1,18 @@
 # Evidence Map
 
-Purpose: claim-to-evidence index for what is established, partially established, and pending.
+This wiki page provides a readable navigation layer plus the historical/research evidence-discipline map used in this repository.
 
-Cross-layer signal semantics are defined in `docs/signal_and_threshold_contract.md`. Use that page before comparing thresholds across eval, runtime/API, and deterministic library control layers.
+## Quick links (canonical + recent artifacts)
+
+- [`docs/evidence_map.md`](../docs/evidence_map.md)
+- [`docs/threshold_regime_contract.md`](../docs/threshold_regime_contract.md)
+- [`results/simpleqa_ollama_qwen3_4b_100_v2_retry/`](../results/simpleqa_ollama_qwen3_4b_100_v2_retry/)
+- [`results/simpleqa_ollama_qwen3_8b_100_v2/`](../results/simpleqa_ollama_qwen3_8b_100_v2/)
+- [`reports/README.md`](../reports/README.md)
+
+## Scope note
+
+Use this page for wiki-level navigation and discipline framing. Canonical claim wording remains in `docs/`.
 
 ## Core Thesis Evidence
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,59 +1,30 @@
 # Home
 
-## Silence-as-Control in one paragraph
+## Start here
 
-Silence-as-Control (Proof of Resonance, PoR) is a **runtime release-control layer**.
-It does not change generation weights or decoding. It evaluates a candidate output and decides whether to release it (`PROCEED`) or withhold it (`SILENCE`).
+Read in this order:
 
-Canonical gate logic:
+1. [`README.md`](../README.md)
+2. [`docs/architecture.md`](../docs/architecture.md)
+3. [`docs/threshold_regime_contract.md`](../docs/threshold_regime_contract.md)
+4. [`docs/evidence_map.md`](../docs/evidence_map.md)
+5. [`benchmarks/simpleqa/README.md`](../benchmarks/simpleqa/README.md)
+6. [`reports/README.md`](../reports/README.md)
 
-```text
-if drift > threshold OR coherence < threshold -> SILENCE
-else -> PROCEED
-```
+## Core thesis (short)
 
-Silence is an intentional control outcome, not an error, timeout, or crash.
+Silence-as-Control (Proof of Resonance, PoR) is release control, not generation improvement. A model can generate a candidate, but release is a separate decision: the PoR gate decides `PROCEED` or `SILENCE`.
 
-## Core framing
+## Recent local Ollama evidence (short)
 
-Generation != Authority.
-Release must be earned by stability.
-Either correct, or silent.
-
-## Current project stage
-
-Current stage is:
-
-- post-proof
-- post-threshold-map
-- structured API/runtime path exists
-- pre-external integration proof
+Recent local SimpleQA/Ollama evidence indicates two different operating points: Qwen3 4B is the current zero-accepted-failure anchor in PR #131, while Qwen3 8B is the high-coverage boundary in PR #132.
 
 ## Quick navigation
 
-- [Current Status](Current-Status)
-- [API Walkthrough](API-Walkthrough)
+- [Reading Order](Reading-Order)
 - [Threshold Regimes](Threshold-Regimes)
 - [Evaluation Summary](Evaluation-Summary)
 - [Evidence Map](Evidence-Map)
-- [Reading Order](Reading-Order)
+- [Current Status](Current-Status)
+- [API Walkthrough](API-Walkthrough)
 - [Milestones](Milestones)
-
-## Repository references
-
-- Runtime/API path: `docs/api_walkthrough.md`, `api/main.py`
-- Evaluation artifacts and plots: `reports/`
-- Existing concept and architecture material: `wiki/concepts/`, `wiki/architecture/`
-
-## Signal/threshold contract note
-
-Before comparing thresholds across files, use `docs/signal_and_threshold_contract.md`.
-
-- Evidence canon for reported runs: eval pipeline + `reports/*` + `wiki/runs/*`.
-- Runtime/demo gate: API-local semantics in `api/main.py`.
-- Deterministic library control: tested contract in `src/silence_as_control/control.py`.
-
-## Notes on evidence surface
-
-The repository now includes tracked JSONL run artifacts, run summaries, and visual evidence snapshots in `reports/`.
-These strengthen proof readability, but they do not replace raw artifacts or external audited integration evidence.

--- a/wiki/Reading-Order.md
+++ b/wiki/Reading-Order.md
@@ -1,17 +1,11 @@
 # Reading Order
 
-For a new engineer, use this order:
+A concise path for external readers:
 
-1. `README.md`
-2. [Wiki Home](./Home.md)
-3. [API Walkthrough](./API-Walkthrough.md)
-4. [Threshold Regimes](./Threshold-Regimes.md)
-5. [Evaluation Summary](./Evaluation-Summary.md)
-6. Reports + artifacts (`reports/`, `wiki/runs/`)
-7. Source/runtime surface (`api/`, `src/silence_as_control/`)
-
-## Why this order
-
-- Steps 1-2 establish thesis and stage.
-- Steps 3-5 define runtime path and evaluation interpretation.
-- Steps 6-7 let the reader verify claims in artifacts and implementation.
+1. **First: project landing / thesis** — start with [`README.md`](../README.md) for the project framing and the release-control thesis.
+2. **Second: architecture** — read [`docs/architecture.md`](../docs/architecture.md) for the system structure and control-layer boundaries.
+3. **Third: threshold regimes** — read [`docs/threshold_regime_contract.md`](../docs/threshold_regime_contract.md) for scoped threshold semantics.
+4. **Fourth: evidence map** — read [`docs/evidence_map.md`](../docs/evidence_map.md) for claim-to-evidence boundaries.
+5. **Fifth: benchmark reproduction** — read [`benchmarks/simpleqa/README.md`](../benchmarks/simpleqa/README.md) for benchmark setup and reproduction expectations.
+6. **Sixth: reports/artifacts** — read [`reports/README.md`](../reports/README.md) and inspect `reports/` artifacts for run-level evidence.
+7. **Seventh: experimental features** — read experimental docs only after core claims, starting from [`docs/`](../docs/) pages that explicitly mark extension-layer work.

--- a/wiki/Threshold-Regimes.md
+++ b/wiki/Threshold-Regimes.md
@@ -1,55 +1,27 @@
 # Threshold Regimes
 
-Threshold is an **operational control dial** for release behavior.
-Raising or lowering threshold shifts the safety-vs-coverage profile.
+Thresholds are behavior-control dials for release decisions (`PROCEED` vs `SILENCE`).
 
-## Mapped operating points
+## Regime framing
 
-- **0.35** -> conservative / strict release-control regime
-- **0.39** -> practical safe anchor
-- **0.42** -> transitional / balanced regime where leakage pressure begins to appear
-- **0.43** -> boundary / leakage-visible regime
+Threshold interpretation is scoped to a specific:
 
-These labels summarize observed behavior in committed run artifacts and should be interpreted as repository-scoped evidence, not universal settings.
+- model,
+- dataset,
+- benchmark path,
+- and PoR mode.
 
-## Coverage vs safety tradeoff
+Do not treat these labels as universal settings.
 
-Across mapped runs:
+## Practical regime labels
 
-- Safer settings maintain stronger accepted-output precision and risk capture, but silence more candidates.
-- Transitional and boundary settings recover some coverage, but accepted failures begin to reappear.
+- **0.35**: conservative
+- **0.39**: practical
+- **0.42**: transitional / practical-high-coverage
+- **0.43**: high-coverage boundary
 
-Use threshold operationally:
+## Canonical source
 
-- choose lower-risk profiles for strict release control,
-- then tune for acceptable coverage in the target domain.
+For contract language and canonical interpretation, use:
 
-## Evidence basis
-
-Primary threshold artifacts:
-
-- `reports/eval_run5_1000_threshold_035.jsonl`
-- `reports/eval_run6_1000_threshold_039.jsonl`
-- `reports/eval_run5_1000_threshold_042.jsonl`
-- `reports/eval_run5_1000_threshold_043.jsonl`
-
-Related run context:
-
-- `wiki/runs/Run_4_300_tasks.md`
-- `wiki/runs/Run_6_1000_tasks.md`
-
-Related visual summaries in `reports/`:
-
-- `reports/threshold_control_curve.png`
-- `reports/accepted_failures_comparison.png`
-- `reports/drift_separation_comparison.png`
-
-## Interpretation discipline
-
-This page documents repository-observed operating behavior.
-
-It does **not** establish:
-
-- a universal best threshold,
-- guaranteed transfer across domains,
-- or a one-time calibration that remains correct under all runtime conditions.
+- [`docs/threshold_regime_contract.md`](../docs/threshold_regime_contract.md)


### PR DESCRIPTION
### Motivation

- Clarify project entry points and canonical artifacts so readers follow the intended documentation flow. 
- Surface recent local evaluation metrics and threshold operating points for easier inspection of reported runs. 
- Emphasize scope limits and discipline so readers do not overgeneralize repository-scoped evidence. 

### Description

- Rewrote `wiki/Evaluation-Summary.md` to a concise summary that points to canonical artifacts and records recent Ollama SimpleQA results for Qwen3 4B and 8B with thresholds and coverage metrics like `0.43`/`84%` and `0.42/0.43`/`93%`. 
- Updated `wiki/Evidence-Map.md` to add quick links to canonical docs and results, add a scope note, and reorganize the claim/evidence sections. 
- Simplified `wiki/Home.md` to a clear reading order and a short core thesis, and added a note about recent local evidence referencing specific PR anchors. 
- Reworked `wiki/Reading-Order.md` and `wiki/Threshold-Regimes.md` into a concise, linked reading path and practical regime labels (e.g., `0.35`, `0.39`, `0.42`, `0.43`) while pointing to the canonical `docs/` contracts. 

### Testing

- No automated tests were applicable for this change since it only updates documentation files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4c0c94f208326831515cd5d982c0f)