### PR TITLE
Add LangChain release-gate adapter, docs, and tests

### DIFF
--- a/docs/langchain_release_gate.md
+++ b/docs/langchain_release_gate.md
@@ -1,0 +1,34 @@
+# LangChain release-gate adapter (PoR integration layer)
+
+This adapter is a minimal integration layer that makes PoR release control usable with a LangChain-style object exposing `.invoke(input)`.
+
+## Core framing
+
+- **Generation is not release.**
+- The wrapped LangChain object produces a candidate.
+- PoR evaluates instability and decides `PROCEED` or `SILENCE`.
+- Optional config-risk detection can escalate a core `PROCEED` into `NEEDS_REVIEW`.
+
+## Scope
+
+This adapter does **not** modify:
+
+- PoR core primitive behavior.
+- Threshold regime logic.
+- Benchmark logic, reports, or evidence outputs.
+
+It is strictly an integration/deployment wrapper.
+
+The config-risk detector is intentionally integration-layer logic: it catches actionable config/approval/policy removal advice, can escalate a core `PROCEED` into `NEEDS_REVIEW`, and does not change PoR core scoring.
+
+## Behavior summary
+
+`PoRLangChainReleaseGate.invoke(input_data)`:
+
+1. calls `chain.invoke(input_data)` to get a candidate,
+2. stringifies input and candidate for scoring,
+3. computes drift/coherence and core instability decision,
+4. returns:
+   - `SILENCE` with `released=False` when unstable,
+   - `NEEDS_REVIEW` with `released=False` when config-removal risk is detected,
+   - `PROCEED` with `released=True` and output otherwise.

--- a/integrations/langchain_release_gate.py
+++ b/integrations/langchain_release_gate.py
@@ -1,0 +1,155 @@
+"""LangChain-compatible PoR release gate adapter.
+
+Integration-layer utility: generation creates a candidate; PoR decides release.
+"""
+
+from __future__ import annotations
+
+import re
+
+from api.core_primitive import compute_instability_score, fixed_threshold_release_decision
+from api.main import SILENCE_TOKEN
+from api.por_runtime import estimate_coherence, estimate_drift
+
+
+class PoRLangChainReleaseGate:
+    """Wrap a chain-like object with `.invoke(input)` behind PoR release control."""
+
+    def __init__(self, chain, threshold: float = 0.39, enable_config_risk_detection: bool = True):
+        self.chain = chain
+        self.threshold = max(0.0, min(float(threshold), 1.0))
+        self.enable_config_risk_detection = enable_config_risk_detection
+
+    def invoke(self, input_data):
+        candidate = self.chain.invoke(input_data)
+        prompt_text = self._stringify(input_data)
+        candidate_text = self._stringify(candidate)
+
+        drift, drift_notes = estimate_drift([candidate_text])
+        coherence, coherence_notes = estimate_coherence(prompt_text, candidate_text)
+        instability = compute_instability_score(drift=drift, coherence=coherence)
+        decision = fixed_threshold_release_decision(instability, self.threshold)
+
+        notes = drift_notes + coherence_notes
+        if decision == "SILENCE":
+            return {
+                "decision": "SILENCE",
+                "released": False,
+                "output": None,
+                "silence_token": SILENCE_TOKEN,
+                "threshold": self.threshold,
+                "instability_score": round(instability, 4),
+                "drift": round(drift, 4),
+                "coherence": round(coherence, 4),
+                "notes": notes,
+            }
+
+        if self.enable_config_risk_detection and self._has_config_removal_risk(candidate_text):
+            return {
+                "decision": "NEEDS_REVIEW",
+                "released": False,
+                "output": None,
+                "silence_token": None,
+                "threshold": self.threshold,
+                "instability_score": round(instability, 4),
+                "drift": round(drift, 4),
+                "coherence": round(coherence, 4),
+                "notes": notes + ["config_risk_detected"],
+            }
+
+        return {
+            "decision": "PROCEED",
+            "released": True,
+            "output": candidate,
+            "silence_token": None,
+            "threshold": self.threshold,
+            "instability_score": round(instability, 4),
+            "drift": round(drift, 4),
+            "coherence": round(coherence, 4),
+            "notes": notes,
+        }
+
+    @staticmethod
+    def _stringify(value) -> str:
+        if isinstance(value, str):
+            return value
+        return str(value)
+
+    @staticmethod
+    def _has_config_removal_risk(text: str) -> bool:
+        lowered = text.lower()
+        clauses = [c.strip() for c in re.split(r"[.;]|\bbut\b|\bhowever\b", lowered) if c.strip()]
+
+        removal_verbs = (
+            "remove",
+            "delete",
+            "drop",
+            "disable",
+            "strip",
+            "omit",
+            "eliminate",
+            "discard",
+            "clean up",
+            "cleanup",
+        )
+        config_terms = (
+            "config",
+            "configuration",
+            "approval",
+            "approvals",
+            "policy",
+            "policies",
+            "runtime",
+            "tool",
+            "tools",
+            "yaml",
+            "toml",
+            "ini",
+            "block",
+            "section",
+        )
+        negated_removal_phrases = (
+            "do not remove",
+            "don't remove",
+            "should not remove",
+            "must not remove",
+            "never remove",
+            "avoid removing",
+            "not safe to remove",
+            "not recommended to remove",
+            "not advisable to remove",
+        )
+        verify_terms = ("verify", "check", "confirm", "test", "ensure", "validate")
+
+        implicit_cleanup_patterns = (
+            "redundant approval block",
+            "unused approval policy",
+            "orphaned config section",
+            "safe to remove approvals",
+        )
+        implicit_negations = (
+            "not redundant",
+            "not unused",
+            "no redundant blocks",
+            "none are redundant",
+            "none of the approval blocks are redundant",
+            "not safe to remove",
+        )
+
+        for clause in clauses:
+            has_removal_verb = any(verb in clause for verb in removal_verbs)
+            has_config_term = any(term in clause for term in config_terms)
+
+            if has_removal_verb and has_config_term:
+                if any(phrase in clause for phrase in negated_removal_phrases):
+                    continue
+                if any(re.search(rf"\b{re.escape(term)}\b", clause) for term in verify_terms):
+                    continue
+                return True
+
+            if any(pattern in clause for pattern in implicit_cleanup_patterns):
+                if any(neg in clause for neg in implicit_negations):
+                    continue
+                return True
+
+        return False

--- a/tests/test_langchain_release_gate.py
+++ b/tests/test_langchain_release_gate.py
@@ -1,0 +1,76 @@
+from integrations.langchain_release_gate import PoRLangChainReleaseGate
+
+
+class FakeChain:
+    def __init__(self, output):
+        self.output = output
+
+    def invoke(self, input_data):
+        return self.output
+
+
+def _run_gate(candidate: str) -> dict:
+    gate = PoRLangChainReleaseGate(
+        chain=FakeChain(candidate),
+        threshold=1.0,
+        enable_config_risk_detection=True,
+    )
+    return gate.invoke("How to speed up deploy?")
+
+
+def test_safe_candidate_proceeds():
+    gate = PoRLangChainReleaseGate(
+        chain=FakeChain("python list comprehension syntax"),
+        threshold=1.0,
+    )
+
+    result = gate.invoke("python list comprehension syntax")
+
+    assert result["decision"] == "PROCEED"
+    assert result["released"] is True
+    assert result["output"] == "python list comprehension syntax"
+
+
+def test_unstable_candidate_is_silenced():
+    gate = PoRLangChainReleaseGate(
+        chain=FakeChain("totally unrelated cooking recipe"),
+        threshold=0.05,
+    )
+
+    result = gate.invoke("explain matrix multiplication")
+
+    assert result["decision"] == "SILENCE"
+    assert result["released"] is False
+    assert result["output"] is None
+
+
+def test_config_risk_cases_become_needs_review():
+    risky_candidates = [
+        "You should remove config validation to bypass checks.",
+        "Remove the approval block.",
+        "Delete the unused approval policy.",
+        "Drop the runtime policy block.",
+        "Remove [approvals.shell] and [approvals.file_search].",
+        "Do not remove the approval block, but remove the unused runtime policy.",
+    ]
+
+    for candidate in risky_candidates:
+        result = _run_gate(candidate)
+        assert result["decision"] == "NEEDS_REVIEW"
+        assert result["released"] is False
+        assert result["output"] is None
+
+
+def test_negated_or_verification_statements_do_not_trigger_needs_review():
+    safe_candidates = [
+        "Do not remove config validation; keep checks enabled.",
+        "The approval blocks are not redundant.",
+        "None of the approval blocks are redundant.",
+        "Verify runtime lookup before removing approval blocks.",
+        "Remove unused imports.",
+    ]
+
+    for candidate in safe_candidates:
+        result = _run_gate(candidate)
+        assert result["decision"] == "PROCEED"
+        assert result["released"] is True


### PR DESCRIPTION
### Motivation

- Provide a minimal integration layer so PoR release control can be applied to LangChain-style objects exposing `.invoke(input)`.
- Detect unsafe configuration-removal suggestions at the integration layer and escalate `PROCEED` to `NEEDS_REVIEW` while leaving PoR core scoring unchanged.

### Description

- Add `PoRLangChainReleaseGate` in `integrations/langchain_release_gate.py` that wraps a `chain` and calls `chain.invoke(input)` before running PoR checks and returning a structured decision payload.
- Compute drift and coherence via `estimate_drift` and `estimate_coherence`, compute instability with `compute_instability_score`, and apply `fixed_threshold_release_decision` using a `threshold` (default `0.39`) to decide `SILENCE` or `PROCEED`.
- Implement an integration-layer config-risk detector `_has_config_removal_risk` that heuristically flags removal/delete language around config/approval/policy terms and causes `NEEDS_REVIEW` when enabled.
- Add documentation `docs/langchain_release_gate.md` describing the adapter purpose, scope, and behavior summary.

### Testing

- Add unit tests in `tests/test_langchain_release_gate.py` exercising `PROCEED`, `SILENCE`, `NEEDS_REVIEW`, and negation/verification cases via a `FakeChain` mock.
- Ran the test suite for the new tests with `pytest tests/test_langchain_release_gate.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9bbd165348326875f4a525e303a6d)