### PR TITLE
Add donate page

### DIFF
--- a/DONATE.md
+++ b/DONATE.md
@@ -1,0 +1,9 @@
+# Support Silence-as-Control
+
+Silence-as-Control adds a release-control layer for large language models.
+
+If you find this project useful, please consider supporting continued development.
+
+```text
+TJmrrUrpsRpG3u9H4FE9oVyCRPYQYEpG27
+```


### PR DESCRIPTION
### Motivation
- Add a simple donation page so users can support continued development of Silence-as-Control by providing a clear place to find the TRC-20 wallet address.

### Description
- Created `DONATE.md` at the repository root containing the heading “Support Silence‑as‑Control”, a short description that the project adds a release-control layer for large language models, an invitation to support continued development, and the TRC‑20 address in a fenced code block; committed with message `Add donate page` and no other files were modified.

### Testing
- Ran `git add`/`git commit` and inspected the file with `nl -ba DONATE.md`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8b5c57dd08326a168f85dde8c23bf)