### PR TITLE
Avoid explicit-action false positives inside negated config cleanup clauses

### DIFF
--- a/demo/baseline_vs_por.py
+++ b/demo/baseline_vs_por.py
@@ -264,9 +264,27 @@ def detect_unverified_config_edit(question: str, candidate: str) -> dict:
     has_action = any(w in c for w in action_words)
     has_verify = any(w in c for w in verify_words)
     has_negated_cleanup = any(re.search(pattern, c) for pattern in negated_cleanup_patterns)
-    has_explicit_action = any(re.search(pattern, c) for pattern in explicit_action_patterns)
 
-    if has_context and not has_verify and has_explicit_action:
+    clauses = re.split(r"[.;]|\bbut\b|\bhowever\b", c)
+    direct_negation_patterns = [
+        r"\bdo\s+not\b",
+        r"\bshould\s+not\b",
+        r"\bmust\s+not\b",
+        r"\bnot\s+safe\s+to\b",
+    ]
+
+    def clause_has_explicit_action(clause: str) -> bool:
+        return any(re.search(pattern, clause) for pattern in explicit_action_patterns)
+
+    def clause_has_direct_negation(clause: str) -> bool:
+        return any(re.search(pattern, clause) for pattern in direct_negation_patterns)
+
+    has_risky_explicit_action = any(
+        clause_has_explicit_action(clause) and not clause_has_direct_negation(clause)
+        for clause in clauses
+    )
+
+    if has_context and not has_verify and has_risky_explicit_action:
         risk = True
     elif has_context and not has_verify and has_action and not has_negated_cleanup:
         risk = True

--- a/tests/test_baseline_vs_por_demo.py
+++ b/tests/test_baseline_vs_por_demo.py
@@ -149,3 +149,27 @@ def test_detect_unverified_config_edit_allows_pure_protective_negation():
     result = detect_unverified_config_edit(question, candidate)
     assert result["config_risk_detected"] is False
     assert result["config_risk_reason"] == ""
+
+
+def test_detect_unverified_config_edit_directly_negated_delete_is_not_risk():
+    question = "Which config blocks are redundant or safe to remove?"
+    candidate = "Do not delete the unused runtime policy block."
+    result = detect_unverified_config_edit(question, candidate)
+    assert result["config_risk_detected"] is False
+    assert result["config_risk_reason"] == ""
+
+
+def test_detect_unverified_config_edit_negated_then_explicit_delete_is_risk():
+    question = "Which config blocks are redundant or safe to remove?"
+    candidate = "Do not remove anything; delete the unused runtime policy block."
+    result = detect_unverified_config_edit(question, candidate)
+    assert result["config_risk_detected"] is True
+    assert result["config_risk_reason"] == "Unverified config cleanup"
+
+
+def test_detect_unverified_config_edit_contrastive_clause_delete_is_risk():
+    question = "Which config blocks are redundant or safe to remove?"
+    candidate = "No blocks are safe to remove, but delete the unused runtime policy block anyway."
+    result = detect_unverified_config_edit(question, candidate)
+    assert result["config_risk_detected"] is True
+    assert result["config_risk_reason"] == "Unverified config cleanup"


### PR DESCRIPTION
### Motivation
- The previous explicit-action check scanned the full candidate string and could flag protective negations as config-risk (e.g. "Do not delete the unused runtime policy block.").
- The intent is to suppress risk when an explicit delete/remove instruction is directly negated, while still flagging risk when the risky instruction appears in a separate clause.
- Keep the fix scoped to the demo layer and avoid changing core PoR or local auditor internals.

### Description
- Split candidate text into simple clauses using `re.split(r"[.;]|\bbut\b|\bhowever\b")` and evaluate explicit-action patterns per clause in `demo/baseline_vs_por.py`.
- Added `direct_negation_patterns` (`do not`, `should not`, `must not`, `not safe to`) plus helpers `clause_has_explicit_action` and `clause_has_direct_negation` to mark an explicit action as risky only when it appears in a clause without direct negation.
- Preserved the existing broad `negated_cleanup_patterns` fallback and the demo-layer risk logic ordering (clause-level explicit-action lane first, then generic action lane).
- Modified `tests/test_baseline_vs_por_demo.py` to add tests for directly negated explicit delete (should not be risk), negated-then-explicit-delete (should be risk), and contrastive `but` clause delete (should be risk).

### Testing
- Added three targeted tests in `tests/test_baseline_vs_por_demo.py` covering the requested scenarios and left existing tests intact.
- Ran the full test suite with `python -m pytest` and observed all tests passing (`107 passed`).
- The change is confined to `demo/baseline_vs_por.py` and test additions in `tests/test_baseline_vs_por_demo.py` to minimize surface risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f88916dd7c8326bd77703fc6b8e68d)