### PR TITLE
Add --run-id support to LangChain+OpenAI benchmark outputs

### DIFF
--- a/benchmarks/langchain_openai/run_langchain_openai_por.py
+++ b/benchmarks/langchain_openai/run_langchain_openai_por.py
@@ -6,6 +6,7 @@ It intentionally requires a live OpenAI API key and is not part of CI.
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import sys
@@ -179,7 +180,28 @@ def _compute_summary(rows: list[dict]) -> dict:
     }
 
 
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run manual LangChain + OpenAI PoR action-risk benchmark.")
+    parser.add_argument(
+        "--run-id",
+        default="01",
+        help="Run identifier used in output filenames and report title.",
+    )
+    return parser.parse_args(argv)
+
+
+def _artifact_paths(run_id: str) -> tuple[Path, Path]:
+    reports_dir = Path("reports")
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    jsonl_path = reports_dir / f"langchain_openai_run_{run_id}.jsonl"
+    summary_path = reports_dir / f"langchain_openai_summary_{run_id}.md"
+    return jsonl_path, summary_path
+
+
 def main() -> int:
+    args = _parse_args()
+    run_id = args.run_id
+
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         print("OPENAI_API_KEY is required. This script is manual-only and should not run in CI.")
@@ -192,10 +214,7 @@ def main() -> int:
         print("Missing dependency: langchain_openai. Install it before running this benchmark.")
         return 1
 
-    reports_dir = Path("reports")
-    reports_dir.mkdir(parents=True, exist_ok=True)
-    jsonl_path = reports_dir / "langchain_openai_run_01.jsonl"
-    summary_path = reports_dir / "langchain_openai_summary_01.md"
+    jsonl_path, summary_path = _artifact_paths(run_id)
 
     llm = ChatOpenAI(model=model_name, api_key=api_key, temperature=0)
     gate = PoRLangChainReleaseGate(chain=llm)
@@ -229,7 +248,7 @@ def main() -> int:
     timestamp = datetime.now(timezone.utc).isoformat()
 
     lines = [
-        "# LangChain + OpenAI PoR Action-Risk Benchmark (Run 01)",
+        f"# LangChain + OpenAI PoR Action-Risk Benchmark (Run {run_id})",
         "",
         "This is a small integration/deployment validation benchmark, not a universal safety claim.",
         "",

--- a/tests/test_langchain_openai_benchmark_paths.py
+++ b/tests/test_langchain_openai_benchmark_paths.py
@@ -1,0 +1,30 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+
+MODULE_PATH = Path("benchmarks/langchain_openai/run_langchain_openai_por.py")
+
+
+def _load_module():
+    spec = spec_from_file_location("run_langchain_openai_por", MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_args_defaults_run_id_to_01():
+    module = _load_module()
+    args = module._parse_args([])
+    assert args.run_id == "01"
+
+
+def test_artifact_paths_include_run_id(tmp_path, monkeypatch):
+    module = _load_module()
+    monkeypatch.chdir(tmp_path)
+
+    jsonl_path, summary_path = module._artifact_paths("02_hardened")
+
+    assert jsonl_path == Path("reports/langchain_openai_run_02_hardened.jsonl")
+    assert summary_path == Path("reports/langchain_openai_summary_02_hardened.md")
+    assert Path("reports").is_dir()


### PR DESCRIPTION
### Motivation
- The manual LangChain + OpenAI benchmark always wrote `reports/langchain_openai_run_01.jsonl` and `reports/langchain_openai_summary_01.md` and used the fixed report title `Run 01`, so reruns overwrote the single artifact and made run history confusing.

### Description
- Added lightweight CLI parsing with `argparse` and a `--run-id` argument (default `"01"`) to `benchmarks/langchain_openai/run_langchain_openai_por.py` to preserve backward compatibility when the flag is omitted.
- Factored artifact path creation into `_artifact_paths(run_id)` and used `run_id` to produce `reports/langchain_openai_run_<run_id>.jsonl` and `reports/langchain_openai_summary_<run_id>.md` and to render the markdown heading as `# LangChain + OpenAI PoR Action-Risk Benchmark (Run <run_id>)`.
- Added pure unit tests `tests/test_langchain_openai_benchmark_paths.py` that verify the default `run_id` and the artifact path naming without making any OpenAI API calls.
- Changed files: `benchmarks/langchain_openai/run_langchain_openai_por.py` and `tests/test_langchain_openai_benchmark_paths.py`; no changes were made to PoR core, threshold logic, or SimpleQA logic.

### Testing
- Ran `python -m pytest tests/test_langchain_release_gate.py -q` which succeeded: `16 passed`.
- Ran `python -m pytest tests/test_langchain_openai_benchmark_paths.py -q` which succeeded: `2 passed`.
- Manually invoking the script with `python benchmarks/langchain_openai/run_langchain_openai_por.py --run-id 02_hardened` returns the expected message when `OPENAI_API_KEY` is not set, confirming argument parsing and early API-key gating work as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9fe1518d483269af03dfd9063cd35)