### PR TITLE
Improve action-risk detection and expand phrase patterns in langchain_release_gate

### DIFF
--- a/integrations/langchain_release_gate.py
+++ b/integrations/langchain_release_gate.py
@@ -96,12 +96,94 @@ class PoRLangChainReleaseGate:
         lowered = text.lower()
         notes: list[str] = []
 
+        api_mutation_verbs = (
+            "overwrite",
+            "rewrite",
+            "force-close",
+            "force close",
+            "reset",
+            "alter",
+            "purge",
+            "update",
+            "disable",
+            "bulk-edit",
+            "bulk edit",
+        )
+        api_mutation_scope_targets = (
+            "all tenants",
+            "all active organizations",
+            "every open invoice",
+            "globally",
+            "all accounts",
+            "every customer record",
+            "all users",
+        )
+        production_mutation_verbs = (
+            "modify",
+            "delete",
+            "patch",
+            "write",
+            "mutate",
+            "update",
+            "alter",
+            "reset",
+            "overwrite",
+            "rewrite",
+        )
+        production_mutation_targets = (
+            "customer record",
+            "customer records",
+            "user record",
+            "user records",
+            "account",
+            "accounts",
+            "subscription",
+            "subscriptions",
+            "billing",
+            "invoice",
+            "invoices",
+            "role mapping",
+            "role mappings",
+            "api key",
+            "api keys",
+            "audit log",
+            "audit logs",
+            "webhook",
+            "webhooks",
+            "payout destination",
+            "payout destinations",
+            "profile data",
+            "queue",
+            "queues",
+        )
+        partner_api_mutation_targets = (
+            "payout destination",
+            "payout destinations",
+            "account",
+            "accounts",
+            "customer",
+            "customers",
+            "credential",
+            "credentials",
+            "setting",
+            "settings",
+        )
+
         risk_patterns = {
             "config_risk_detected": (
                 "disable config schema checks",
                 "plaintext env vars",
                 "secrets in plaintext env vars",
                 "hot-edit production config without peer review",
+                "bypass config guardrails",
+                "accept unknown config keys",
+                "config safety checks can be skipped",
+                "turn off rate-limit config",
+                "staging config validation disabled then copied to prod",
+                "merge unreviewed config overrides directly to main",
+                "deleting approval metadata from deployment config",
+                "default missing config fields silently instead of failing closed",
+                "bypass secret-rotation constraints",
             ),
             "api_mutation_risk_detected": (
                 "bulk-delete",
@@ -117,6 +199,17 @@ class PoRLangChainReleaseGate:
                 "mass-disable mfa",
                 "erase all audit logs",
                 "purge all archived projects",
+                "overwrite subscription tiers across all tenants",
+                "rewrite webhook urls for all active organizations",
+                "force-close every open invoice in prod",
+                "reset user role mappings globally",
+                "alter billing status for all accounts",
+                "purge archived projects immediately using management apis",
+                "update compliance flags on every customer record",
+                "disable notification settings for all users",
+                "bulk-edit payout destinations via partner api",
+                "patch production customer records directly",
+                "delete all inactive users in prod",
             ),
             "auth_scope_risk_detected": (
                 "grant org-admin",
@@ -134,6 +227,16 @@ class PoRLangChainReleaseGate:
                 "skip sso enforcement",
                 "wildcard scopes",
                 "impersonate privileged users without audit records",
+                "relax oauth scopes",
+                "bypassing sso enforcement",
+                "broaden iam roles",
+                "impersonating privileged users",
+                "skip token audience checks",
+                "suppress authorization denials by widening access scopes",
+                "disable step-up authentication for admin actions",
+                "share one elevated credential across multiple automation pipelines",
+                "turn off tenant-level authz checks",
+                "bypass role review and directly elevate support agents",
             ),
             "partial_update_risk_detected": (
                 "skip consistency checks",
@@ -146,12 +249,24 @@ class PoRLangChainReleaseGate:
                 "ignore drift alarms",
                 "without end-to-end validation",
                 "defer verification",
+                "postpone read-path compatibility checks",
+                "skip consistency validation until later",
+                "ignore drift alerts",
+                "skip downstream validation jobs",
+                "without global parity checks",
+                "postpone verification",
+                "reconcile inactive accounts later",
             ),
             "hidden_dependency_risk_detected": (
                 "dependent jobs are probably gone",
                 "without checking downstream consumers",
                 "no one should still use old clients",
                 "without dependency mapping",
+                "without mapping dependent services",
+                "without consumer inventory",
+                "looks unused from recent dashboards",
+                "before checking edge-region dependencies",
+                "investigate downstream impact later",
             ),
             "unsupported_overclaim_risk_detected": (
                 "guarantee zero downtime",
@@ -163,6 +278,15 @@ class PoRLangChainReleaseGate:
                 "risk-free",
                 "no security regressions ever",
                 "certify legal compliance globally without jurisdiction review",
+                "zero risk across every environment",
+                "full legal compliance in every jurisdiction",
+                "security posture can only improve",
+                "perfect uptime regardless of traffic or infrastructure failures",
+                "cannot produce any data inconsistency ever",
+                "absolute guarantee that audit findings will be zero",
+                "universally safe for every integration partner",
+                "no chance of customer-impacting side effects",
+                "permanently eliminates operational incidents",
             ),
         }
 
@@ -171,27 +295,23 @@ class PoRLangChainReleaseGate:
                 notes.append(risk_note)
 
         if "api_mutation_risk_detected" not in notes:
-            has_environment_word = bool(re.search(r"\bprod\b", lowered) or re.search(r"\bproduction\b", lowered))
-            has_strong_mutation_verb = any(
-                verb in lowered for verb in ("delete", "patch", "mutate", "write", "modify")
-            )
-            has_update_data_mutation = "update" in lowered and any(
-                target in lowered
-                for target in (
-                    "record",
-                    "records",
-                    "user",
-                    "users",
-                    "account",
-                    "accounts",
-                    "customer",
-                    "customers",
-                    "subscription",
-                    "subscriptions",
-                    "data",
-                )
-            )
-            if has_environment_word and (has_strong_mutation_verb or has_update_data_mutation):
+            has_required_mutation_verb = any(verb in lowered for verb in api_mutation_verbs)
+            has_high_impact_scope_target = any(target in lowered for target in api_mutation_scope_targets)
+            if has_required_mutation_verb and has_high_impact_scope_target:
+                notes.append("api_mutation_risk_detected")
+
+        if "api_mutation_risk_detected" not in notes:
+            has_production_context = bool(re.search(r"\bprod\b", lowered) or re.search(r"\bproduction\b", lowered))
+            has_production_mutation_verb = any(verb in lowered for verb in production_mutation_verbs)
+            has_sensitive_target = any(target in lowered for target in production_mutation_targets)
+            if has_production_context and has_production_mutation_verb and has_sensitive_target:
+                notes.append("api_mutation_risk_detected")
+
+        if "api_mutation_risk_detected" not in notes:
+            has_partner_api = "partner api" in lowered
+            has_mutation_verb = any(verb in lowered for verb in api_mutation_verbs)
+            has_partner_mutation_target = any(target in lowered for target in partner_api_mutation_targets)
+            if has_partner_api and has_mutation_verb and has_partner_mutation_target:
                 notes.append("api_mutation_risk_detected")
 
         if "api_mutation_risk_detected" not in notes:

--- a/tests/test_langchain_release_gate.py
+++ b/tests/test_langchain_release_gate.py
@@ -242,3 +242,72 @@ def test_run03_negative_controls_do_not_trigger_false_positives():
         "Map downstream consumers before retiring an ETL step."
     )
     assert "hidden_dependency_risk_detected" not in notes
+
+
+def test_run04_targeted_phrase_expansions_trigger_expected_risk_notes():
+    cases = [
+        ("Bypass config guardrails for speed.", "config_risk_detected"),
+        ("Accept unknown config keys during rollout.", "config_risk_detected"),
+        ("Turn off rate-limit config for launch day.", "config_risk_detected"),
+        ("Overwrite subscription tiers across all tenants.", "api_mutation_risk_detected"),
+        ("Reset user role mappings globally.", "api_mutation_risk_detected"),
+        ("Disable notification settings for all users.", "api_mutation_risk_detected"),
+        ("Relax OAuth scopes for this deployment.", "auth_scope_risk_detected"),
+        ("Disable step-up authentication for admin actions.", "auth_scope_risk_detected"),
+        ("Turn off tenant-level authz checks temporarily.", "auth_scope_risk_detected"),
+        ("Postpone read-path compatibility checks until next sprint.", "partial_update_risk_detected"),
+        ("Skip downstream validation jobs and reconcile inactive accounts later.", "partial_update_risk_detected"),
+        ("Proceed without mapping dependent services.", "hidden_dependency_risk_detected"),
+        ("Looks unused from recent dashboards; investigate downstream impact later.", "hidden_dependency_risk_detected"),
+        ("Zero risk across every environment.", "unsupported_overclaim_risk_detected"),
+        ("Perfect uptime regardless of traffic or infrastructure failures.", "unsupported_overclaim_risk_detected"),
+    ]
+    for candidate, expected_note in cases:
+        notes = PoRLangChainReleaseGate._detect_action_risk_notes(candidate)
+        assert expected_note in notes
+
+
+def test_run04_safe_read_only_educational_prompts_do_not_trigger_action_risk_notes():
+    safe_cases = [
+        "What documentation should exist before production changes?",
+        "Summarize blue/green deployments in plain language.",
+        "Summarize immutable infrastructure at a high level.",
+        "Explain production deployment documentation concepts.",
+    ]
+    for candidate in safe_cases:
+        notes = PoRLangChainReleaseGate._detect_action_risk_notes(candidate)
+        assert notes == []
+
+
+def test_run04_production_mutation_fallback_triggers_api_mutation_risk():
+    cases = [
+        "Modify customer records in production.",
+        "Patch user records in prod.",
+        "Rewrite webhook URLs in production.",
+        "Reset role mappings in prod.",
+    ]
+    for candidate in cases:
+        notes = PoRLangChainReleaseGate._detect_action_risk_notes(candidate)
+        assert "api_mutation_risk_detected" in notes
+
+
+def test_run04_partner_api_narrowing_avoids_editorial_false_positive():
+    notes = PoRLangChainReleaseGate._detect_action_risk_notes("Rewrite partner API documentation.")
+    assert "api_mutation_risk_detected" not in notes
+
+    notes = PoRLangChainReleaseGate._detect_action_risk_notes(
+        "Bulk-edit payout destinations via partner API."
+    )
+    assert "api_mutation_risk_detected" in notes
+
+
+def test_run04_production_documentation_prompts_remain_safe():
+    safe_cases = [
+        "Explain production deployment documentation concepts.",
+        "What documentation should exist before production changes?",
+        "Update product documentation.",
+        "Rewrite production documentation.",
+    ]
+    for candidate in safe_cases:
+        notes = PoRLangChainReleaseGate._detect_action_risk_notes(candidate)
+        assert "api_mutation_risk_detected" not in notes


### PR DESCRIPTION
### Motivation
- Reduce false negatives by broadening pattern coverage for dangerous config, API mutation, auth, partial-update, hidden-dependency, and overclaim phrases. 
- Better detect high-impact mutations that target production or partner APIs by recognizing more verbs and scope targets. 
- Avoid editorial false positives while still catching nuanced risky phrasings that were previously missed.

### Description
- Added multiple verb and target tuples (`api_mutation_verbs`, `api_mutation_scope_targets`, `production_mutation_verbs`, `production_mutation_targets`, and `partner_api_mutation_targets`) and used them to refine detection logic in `PoRLangChainReleaseGate._detect_action_risk_notes`.
- Expanded the `risk_patterns` dictionary with many additional example phrases for `config_risk_detected`, `api_mutation_risk_detected`, `auth_scope_risk_detected`, `partial_update_risk_detected`, `hidden_dependency_risk_detected`, and `unsupported_overclaim_risk_detected`.
- Implemented a multi-stage `api_mutation_risk_detected` detection flow that checks (1) explicit high-impact mutation verbs + scope targets, (2) production context + mutation verbs + sensitive targets, (3) partner API + mutation verbs + partner targets, and (4) specific overwrite/data-target patterns.
- Added a set of focused tests in `tests/test_langchain_release_gate.py` to validate the new phrase expansions, production/partner handling, and to ensure safe educational/documentation prompts remain non-flagged.

### Testing
- Ran the updated unit tests with `pytest tests/test_langchain_release_gate.py` which exercised the new detection cases and negative controls. 
- All tests in the updated test file passed. 
- No other automated test failures were observed when running the local test selection above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa139cfc1c8326bca4de9287ecef3e)