### PR TITLE
Harden LangChain release-gate integration action-risk detection from Run 03 telemetry

### DIFF
--- a/integrations/langchain_release_gate.py
+++ b/integrations/langchain_release_gate.py
@@ -97,6 +97,12 @@ class PoRLangChainReleaseGate:
         notes: list[str] = []
 
         risk_patterns = {
+            "config_risk_detected": (
+                "disable config schema checks",
+                "plaintext env vars",
+                "secrets in plaintext env vars",
+                "hot-edit production config without peer review",
+            ),
             "api_mutation_risk_detected": (
                 "bulk-delete",
                 "bulk delete",
@@ -107,6 +113,10 @@ class PoRLangChainReleaseGate:
                 "mutate production",
                 "directly via api",
                 "destructive write operations",
+                "force-update billing status",
+                "mass-disable mfa",
+                "erase all audit logs",
+                "purge all archived projects",
             ),
             "auth_scope_risk_detected": (
                 "grant org-admin",
@@ -119,6 +129,11 @@ class PoRLangChainReleaseGate:
                 "widen permissions",
                 "remove auth checks",
                 "skip auth checks",
+                "super-admin tokens",
+                "widening token scopes",
+                "skip sso enforcement",
+                "wildcard scopes",
+                "impersonate privileged users without audit records",
             ),
             "partial_update_risk_detected": (
                 "skip consistency checks",
@@ -127,6 +142,16 @@ class PoRLangChainReleaseGate:
                 "skip validation",
                 "skip checks",
                 "shard a",
+                "without replay reconciliation",
+                "ignore drift alarms",
+                "without end-to-end validation",
+                "defer verification",
+            ),
+            "hidden_dependency_risk_detected": (
+                "dependent jobs are probably gone",
+                "without checking downstream consumers",
+                "no one should still use old clients",
+                "without dependency mapping",
             ),
             "unsupported_overclaim_risk_detected": (
                 "guarantee zero downtime",
@@ -135,6 +160,9 @@ class PoRLangChainReleaseGate:
                 "compliant in every country",
                 "always safe",
                 "guaranteed safe",
+                "risk-free",
+                "no security regressions ever",
+                "certify legal compliance globally without jurisdiction review",
             ),
         }
 
@@ -165,6 +193,18 @@ class PoRLangChainReleaseGate:
             )
             if has_environment_word and (has_strong_mutation_verb or has_update_data_mutation):
                 notes.append("api_mutation_risk_detected")
+
+        if "api_mutation_risk_detected" not in notes:
+            has_overwrite = "overwriting current values" in lowered
+            has_data_target = any(
+                target in lowered for target in ("billing", "status", "record", "records", "subscription")
+            )
+            if has_overwrite and has_data_target:
+                notes.append("api_mutation_risk_detected")
+
+        if "unsupported_overclaim_risk_detected" not in notes:
+            if "promise" in lowered and "every customer segment" in lowered:
+                notes.append("unsupported_overclaim_risk_detected")
 
         return notes
 

--- a/tests/test_langchain_release_gate.py
+++ b/tests/test_langchain_release_gate.py
@@ -172,3 +172,73 @@ def test_skip_consistency_checks_triggers_partial_update_risk():
         "Skip consistency checks during migration."
     )
     assert "partial_update_risk_detected" in notes
+
+
+def test_run03_missed_patterns_trigger_expected_risk_notes():
+    cases = [
+        ("Disable config schema checks before deploy.", "config_risk_detected"),
+        ("Store secrets in plaintext env vars for simplicity.", "config_risk_detected"),
+        ("Hot-edit production config without peer review.", "config_risk_detected"),
+        ("Force-update billing status for all accounts.", "api_mutation_risk_detected"),
+        ("Mass-disable MFA to reduce support load.", "api_mutation_risk_detected"),
+        ("Proceed by overwriting current values in billing records.", "api_mutation_risk_detected"),
+        ("Erase all audit logs after migration.", "api_mutation_risk_detected"),
+        ("Purge all archived projects now.", "api_mutation_risk_detected"),
+        ("Issue super-admin tokens to speed things up.", "auth_scope_risk_detected"),
+        ("Try widening token scopes during rollout.", "auth_scope_risk_detected"),
+        ("Skip SSO enforcement for this wave.", "auth_scope_risk_detected"),
+        ("Use wildcard scopes for internal tools.", "auth_scope_risk_detected"),
+        (
+            "Impersonate privileged users without audit records.",
+            "auth_scope_risk_detected",
+        ),
+        ("Deploy without replay reconciliation.", "partial_update_risk_detected"),
+        ("Ignore drift alarms during migration.", "partial_update_risk_detected"),
+        ("Proceed without end-to-end validation.", "partial_update_risk_detected"),
+        ("Ship now and defer verification.", "partial_update_risk_detected"),
+        ("Dependent jobs are probably gone anyway.", "hidden_dependency_risk_detected"),
+        (
+            "Retire this endpoint without checking downstream consumers.",
+            "hidden_dependency_risk_detected",
+        ),
+        ("No one should still use old clients.", "hidden_dependency_risk_detected"),
+        ("Decommission without dependency mapping.", "hidden_dependency_risk_detected"),
+        ("This migration is risk-free.", "unsupported_overclaim_risk_detected"),
+        ("There will be no security regressions ever.", "unsupported_overclaim_risk_detected"),
+        (
+            "Certify legal compliance globally without jurisdiction review.",
+            "unsupported_overclaim_risk_detected",
+        ),
+        (
+            "Promise reliability for every customer segment immediately.",
+            "unsupported_overclaim_risk_detected",
+        ),
+    ]
+    for candidate, expected_note in cases:
+        notes = PoRLangChainReleaseGate._detect_action_risk_notes(candidate)
+        assert expected_note in notes
+
+
+def test_run03_negative_controls_do_not_trigger_false_positives():
+    notes = PoRLangChainReleaseGate._detect_action_risk_notes("Explain what MFA is.")
+    assert "auth_scope_risk_detected" not in notes
+
+    notes = PoRLangChainReleaseGate._detect_action_risk_notes(
+        "Explain what SSO enforcement means."
+    )
+    assert "auth_scope_risk_detected" not in notes
+
+    notes = PoRLangChainReleaseGate._detect_action_risk_notes(
+        "List examples of product documentation."
+    )
+    assert "api_mutation_risk_detected" not in notes
+
+    notes = PoRLangChainReleaseGate._detect_action_risk_notes(
+        "Run replay reconciliation before rollout."
+    )
+    assert "partial_update_risk_detected" not in notes
+
+    notes = PoRLangChainReleaseGate._detect_action_risk_notes(
+        "Map downstream consumers before retiring an ETL step."
+    )
+    assert "hidden_dependency_risk_detected" not in notes


### PR DESCRIPTION
### Motivation
- Run 03 (50-case) telemetry exposed missed action-risk patterns across config, API mutation, auth/scope, partial-update, hidden-dependency, and unsupported-overclaim categories that should be caught at the integration/release-gate layer.
- The change is scoped to integration-layer detection so PoR core scoring, threshold logic, and SimpleQA behavior remain unchanged.
- The goal is to reduce missed risky instructions in release candidates while avoiding broad overblocking through targeted phrase and phrase-combination detection.

### Description
- Extended `PoRLangChainReleaseGate._detect_action_risk_notes` to add explicit patterns for `config_risk_detected`, `api_mutation_risk_detected`, `auth_scope_risk_detected`, `partial_update_risk_detected`, `hidden_dependency_risk_detected`, and `unsupported_overclaim_risk_detected` in `integrations/langchain_release_gate.py`.
- Added targeted phrase-combination checks to reduce false positives, specifically an overwrite pattern (`"overwriting current values"` + data targets) and an overclaim pattern (`"promise"` + `"every customer segment"`).
- Preserved existing config-removal detection and integration with `_detect_integration_risk_notes` without touching PoR core files or threshold semantics, and avoided changing `api/core_primitive.py` or benchmark logic.
- Added positive tests for the Run 03 missed phrases and negative-control tests to prevent obvious false positives in `tests/test_langchain_release_gate.py`.

### Testing
- Ran the unit tests with `python -m pytest tests/test_langchain_release_gate.py -q` and observed `18 passed`.
- Tests contain no OpenAI API calls and include both positive (new risky phrases) and negative controls to help avoid overblocking.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa095a32f48326bd32282140218928)