### PR TITLE
Add minimal external PoR gate CLI with docs, example, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ curl -s http://127.0.0.1:8000/por/complete \
 - Repository root: `./`
 - README: `README.md`
 - Docs index: `docs/README.md`
+- External CLI integration: `docs/external_integration.md`
 - Paper/preprint materials: `paper/README.md`
 - Reports/evidence: `reports/README.md`
 

--- a/docs/external_integration.md
+++ b/docs/external_integration.md
@@ -1,0 +1,57 @@
+# External PoR gate integration (minimal CLI)
+
+This interface is a **release-control integration point**, not a generation-improvement mechanism.
+It evaluates a candidate answer against the existing PoR gate logic and returns a release decision.
+
+The first CLI version supports mode `v1` only. v2-family modes require additional external signals and will be added after the external contract is stable.
+
+## CLI usage
+
+```bash
+python scripts/por_gate_cli.py \
+  --input examples/por_gate_input.json \
+  --output /tmp/por_gate_output.json
+```
+
+Optional overrides:
+
+- `--threshold 0.39` (overrides JSON threshold)
+- `--mode v1` (overrides JSON mode)
+
+## Required input fields
+
+Input JSON must include:
+
+- `prompt` (string)
+- `candidate_answer` (string)
+
+`candidate_samples` is recommended for drift estimation; if missing or empty, the CLI safely falls back to `[candidate_answer]`.
+
+## Optional metadata
+
+`metadata` is optional and audit-facing. Common fields include:
+
+- `model`
+- `source`
+- generation settings like `temperature`, `top_p`, `top_k`
+
+Only `model` and `source` are forwarded into the output audit block by this minimal interface.
+
+## Decision semantics
+
+- `PROCEED`: candidate is releasable under the configured threshold.
+- `SILENCE`: candidate is withheld by release control.
+
+Output includes:
+
+- `decision`
+- `released_output` (string for `PROCEED`, `null` for `SILENCE`)
+- `silence` boolean
+- `signals` (`drift`, `coherence`, `instability`)
+- `audit` metadata
+
+## Threshold and scope
+
+Thresholds are **scoped configuration values** and should be calibrated per model/dataset/pipeline/mode.
+
+This interface does **not** make universal safety claims.

--- a/examples/por_gate_input.json
+++ b/examples/por_gate_input.json
@@ -1,0 +1,18 @@
+{
+  "prompt": "What is the capital of France?",
+  "candidate_answer": "Paris",
+  "candidate_samples": [
+    "Paris",
+    "The capital of France is Paris.",
+    "Paris, France."
+  ],
+  "threshold": 0.39,
+  "mode": "v1",
+  "metadata": {
+    "model": "external-generator-name",
+    "temperature": 0.0,
+    "top_p": null,
+    "top_k": null,
+    "source": "external_pipeline"
+  }
+}

--- a/scripts/por_gate_cli.py
+++ b/scripts/por_gate_cli.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from api.core_primitive import CORE_FIXED_THRESHOLD
+from benchmarks.simpleqa.por_adapter import evaluate_por_gate
+
+DEFAULT_MODE = "v1"
+ALLOWED_MODES = {"v1"}
+
+
+def _load_input(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        payload = json.load(f)
+    if not isinstance(payload, dict):
+        raise ValueError("input JSON must be an object")
+    if "prompt" not in payload or "candidate_answer" not in payload:
+        raise ValueError("input JSON must include 'prompt' and 'candidate_answer'")
+    return payload
+
+
+def _resolve_candidate_samples(payload: dict[str, Any]) -> list[str]:
+    samples = payload.get("candidate_samples")
+    candidate_answer = str(payload.get("candidate_answer", ""))
+
+    if isinstance(samples, list):
+        cleaned = [str(item) for item in samples if str(item).strip()]
+        if cleaned:
+            return cleaned
+    return [candidate_answer]
+
+
+def _resolve_mode(payload: dict[str, Any], mode_override: str | None) -> str:
+    mode = mode_override if mode_override is not None else str(payload.get("mode", DEFAULT_MODE))
+    if mode not in ALLOWED_MODES:
+        allowed = ", ".join(sorted(ALLOWED_MODES))
+        raise ValueError(f"unsupported mode: {mode}. allowed modes: {allowed}")
+    return mode
+
+
+def _build_output(payload: dict[str, Any], threshold_override: float | None, mode_override: str | None) -> dict[str, Any]:
+    prompt = str(payload.get("prompt", ""))
+    candidate_answer = str(payload.get("candidate_answer", ""))
+
+    threshold = (
+        threshold_override
+        if threshold_override is not None
+        else float(payload.get("threshold", CORE_FIXED_THRESHOLD))
+    )
+    mode = _resolve_mode(payload, mode_override)
+
+    candidate_samples = _resolve_candidate_samples(payload)
+
+    evaluation = evaluate_por_gate(
+        prompt=prompt,
+        primary_candidate=candidate_answer,
+        candidate_samples=candidate_samples,
+        threshold=threshold,
+    )
+
+    metadata = payload.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        metadata = {}
+
+    decision = evaluation.por_decision
+    return {
+        "decision": decision,
+        "released_output": candidate_answer if decision == "PROCEED" else None,
+        "silence": decision == "SILENCE",
+        "threshold": evaluation.threshold,
+        "mode": mode,
+        "signals": {
+            "drift": evaluation.drift,
+            "coherence": evaluation.coherence,
+            "instability": evaluation.instability_score,
+        },
+        "audit": {
+            "reason": (
+                "candidate below instability threshold"
+                if decision == "PROCEED"
+                else "candidate exceeded instability threshold"
+            ),
+            "model": metadata.get("model"),
+            "source": metadata.get("source"),
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Minimal external PoR release-gate CLI")
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--threshold", type=float, default=None)
+    parser.add_argument("--mode", default=None)
+    args = parser.parse_args()
+
+    payload = _load_input(args.input)
+    result = _build_output(payload, args.threshold, args.mode)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as f:
+        json.dump(result, f, indent=2)
+        f.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_por_gate_cli.py
+++ b/tests/test_por_gate_cli.py
@@ -1,0 +1,95 @@
+import json
+import subprocess
+import sys
+
+import pytest
+
+from scripts.por_gate_cli import _build_output, _load_input, _resolve_candidate_samples
+
+
+def test_load_input(tmp_path):
+    payload = {"prompt": "p", "candidate_answer": "a"}
+    path = tmp_path / "input.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = _load_input(path)
+    assert loaded == payload
+
+
+def test_output_shape_proceed():
+    payload = {
+        "prompt": "Paris",
+        "candidate_answer": "Paris",
+        "candidate_samples": ["Paris", "Paris"],
+        "threshold": 0.39,
+        "mode": "v1",
+        "metadata": {"model": "m", "source": "s"},
+    }
+    out = _build_output(payload, None, None)
+    assert out["decision"] == "PROCEED"
+    assert out["released_output"] == "Paris"
+    assert out["silence"] is False
+    assert out["mode"] == "v1"
+    assert set(out["signals"].keys()) == {"drift", "coherence", "instability"}
+
+
+def test_output_shape_silence():
+    payload = {
+        "prompt": "Explain recursion with Python examples",
+        "candidate_answer": "banana parquet nebula",
+        "candidate_samples": ["banana parquet nebula"],
+        "threshold": 0.01,
+        "mode": "v1",
+        "metadata": {"model": "m", "source": "s"},
+    }
+    out = _build_output(payload, None, None)
+    assert out["decision"] == "SILENCE"
+    assert out["released_output"] is None
+    assert out["silence"] is True
+
+
+def test_missing_candidate_samples_falls_back_to_candidate_answer():
+    payload = {"prompt": "p", "candidate_answer": "a"}
+    samples = _resolve_candidate_samples(payload)
+    assert samples == ["a"]
+
+
+def test_cli_writes_output_json(tmp_path):
+    input_path = tmp_path / "input.json"
+    output_path = tmp_path / "output.json"
+    payload = {
+        "prompt": "Paris",
+        "candidate_answer": "Paris",
+        "threshold": 0.39,
+        "mode": "v1",
+        "metadata": {"model": "m", "source": "s"},
+    }
+    input_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    cmd = [
+        sys.executable,
+        "scripts/por_gate_cli.py",
+        "--input",
+        str(input_path),
+        "--output",
+        str(output_path),
+    ]
+    subprocess.run(cmd, check=True)
+    result = json.loads(output_path.read_text(encoding="utf-8"))
+    assert "decision" in result
+    assert "signals" in result
+
+
+def test_unsupported_modes_are_rejected():
+    payload = {"prompt": "p", "candidate_answer": "a", "mode": "v2"}
+    with pytest.raises(ValueError):
+        _build_output(payload, None, None)
+
+
+
+def test_load_input_rejects_missing_required_fields(tmp_path):
+    path = tmp_path / "input.json"
+    path.write_text(json.dumps({"prompt": "p"}), encoding="utf-8")
+    with pytest.raises(ValueError, match="input JSON must include 'prompt' and 'candidate_answer'"):
+        _load_input(path)
+


### PR DESCRIPTION
### Motivation
- Provide a minimal, auditable external integration point for the PoR release gate so external pipelines can evaluate candidate outputs without embedding gate logic. 
- Document a simple CLI contract and example payload to make it straightforward to adopt the release-control interface. 
- Add tests to ensure the CLI shape and basic decision semantics are stable and well-specified. 

### Description
- Add a minimal CLI entrypoint `scripts/por_gate_cli.py` that loads an input JSON, calls `evaluate_por_gate`, and writes a structured decision JSON with `decision`, `released_output`, `signals`, and `audit` fields. 
- Add integration docs `docs/external_integration.md` describing usage, required fields, decision semantics, and optional metadata, and add a small example payload at `examples/por_gate_input.json`. 
- Update `README.md` to reference the new external integration docs. 
- Add unit tests in `tests/test_por_gate_cli.py` covering input validation, candidate-sample fallback behavior, `PROCEED`/`SILENCE` outputs, unsupported modes, and end-to-end CLI invocation. 

### Testing
- Ran the new unit tests with `pytest tests/test_por_gate_cli.py` and the suite passed. 
- Tests validate `_load_input`, `_resolve_candidate_samples`, `_build_output`, CLI file output, and rejection of unsupported modes. 
- End-to-end CLI invocation test confirmed the script writes a well-formed output JSON containing `decision` and `signals`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5b873463c8326872aed42c13ee3f6)