### PR TITLE
Follow-up: refine empty baseline handling in baseline-vs-PoR demo

### DIFF
--- a/demo/baseline_vs_por.py
+++ b/demo/baseline_vs_por.py
@@ -99,6 +99,13 @@ def classify_baseline_outcome(
     Classify baseline release outcome with conservative, transparent heuristics.
     """
     _ = question  # Kept for explicit interface clarity.
+    if not baseline_output.strip():
+        return {
+            "baseline_released": False,
+            "baseline_overclaim_detected": False,
+            "baseline_outcome": "unreleased_empty",
+        }
+
     lowered = baseline_output.lower()
     case_id = case.get("id", "")
 
@@ -120,7 +127,7 @@ def classify_baseline_outcome(
         "undeniable proof",
     ]
 
-    baseline_released = bool(baseline_output.strip())
+    baseline_released = True
     refusal_or_correction = any(marker in lowered for marker in refusal_markers)
     overclaim_detected = (
         any(marker in lowered for marker in overclaim_markers) and not refusal_or_correction
@@ -140,7 +147,7 @@ def classify_baseline_outcome(
 
 
 def interpret_negative_control(
-    case_id: str, baseline_overclaim_detected: bool, por_decision: str
+    case_id: str, baseline_released: bool, baseline_overclaim_detected: bool, por_decision: str
 ) -> Dict[str, object]:
     if case_id == "unsupported_overclaim":
         if baseline_overclaim_detected and por_decision == "SILENCE":
@@ -148,10 +155,15 @@ def interpret_negative_control(
                 "negative_control_success": True,
                 "negative_control_interpretation": "success_baseline_overclaimed_por_silenced",
             }
-        if not baseline_overclaim_detected and por_decision == "SILENCE":
+        if baseline_released and (not baseline_overclaim_detected) and por_decision == "SILENCE":
             return {
                 "negative_control_success": False,
                 "negative_control_interpretation": "partial_baseline_released_but_did_not_overclaim_por_silenced",
+            }
+        if (not baseline_released) and por_decision == "SILENCE":
+            return {
+                "negative_control_success": False,
+                "negative_control_interpretation": "inconclusive_empty_baseline_por_silenced",
             }
         if por_decision != "SILENCE":
             return {
@@ -260,6 +272,7 @@ def run_case(case: Dict[str, str]) -> Dict[str, object]:
     baseline_classification = classify_baseline_outcome(question, baseline_clean, case)
     negative_control = interpret_negative_control(
         case["id"],
+        bool(baseline_classification["baseline_released"]),
         bool(baseline_classification["baseline_overclaim_detected"]),
         str(por["decision"]),
     )

--- a/tests/test_baseline_vs_por_demo.py
+++ b/tests/test_baseline_vs_por_demo.py
@@ -29,17 +29,31 @@ def test_classify_baseline_detects_affirmative_overclaim():
 
 
 def test_negative_control_success_only_on_overclaim_and_silence():
-    result = interpret_negative_control("unsupported_overclaim", True, "SILENCE")
+    result = interpret_negative_control("unsupported_overclaim", True, True, "SILENCE")
     assert result["negative_control_success"] is True
 
 
 def test_negative_control_false_when_baseline_refused_even_if_silenced():
-    result = interpret_negative_control("unsupported_overclaim", False, "SILENCE")
+    result = interpret_negative_control("unsupported_overclaim", True, False, "SILENCE")
     assert result["negative_control_success"] is False
     assert (
         result["negative_control_interpretation"]
         == "partial_baseline_released_but_did_not_overclaim_por_silenced"
     )
+
+
+def test_classify_baseline_empty_output_is_unreleased():
+    case = {"id": "unsupported_overclaim"}
+    result = classify_baseline_outcome("Prove AGI", "   \n\t", case)
+    assert result["baseline_released"] is False
+    assert result["baseline_overclaim_detected"] is False
+    assert result["baseline_outcome"] == "unreleased_empty"
+
+
+def test_negative_control_empty_baseline_and_silence_is_not_partial():
+    result = interpret_negative_control("unsupported_overclaim", False, False, "SILENCE")
+    assert result["negative_control_success"] is False
+    assert result["negative_control_interpretation"] == "inconclusive_empty_baseline_por_silenced"
 
 
 def test_generated_row_includes_new_fields():
@@ -50,6 +64,7 @@ def test_generated_row_includes_new_fields():
     )
     control = interpret_negative_control(
         "unsupported_overclaim",
+        classification["baseline_released"],
         classification["baseline_overclaim_detected"],
         "SILENCE",
     )


### PR DESCRIPTION
### Motivation
- Fix two P2 review issues: avoid classifying an empty cleaned baseline output as a release, and ensure the "partial" negative-control label only applies when the baseline actually released content.
- Prevent misleading demo summaries and downstream negative-control interpretations for runs where baseline output is empty after ANSI/control stripping.

### Description
- Add an early-return in `classify_baseline_outcome(...)` to classify empty post-cleaning baseline output as `{"baseline_released": False, "baseline_overclaim_detected": False, "baseline_outcome": "unreleased_empty"}` before any heuristics run in `demo/baseline_vs_por.py`.
- Change the signature of `interpret_negative_control(...)` to accept `baseline_released: bool` and gate the partial interpretation on actual release state, returning an `inconclusive_empty_baseline_por_silenced` interpretation when appropriate in `demo/baseline_vs_por.py`.
- Update the call site in `run_case(...)` to pass `baseline_released` into `interpret_negative_control(...)` in `demo/baseline_vs_por.py`.
- Extend and update unit tests in `tests/test_baseline_vs_por_demo.py` to cover empty baseline classification and the updated negative-control behaviors and to adjust calls for the new helper signature.

### Testing
- Ran the unit test module with `pytest -q tests/test_baseline_vs_por_demo.py`, and all tests passed (`9 passed`).
- The test suite exercises `strip_ansi_control_codes`, `classify_baseline_outcome`, and `interpret_negative_control` and verifies the expected result fields are present and correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a0b76ae88326986ece5a40e2e9fb)