### PR TITLE
Fix benchmark import path and reduce LangChain release-gate false positives

### DIFF
--- a/benchmarks/langchain_openai/run_langchain_openai_por.py
+++ b/benchmarks/langchain_openai/run_langchain_openai_por.py
@@ -8,9 +8,14 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from integrations.langchain_release_gate import PoRLangChainReleaseGate
 

--- a/integrations/langchain_release_gate.py
+++ b/integrations/langchain_release_gate.py
@@ -127,7 +127,6 @@ class PoRLangChainReleaseGate:
                 "skip validation",
                 "skip checks",
                 "shard a",
-                "consistency checks",
             ),
             "unsupported_overclaim_risk_detected": (
                 "guarantee zero downtime",
@@ -144,11 +143,27 @@ class PoRLangChainReleaseGate:
                 notes.append(risk_note)
 
         if "api_mutation_risk_detected" not in notes:
-            has_environment_word = any(word in lowered for word in ("prod", "production"))
-            has_mutation_verb = any(
-                verb in lowered for verb in ("delete", "patch", "update", "mutate", "write", "modify")
+            has_environment_word = bool(re.search(r"\bprod\b", lowered) or re.search(r"\bproduction\b", lowered))
+            has_strong_mutation_verb = any(
+                verb in lowered for verb in ("delete", "patch", "mutate", "write", "modify")
             )
-            if has_environment_word and has_mutation_verb:
+            has_update_data_mutation = "update" in lowered and any(
+                target in lowered
+                for target in (
+                    "record",
+                    "records",
+                    "user",
+                    "users",
+                    "account",
+                    "accounts",
+                    "customer",
+                    "customers",
+                    "subscription",
+                    "subscriptions",
+                    "data",
+                )
+            )
+            if has_environment_word and (has_strong_mutation_verb or has_update_data_mutation):
                 notes.append("api_mutation_risk_detected")
 
         return notes

--- a/tests/test_langchain_release_gate.py
+++ b/tests/test_langchain_release_gate.py
@@ -133,3 +133,42 @@ def test_read_only_production_monitoring_prompt_does_not_trigger_api_mutation_ri
         "Give a read-only checklist for production post-deploy monitoring metrics."
     )
     assert "api_mutation_risk_detected" not in notes
+
+
+def test_product_word_does_not_trigger_production_api_mutation_risk():
+    for candidate in (
+        "Update product documentation.",
+        "Improve product analytics dashboard.",
+    ):
+        notes = PoRLangChainReleaseGate._detect_action_risk_notes(candidate)
+        assert "api_mutation_risk_detected" not in notes
+
+
+def test_production_without_mutation_does_not_trigger_api_mutation_risk():
+    notes = PoRLangChainReleaseGate._detect_action_risk_notes(
+        "Update production deployment config."
+    )
+    assert "api_mutation_risk_detected" not in notes
+
+
+def test_production_with_mutation_triggers_api_mutation_risk():
+    for candidate in (
+        "Patch production customer records directly.",
+        "Delete all inactive users in prod.",
+    ):
+        notes = PoRLangChainReleaseGate._detect_action_risk_notes(candidate)
+        assert "api_mutation_risk_detected" in notes
+
+
+def test_consistency_checks_without_skip_does_not_trigger_partial_update_risk():
+    notes = PoRLangChainReleaseGate._detect_action_risk_notes(
+        "Run consistency checks before rollout."
+    )
+    assert "partial_update_risk_detected" not in notes
+
+
+def test_skip_consistency_checks_triggers_partial_update_risk():
+    notes = PoRLangChainReleaseGate._detect_action_risk_notes(
+        "Skip consistency checks during migration."
+    )
+    assert "partial_update_risk_detected" in notes


### PR DESCRIPTION
### Motivation
- Running `benchmarks/langchain_openai/run_langchain_openai_por.py` from the repository root could raise `ModuleNotFoundError: No module named 'integrations'` because the repo root was not guaranteed on `sys.path` before local imports.
- The environment heuristic in the LangChain release gate treated substrings like "product" as production context and flagged benign phrasing as risky.
- The partial-update detector included the bare phrase "consistency checks" which caused safe recommendations (e.g., "run consistency checks before rollout") to be flagged as risky.

### Description
- Prepend the repository root to `sys.path` in `benchmarks/langchain_openai/run_langchain_openai_por.py` using `ROOT = Path(__file__).resolve().parents[2]` and a `sys.path.insert(0, ...)` before importing `integrations.langchain_release_gate` to eliminate hardcoded paths and import failures.
- Tighten production detection in `integrations/langchain_release_gate.py` by using token-boundary regex checks (`\bprod\b` and `\bproduction\b`) so words like "product" do not match as production.
- Reduce `api_mutation_risk_detected` false positives by requiring either a strong mutation verb (`delete`, `patch`, `mutate`, `write`, `modify`) in the production context or an `update` that targets data terms (e.g., `record`, `user`, `customer`, `data`).
- Remove the standalone "consistency checks" trigger from `partial_update_risk_detected` while preserving skip-oriented phrases like "skip consistency checks" and other explicit partial-update patterns, and add focused regression tests in `tests/test_langchain_release_gate.py`.

### Testing
- Ran `python -m pytest tests/test_langchain_release_gate.py -q` and all tests passed: `16 passed in 1.25s`.
- Ran the benchmark script `python benchmarks/langchain_openai/run_langchain_openai_por.py` and it now exits at the API-key guard (`OPENAI_API_KEY is required`) instead of failing with `ModuleNotFoundError` when run from the repo root.
- Changed files: `benchmarks/langchain_openai/run_langchain_openai_por.py`, `integrations/langchain_release_gate.py`, and `tests/test_langchain_release_gate.py`.
- Scope: these changes are strictly integration/deployment-layer hygiene and address import-path and false-positive detection only, with no modifications to `api/core_primitive.py`, threshold logic, SimpleQA benchmark logic, or PoR core decision semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f8ef335c8326872cd616ff621d18)