### PR TITLE
Centralize config and signals, refactor runtime/API, add types, docs and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## Unreleased
+
+- Added centralized configuration helpers for thresholds and runtime tunables.
+- Added shared `DecisionResult` and runtime/demo `compute_signals` utilities.
+- Expanded API/control/runtime tests around boundaries, adaptive thresholds, and
+  error handling.
+- Improved README/wiki organization while preserving benchmark artifacts and
+  existing public behavior.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,37 @@ It does **not** improve model weights. It controls release behavior.
 
 **Same model. Different decision.**
 
+
+## Installation and dependency setup
+
+### From a fresh checkout
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+python -m pip install -e .
+```
+
+### API key guidance
+- The deterministic core and local tests do not require an OpenAI API key.
+- OpenAI-backed demos or live benchmark scripts should read credentials from
+  environment variables such as `OPENAI_API_KEY`.
+- Do not commit API keys, prompt logs containing secrets, or provider tokens.
+
+## Minimal wrapping example
+```python
+from silence_as_control import por_control
+
+candidate = "A candidate answer generated upstream"
+result = por_control(candidate, coherence=0.82, drift=0.15)
+
+if result["status"] == "ok":
+    release_to_user = result["output"]
+else:
+    release_to_user = None  # silence / abstain
+```
+
 ## Use / Integration
 PoR is useful as:
 - a release gate before final LLM output,
@@ -66,14 +97,35 @@ MAYBE_SHORT_REGEN: post-silence boundary-pocket retry.
 
 Code: `api/experimental_recovery.py` + `/por/complete` integration.
 
-## Minimal system diagram
+## Architecture flow diagram
 ```text
-Request
-  -> Candidate Output(s)
-  -> PoR Gate (instability vs threshold)
-  -> PROCEED or SILENCE
-  -> optional MAYBE_SHORT_REGEN (experimental, post-silence only)
+prompt
+  -> candidate generation
+  -> PoR gate
+       -> PROCEED
+       -> NEEDS_REVIEW (where an integration defines a review lane)
+       -> SILENCE
 ```
+
+Generation is not release. The PoR gate is a release-control gate, not a
+generation-improvement method. Guardrails may classify or constrain inputs and
+outputs; Silence-as-Control gates whether a candidate is released.
+
+## Threshold regimes
+
+Threshold defaults are **not universal**. The core/runtime default of `0.39`,
+historical sweep values such as `0.35`, `0.42`, and `0.43`, and benchmark-specific
+settings are meaningful only within their signal regime, model/task mix, and
+evidence protocol. Calibrate thresholds before using them with a new model, a new
+task family, or a new signal source.
+
+The deterministic core rule remains:
+- `I <= τ` -> `PROCEED`
+- `I > τ` -> `SILENCE`
+
+Some integrations may layer a separate `NEEDS_REVIEW` lane. Do not collapse an
+existing tri-state integration into binary behavior unless that integration
+explicitly chooses to do so.
 
 ## Start here
 1. This README (`README.md`)
@@ -138,6 +190,8 @@ curl -s http://127.0.0.1:8000/por/complete \
 - README: `README.md`
 - Docs index: `docs/README.md`
 - External CLI integration: `docs/external_integration.md`
+- Package migration plan: `docs/package_migration_plan.md`
+- Changelog: `CHANGELOG.md`
 - Paper/preprint materials: `paper/README.md`
 - Reports/evidence: `reports/README.md`
 
@@ -145,3 +199,14 @@ curl -s http://127.0.0.1:8000/por/complete \
 - **Paper-core claim**: deterministic fixed-threshold PoR release control.
 - **Runtime extensions**: practical deployment helpers, optional deployment scaffolding.
 - **Experimental features**: MAYBE_SHORT_REGEN, optional and non-core.
+
+## Contributing
+
+Contributions should preserve the architecture split: primitive core, runtime
+behavior, evidence/evaluation surface, demos, documentation/wiki, and
+extension-layer experiments. Keep changes scoped and reversible, avoid modifying
+historical benchmark artifacts, and document any threshold-regime changes with
+evidence.
+
+Before opening a PR, run the focused tests relevant to your change and include
+any environment limitations or skipped checks.

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,5 @@
+"""API package for Silence-as-Control runtime surfaces."""
+
+from api._repo_path import ensure_src_on_path
+
+ensure_src_on_path()

--- a/api/_repo_path.py
+++ b/api/_repo_path.py
@@ -1,0 +1,20 @@
+"""Repository-local import path helpers for direct script execution.
+
+The package is installable via `pip install -e .`, but several benchmark and CLI
+scripts are intentionally runnable directly from a checkout. This helper keeps
+that compatibility for the `src/` package layout without changing benchmark
+semantics.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def ensure_src_on_path() -> None:
+    """Make the repository `src/` directory importable for direct scripts."""
+    src_path = Path(__file__).resolve().parents[1] / "src"
+    src_path_str = str(src_path)
+    if src_path.is_dir() and src_path_str not in sys.path:
+        sys.path.insert(0, src_path_str)

--- a/api/core_primitive.py
+++ b/api/core_primitive.py
@@ -9,7 +9,12 @@ No runtime adaptation or experimental recovery belongs here.
 
 from __future__ import annotations
 
-CORE_FIXED_THRESHOLD = 0.39
+from typing import Literal
+
+from silence_as_control.config import get_core_fixed_threshold
+
+DecisionStatus = Literal["PROCEED", "SILENCE"]
+CORE_FIXED_THRESHOLD = get_core_fixed_threshold()
 
 
 def compute_instability_score(drift: float, coherence: float) -> float:
@@ -21,7 +26,10 @@ def compute_instability_score(drift: float, coherence: float) -> float:
     return max(0.0, min(instability, 1.0))
 
 
-def fixed_threshold_release_decision(instability_score: float, threshold: float) -> str:
+def fixed_threshold_release_decision(
+    instability_score: float,
+    threshold: float,
+) -> DecisionStatus:
     """[CORE] Deterministically return `PROCEED` or `SILENCE`.
 
     Rule: release when instability <= threshold, else silence.

--- a/api/main.py
+++ b/api/main.py
@@ -6,12 +6,17 @@ Layering in this module:
 - EXPERIMENTAL recovery: imported from `api.experimental_recovery`.
 """
 
+from __future__ import annotations
+
 import json
 import logging
-from typing import List, Optional
+from typing import Any, TypedDict
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
+
+from silence_as_control.config import get_legacy_generate_coherence
+from silence_as_control.types import DecisionResult
 
 from api.core_primitive import (
     CORE_FIXED_THRESHOLD,
@@ -43,10 +48,10 @@ SILENCE_TOKEN = "[SILENCE: UNSTABLE OUTPUT BLOCKED]"
 class EvaluateRequest(BaseModel):
     prompt: str
     candidate: str
-    threshold: Optional[float] = None
+    threshold: float | None = None
     use_adaptive_threshold: bool = False
-    recent_drifts: List[float] = Field(default_factory=list)
-    recent_coherences: List[float] = Field(default_factory=list)
+    recent_drifts: list[float] = Field(default_factory=list)
+    recent_coherences: list[float] = Field(default_factory=list)
 
 
 class EvaluateResponse(BaseModel):
@@ -55,37 +60,37 @@ class EvaluateResponse(BaseModel):
     instability_score: float
     threshold: float
     decision: str
-    release_output: Optional[str] = None
-    silence_token: Optional[str] = None
-    notes: List[str]
+    release_output: str | None = None
+    silence_token: str | None = None
+    notes: list[str]
 
 
 class CompleteRequest(BaseModel):
     prompt: str
-    threshold: Optional[float] = None
+    threshold: float | None = None
     use_adaptive_threshold: bool = False
-    recent_drifts: List[float] = Field(default_factory=list)
-    recent_coherences: List[float] = Field(default_factory=list)
+    recent_drifts: list[float] = Field(default_factory=list)
+    recent_coherences: list[float] = Field(default_factory=list)
     model: str = DEFAULT_MODEL
     system_prompt: str = "You are a precise technical assistant."
     temperature: float = 0.0
     drift_samples: int = 3
     enable_experimental_short_regen: bool = True
     # Backward-compatible alias for older clients.
-    enable_short_regen: Optional[bool] = None
+    enable_short_regen: bool | None = None
 
 
 class CompleteResponse(BaseModel):
     model: str
-    candidate: Optional[str] = None
+    candidate: str | None = None
     drift: float
     coherence: float
     instability_score: float
     threshold: float
     decision: str
-    release_output: Optional[str] = None
-    silence_token: Optional[str] = None
-    notes: List[str]
+    release_output: str | None = None
+    silence_token: str | None = None
+    notes: list[str]
 
 
 class LegacyGenerateRequest(BaseModel):
@@ -97,14 +102,25 @@ class LegacyGenerateRequest(BaseModel):
 
 class LegacyGenerateResponse(BaseModel):
     status: str
-    output: Optional[str] = None
-    reason: Optional[str] = None
+    output: str | None = None
+    reason: str | None = None
 
 
-def check_json_validity(prompt: str, candidate: str) -> dict:
+class RuntimeScore(TypedDict):
+    drift: float
+    coherence: float
+    instability_score: float
+    threshold: float
+    decision: str
+    release_output: str | None
+    silence_token: str | None
+    notes: list[str]
+
+
+def check_json_validity(prompt: str, candidate: str) -> dict[str, Any]:
     """[RUNTIME] Enforce JSON validity when prompt explicitly asks for JSON."""
     prompt_lower = prompt.lower()
-    notes: List[str] = []
+    notes: list[str] = []
 
     expects_json = "json" in prompt_lower
 
@@ -136,10 +152,10 @@ def check_json_validity(prompt: str, candidate: str) -> dict:
 
 
 def resolve_runtime_threshold(
-    request_threshold: Optional[float],
+    request_threshold: float | None,
     use_adaptive_threshold: bool,
-    recent_drifts: List[float],
-    recent_coherences: List[float],
+    recent_drifts: list[float],
+    recent_coherences: list[float],
 ) -> float:
     """[RUNTIME] Resolve the threshold used by API runtime decisions.
 
@@ -163,8 +179,8 @@ def score_candidate_runtime(
     prompt: str,
     candidate: str,
     threshold: float,
-    candidate_samples: Optional[List[str]] = None,
-) -> dict:
+    candidate_samples: list[str] | None = None,
+) -> RuntimeScore:
     """[RUNTIME] Score one candidate and apply the core release decision."""
     samples = candidate_samples or [candidate]
     drift, drift_notes = estimate_drift(samples)
@@ -180,7 +196,8 @@ def score_candidate_runtime(
         notes.append("forced_silence_invalid_json")
 
     LOGGER.info(
-        "por_runtime_scoring drift=%.4f coherence=%.4f instability=%.4f threshold=%.4f decision=%s",
+        "por_runtime_scoring "
+        "drift=%.4f coherence=%.4f instability=%.4f threshold=%.4f decision=%s",
         drift,
         coherence,
         instability,
@@ -188,15 +205,22 @@ def score_candidate_runtime(
         decision,
     )
 
+    decision_result = DecisionResult(
+        status=decision,
+        output=candidate if decision == "PROCEED" else None,
+        coherence=round(coherence, 4),
+        drift=round(drift, 4),
+        notes=notes,
+    )
     return {
-        "drift": round(drift, 4),
-        "coherence": round(coherence, 4),
+        "drift": decision_result.drift,
+        "coherence": decision_result.coherence,
         "instability_score": round(instability, 4),
         "threshold": threshold,
-        "decision": decision,
-        "release_output": candidate if decision == "PROCEED" else None,
+        "decision": decision_result.status,
+        "release_output": decision_result.output,
         "silence_token": SILENCE_TOKEN if decision == "SILENCE" else None,
-        "notes": notes,
+        "notes": decision_result.notes,
     }
 
 
@@ -208,7 +232,7 @@ def resolve_experimental_short_regen_flag(req: CompleteRequest) -> bool:
 
 
 @app.get("/health")
-def health() -> dict:
+def health() -> dict[str, str]:
     """Health endpoint for API runtime checks."""
     return {"status": "healthy"}
 
@@ -233,7 +257,7 @@ def evaluate(req: EvaluateRequest) -> EvaluateResponse:
 @app.post("/generate", response_model=LegacyGenerateResponse, response_model_exclude_none=True)
 def legacy_generate(req: LegacyGenerateRequest) -> LegacyGenerateResponse:
     """Backward-compatible legacy endpoint preserved for existing tests/clients."""
-    if req.coherence >= 0.8:
+    if req.coherence >= get_legacy_generate_coherence():
         return LegacyGenerateResponse(
             status="ok",
             output=req.output,
@@ -257,7 +281,7 @@ def complete(req: CompleteRequest) -> CompleteResponse:
         )
 
         sample_count = max(1, req.drift_samples)
-        candidates: List[str] = []
+        candidates: list[str] = []
         for _ in range(sample_count):
             candidates.append(
                 generate_candidate(
@@ -279,7 +303,7 @@ def complete(req: CompleteRequest) -> CompleteResponse:
         # Experimental lane only: MAYBE_SHORT_REGEN is post-silence and non-core.
         if result["decision"] == "SILENCE":
 
-            def _regen_once() -> dict:
+            def _regen_once() -> dict[str, Any]:
                 regen_candidate = generate_candidate(
                     prompt=(
                         "Answer briefly and directly in <= 80 tokens. "

--- a/api/por_runtime.py
+++ b/api/por_runtime.py
@@ -9,20 +9,34 @@ These helpers are deployment-oriented additions around the core primitive:
 
 from __future__ import annotations
 
-import math
-import os
-from hashlib import sha256
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
-from typing import Callable, Iterable, Sequence
+
+from silence_as_control.config import (
+    ADAPTIVE_THRESHOLD_ALPHA_DEFAULT,
+    ADAPTIVE_THRESHOLD_MAXIMUM_DEFAULT,
+    ADAPTIVE_THRESHOLD_MINIMUM_DEFAULT,
+    MAX_EMBEDDING_CHARS_DEFAULT,
+    RUNTIME_EXTENSION_THRESHOLD_DEFAULT,
+    get_max_embedding_chars as resolve_max_embedding_chars,
+    get_runtime_gate_threshold,
+)
+from silence_as_control.signals import (
+    cosine_similarity,
+    is_nonnegative_vector,
+    local_bow_embedding,
+    map_similarity_to_coherence,
+    stable_token_index,
+)
 
 # Runtime extension default. Kept aligned to the core default by default.
-RUNTIME_EXTENSION_DEFAULT_THRESHOLD = 0.39
+RUNTIME_EXTENSION_DEFAULT_THRESHOLD = RUNTIME_EXTENSION_THRESHOLD_DEFAULT
 # Backward-compatible alias.
 RUNTIME_GATE_THRESHOLD_DEFAULT = RUNTIME_EXTENSION_DEFAULT_THRESHOLD
 
 THRESHOLD_ENV_VAR = "POR_RUNTIME_GATE_THRESHOLD"
 MAX_EMBEDDING_CHARS_ENV_VAR = "MAX_EMBEDDING_CHARS"
-DEFAULT_MAX_EMBEDDING_CHARS = 4000
+DEFAULT_MAX_EMBEDDING_CHARS = MAX_EMBEDDING_CHARS_DEFAULT
 EmbeddingFn = Callable[[str], list[float]]
 CUSTOM_EMBEDDING_FN: EmbeddingFn | None = None
 
@@ -31,9 +45,9 @@ CUSTOM_EMBEDDING_FN: EmbeddingFn | None = None
 class AdaptiveThresholdConfig:
     """[RUNTIME] Adaptive-threshold policy parameters."""
 
-    alpha: float = 0.4
-    minimum: float = 0.20
-    maximum: float = 0.80
+    alpha: float = ADAPTIVE_THRESHOLD_ALPHA_DEFAULT
+    minimum: float = ADAPTIVE_THRESHOLD_MINIMUM_DEFAULT
+    maximum: float = ADAPTIVE_THRESHOLD_MAXIMUM_DEFAULT
 
 
 def _clip(value: float, low: float = 0.0, high: float = 1.0) -> float:
@@ -41,30 +55,12 @@ def _clip(value: float, low: float = 0.0, high: float = 1.0) -> float:
 
 
 def _stable_token_index(token: str, dim: int) -> int:
-    """Map token to embedding slot with deterministic hashing.
-
-    Python's built-in `hash()` is process-randomized, so we use SHA-256 and
-    take the first 8 bytes for a stable integer across runs and machines.
-    """
-    digest = sha256(token.encode("utf-8")).digest()
-    return int.from_bytes(digest[:8], byteorder="big") % dim
-
-
-def map_similarity_to_coherence(similarity: float, *, nonnegative_space: bool) -> float:
-    """Convert cosine similarity to coherence in [0, 1] for runtime gating.
-
-    - For nonnegative bag-of-words fallback embeddings, cosine is already in
-      [0, 1], so we only clamp.
-    - For signed embedding spaces, cosine is in [-1, 1], so we map with
-      `(cos + 1) / 2`.
-    """
-    if nonnegative_space:
-        return _clip(similarity)
-    return _clip((similarity + 1.0) / 2.0)
+    """Backward-compatible wrapper around the shared stable token index."""
+    return stable_token_index(token, dim)
 
 
 def _is_nonnegative_vector(vec: Sequence[float]) -> bool:
-    return all(v >= 0.0 for v in vec)
+    return is_nonnegative_vector(vec)
 
 
 def get_runtime_threshold(default: float = RUNTIME_EXTENSION_DEFAULT_THRESHOLD) -> float:
@@ -72,26 +68,12 @@ def get_runtime_threshold(default: float = RUNTIME_EXTENSION_DEFAULT_THRESHOLD) 
 
     Uses `POR_RUNTIME_GATE_THRESHOLD` if set; otherwise returns `default`.
     """
-    raw = os.getenv(THRESHOLD_ENV_VAR)
-    if raw is None:
-        return default
-    try:
-        value = float(raw)
-    except ValueError:
-        return default
-    return _clip(value)
+    return get_runtime_gate_threshold(default)
 
 
 def get_max_embedding_chars(default: int = DEFAULT_MAX_EMBEDDING_CHARS) -> int:
     """[RUNTIME] Resolve max chars for local embedding with safe fallback."""
-    raw = os.getenv(MAX_EMBEDDING_CHARS_ENV_VAR)
-    if raw is None:
-        return default
-    try:
-        value = int(raw)
-    except ValueError:
-        return default
-    return max(1, value)
+    return resolve_max_embedding_chars(default)
 
 
 def _truncate_for_local_embedding(text: str) -> str:
@@ -113,26 +95,7 @@ def get_embedding(text: str) -> list[float]:
     This lightweight fallback keeps offline usage and tests stable.
     Production integrations can inject a stronger embedding function.
     """
-    vec = [0.0] * 64
-    truncated = _truncate_for_local_embedding(text)
-    for token in truncated.lower().split():
-        vec[_stable_token_index(token, len(vec))] += 1.0
-
-    norm = math.sqrt(sum(v * v for v in vec))
-    if norm == 0.0:
-        return vec
-    return [v / norm for v in vec]
-
-
-def cosine_similarity(vec_a: Sequence[float], vec_b: Sequence[float]) -> float:
-    """[RUNTIME] Compute cosine similarity with zero-vector safeguards."""
-    dot = sum(a * b for a, b in zip(vec_a, vec_b))
-    norm_a = math.sqrt(sum(a * a for a in vec_a))
-    norm_b = math.sqrt(sum(b * b for b in vec_b))
-    denom = norm_a * norm_b
-    if denom == 0.0:
-        return 0.0
-    return dot / denom
+    return local_bow_embedding(text)
 
 
 def estimate_coherence(
@@ -154,7 +117,9 @@ def estimate_coherence(
         candidate_vec
     )
     coherence = map_similarity_to_coherence(cos, nonnegative_space=nonnegative_space)
-    notes.append("embedding_cosine_nonnegative" if nonnegative_space else "embedding_cosine")
+    notes.append(
+        "embedding_cosine_nonnegative" if nonnegative_space else "embedding_cosine"
+    )
     return coherence, notes
 
 
@@ -204,7 +169,9 @@ def compute_adaptive_threshold(
         return _clip(base_threshold, config.minimum, config.maximum)
 
     n = min(len(drifts), len(coherences))
-    instabilities = [_clip((drifts[i] + (1.0 - coherences[i])) / 2.0) for i in range(n)]
+    instabilities = [
+        _clip((drifts[i] + (1.0 - coherences[i])) / 2.0) for i in range(n)
+    ]
     mean_instability = sum(instabilities) / len(instabilities)
 
     adapted = base_threshold + config.alpha * (mean_instability - base_threshold)

--- a/docs/package_migration_plan.md
+++ b/docs/package_migration_plan.md
@@ -1,0 +1,28 @@
+# Package Organization Migration Plan
+
+This repository intentionally keeps the current package layout stable for this
+cleanup pass. A forced move into `core/`, `runtime/`, and `experimental/`
+subpackages would risk breaking benchmark scripts, historical import paths, and
+report reproduction workflows.
+
+## Current safe mapping
+
+- Deterministic control logic:
+  - `src/silence_as_control/control.py`
+  - `api/core_primitive.py`
+- Runtime/adaptive extensions:
+  - `api/por_runtime.py`
+  - `src/silence_as_control/signals.py` for shared runtime/demo estimators
+- Experimental recovery:
+  - `api/experimental_recovery.py`
+  - `scripts/short_regen_sandbox.py`
+
+## Future migration approach
+
+1. Add compatibility re-export modules first, for example
+   `silence_as_control.core`, `silence_as_control.runtime`, and
+   `silence_as_control.experimental`.
+2. Move one layer at a time while keeping old imports alive.
+3. Run benchmark-path tests before and after each move.
+4. Do not migrate historical artifacts or reports.
+5. Only remove compatibility imports in a documented major-version change.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,10 @@ dependencies = [
   "fastapi==0.115.12",
   "uvicorn==0.34.0",
   "pydantic==2.11.1",
+  "httpx",
+  "openai",
+  "python-dotenv",
+  "matplotlib",
 ]
 
 [tool.setuptools]

--- a/src/silence_as_control/__init__.py
+++ b/src/silence_as_control/__init__.py
@@ -1,5 +1,23 @@
-"""silence_as_control package."""
+"""silence_as_control public package API."""
 
-from .control import por_control
+from .config import (
+    CONTROL_MAX_DRIFT_DEFAULT,
+    CONTROL_MIN_COHERENCE_DEFAULT,
+    CORE_FIXED_THRESHOLD_DEFAULT,
+    RUNTIME_EXTENSION_THRESHOLD_DEFAULT,
+)
+from .control import CONTROL_MAX_DRIFT, CONTROL_MIN_COHERENCE, por_control
+from .signals import compute_signals
+from .types import DecisionResult
 
-__all__ = ["por_control"]
+__all__ = [
+    "CONTROL_MAX_DRIFT",
+    "CONTROL_MAX_DRIFT_DEFAULT",
+    "CONTROL_MIN_COHERENCE",
+    "CONTROL_MIN_COHERENCE_DEFAULT",
+    "CORE_FIXED_THRESHOLD_DEFAULT",
+    "DecisionResult",
+    "RUNTIME_EXTENSION_THRESHOLD_DEFAULT",
+    "compute_signals",
+    "por_control",
+]

--- a/src/silence_as_control/config.py
+++ b/src/silence_as_control/config.py
@@ -1,0 +1,120 @@
+"""Centralized configuration defaults for Silence-as-Control.
+
+The values here preserve the repository's existing defaults while making the
+runtime knobs easier to audit. Environment variables are optional overrides;
+invalid values fall back to the same sensible defaults instead of changing gate
+semantics implicitly.
+"""
+
+from __future__ import annotations
+
+import os
+
+CORE_FIXED_THRESHOLD_DEFAULT = 0.39
+CONTROL_MIN_COHERENCE_DEFAULT = 0.7
+CONTROL_MAX_DRIFT_DEFAULT = 0.3
+RUNTIME_EXTENSION_THRESHOLD_DEFAULT = CORE_FIXED_THRESHOLD_DEFAULT
+ADAPTIVE_THRESHOLD_ALPHA_DEFAULT = 0.4
+ADAPTIVE_THRESHOLD_MINIMUM_DEFAULT = 0.20
+ADAPTIVE_THRESHOLD_MAXIMUM_DEFAULT = 0.80
+MAX_EMBEDDING_CHARS_DEFAULT = 4000
+LEGACY_GENERATE_COHERENCE_DEFAULT = 0.8
+
+CORE_FIXED_THRESHOLD_ENV_VAR = "POR_CORE_FIXED_THRESHOLD"
+CONTROL_MIN_COHERENCE_ENV_VAR = "POR_CONTROL_MIN_COHERENCE"
+CONTROL_MAX_DRIFT_ENV_VAR = "POR_CONTROL_MAX_DRIFT"
+RUNTIME_GATE_THRESHOLD_ENV_VAR = "POR_RUNTIME_GATE_THRESHOLD"
+ADAPTIVE_THRESHOLD_ALPHA_ENV_VAR = "POR_ADAPTIVE_THRESHOLD_ALPHA"
+ADAPTIVE_THRESHOLD_MINIMUM_ENV_VAR = "POR_ADAPTIVE_THRESHOLD_MINIMUM"
+ADAPTIVE_THRESHOLD_MAXIMUM_ENV_VAR = "POR_ADAPTIVE_THRESHOLD_MAXIMUM"
+MAX_EMBEDDING_CHARS_ENV_VAR = "MAX_EMBEDDING_CHARS"
+LEGACY_GENERATE_COHERENCE_ENV_VAR = "POR_LEGACY_GENERATE_COHERENCE"
+
+
+def _get_float(name: str, default: float) -> float:
+    """Read a float environment override with default-preserving fallback."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+def _get_int(name: str, default: int) -> int:
+    """Read an integer environment override with default-preserving fallback."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def clip_unit_interval(value: float) -> float:
+    """Clamp a numeric threshold/signal value to the [0, 1] interval."""
+    return max(0.0, min(value, 1.0))
+
+
+def get_core_fixed_threshold() -> float:
+    """Resolve the core fixed threshold default without changing its meaning."""
+    return clip_unit_interval(
+        _get_float(CORE_FIXED_THRESHOLD_ENV_VAR, CORE_FIXED_THRESHOLD_DEFAULT)
+    )
+
+
+def get_control_min_coherence() -> float:
+    """Resolve the deterministic control-layer coherence bound."""
+    return clip_unit_interval(
+        _get_float(CONTROL_MIN_COHERENCE_ENV_VAR, CONTROL_MIN_COHERENCE_DEFAULT)
+    )
+
+
+def get_control_max_drift() -> float:
+    """Resolve the deterministic control-layer drift tolerance."""
+    return clip_unit_interval(
+        _get_float(CONTROL_MAX_DRIFT_ENV_VAR, CONTROL_MAX_DRIFT_DEFAULT)
+    )
+
+
+def get_runtime_gate_threshold(default: float = RUNTIME_EXTENSION_THRESHOLD_DEFAULT) -> float:
+    """Resolve the runtime gate threshold override, preserving fixed-threshold semantics."""
+    return clip_unit_interval(_get_float(RUNTIME_GATE_THRESHOLD_ENV_VAR, default))
+
+
+def get_adaptive_threshold_alpha() -> float:
+    """Resolve the runtime adaptive-threshold smoothing factor."""
+    return clip_unit_interval(
+        _get_float(ADAPTIVE_THRESHOLD_ALPHA_ENV_VAR, ADAPTIVE_THRESHOLD_ALPHA_DEFAULT)
+    )
+
+
+def get_adaptive_threshold_minimum() -> float:
+    """Resolve the runtime adaptive-threshold lower bound."""
+    return clip_unit_interval(
+        _get_float(ADAPTIVE_THRESHOLD_MINIMUM_ENV_VAR, ADAPTIVE_THRESHOLD_MINIMUM_DEFAULT)
+    )
+
+
+def get_adaptive_threshold_maximum() -> float:
+    """Resolve the runtime adaptive-threshold upper bound."""
+    return clip_unit_interval(
+        _get_float(ADAPTIVE_THRESHOLD_MAXIMUM_ENV_VAR, ADAPTIVE_THRESHOLD_MAXIMUM_DEFAULT)
+    )
+
+
+def get_max_embedding_chars(default: int = MAX_EMBEDDING_CHARS_DEFAULT) -> int:
+    """Resolve local embedding truncation length for runtime/demo estimators."""
+    return max(1, _get_int(MAX_EMBEDDING_CHARS_ENV_VAR, default))
+
+
+def get_legacy_generate_coherence() -> float:
+    """Resolve the backward-compatible legacy `/generate` coherence cutoff."""
+    return clip_unit_interval(
+        _get_float(
+            LEGACY_GENERATE_COHERENCE_ENV_VAR,
+            LEGACY_GENERATE_COHERENCE_DEFAULT,
+        )
+    )

--- a/src/silence_as_control/control.py
+++ b/src/silence_as_control/control.py
@@ -6,25 +6,49 @@ It is intentionally separate from:
 - runtime/API demo heuristics in api/main.py.
 """
 
+from __future__ import annotations
+
+from typing import Any
+
 from .abstention import control_abstention
+from .config import get_control_max_drift, get_control_min_coherence
+from .types import DecisionResult
 
 
-CONTROL_MIN_COHERENCE = 0.7
-CONTROL_MAX_DRIFT = 0.3
+CONTROL_MIN_COHERENCE = get_control_min_coherence()
+CONTROL_MAX_DRIFT = get_control_max_drift()
 
 
 def por_control(
-    output,
-    coherence,
-    drift,
-    threshold=CONTROL_MIN_COHERENCE,
-    tolerance=CONTROL_MAX_DRIFT,
-):
+    output: str,
+    coherence: float,
+    drift: float,
+    threshold: float = CONTROL_MIN_COHERENCE,
+    tolerance: float = CONTROL_MAX_DRIFT,
+) -> dict[str, Any]:
     """Return output only when deterministic control bounds are satisfied.
 
     `CONTROL_MIN_COHERENCE` and `CONTROL_MAX_DRIFT` are simplified defaults
     intended for environments that do not run multi-sample drift estimation.
     """
     if drift > tolerance or coherence < threshold:
-        return control_abstention()
-    return {"status": "ok", "output": output}
+        result = DecisionResult(
+            status="abstained",
+            output=None,
+            coherence=coherence,
+            drift=drift,
+            notes=["control_abstention"],
+        )
+        payload = control_abstention()
+        payload["status"] = result.status
+        payload["reason"] = result.notes[0]
+        return payload
+
+    result = DecisionResult(
+        status="ok",
+        output=output,
+        coherence=coherence,
+        drift=drift,
+        notes=[],
+    )
+    return {"status": result.status, "output": result.output}

--- a/src/silence_as_control/schema.py
+++ b/src/silence_as_control/schema.py
@@ -4,13 +4,18 @@ from typing import Literal, Union
 
 from pydantic import BaseModel, Field
 
+from silence_as_control.config import (
+    CONTROL_MAX_DRIFT_DEFAULT,
+    CONTROL_MIN_COHERENCE_DEFAULT,
+)
+
 
 class GenerateRequest(BaseModel):
     output: str
     coherence: float
     drift: float
-    threshold: float = Field(default=0.7)
-    tolerance: float = Field(default=0.3)
+    threshold: float = Field(default=CONTROL_MIN_COHERENCE_DEFAULT)
+    tolerance: float = Field(default=CONTROL_MAX_DRIFT_DEFAULT)
 
 
 class OkResponse(BaseModel):

--- a/src/silence_as_control/signals.py
+++ b/src/silence_as_control/signals.py
@@ -1,0 +1,86 @@
+"""Shared runtime/demo signal-estimation utilities.
+
+This module intentionally does not define a universal PoR signal contract.
+Benchmark/eval signal semantics, action-risk telemetry, SimpleQA scoring, and
+LangChain-specific benchmark signals can use distinct contracts and thresholds.
+"""
+
+from __future__ import annotations
+
+import math
+from hashlib import sha256
+from collections.abc import Callable, Sequence
+
+from silence_as_control.config import get_max_embedding_chars
+
+EmbeddingFn = Callable[[str], list[float]]
+
+
+def _clip(value: float, low: float = 0.0, high: float = 1.0) -> float:
+    return max(low, min(value, high))
+
+
+def stable_token_index(token: str, dim: int) -> int:
+    """Map token to a deterministic embedding slot."""
+    digest = sha256(token.encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], byteorder="big") % dim
+
+
+def local_bow_embedding(text: str, *, dim: int = 64) -> list[float]:
+    """Return the deterministic local bag-of-words embedding used by runtime demos."""
+    vec = [0.0] * dim
+    truncated = text[: get_max_embedding_chars()]
+    for token in truncated.lower().split():
+        vec[stable_token_index(token, len(vec))] += 1.0
+
+    norm = math.sqrt(sum(v * v for v in vec))
+    if norm == 0.0:
+        return vec
+    return [v / norm for v in vec]
+
+
+def cosine_similarity(vec_a: Sequence[float], vec_b: Sequence[float]) -> float:
+    """Compute cosine similarity with zero-vector safeguards."""
+    dot = sum(a * b for a, b in zip(vec_a, vec_b))
+    norm_a = math.sqrt(sum(a * a for a in vec_a))
+    norm_b = math.sqrt(sum(b * b for b in vec_b))
+    denom = norm_a * norm_b
+    if denom == 0.0:
+        return 0.0
+    return dot / denom
+
+
+def is_nonnegative_vector(vec: Sequence[float]) -> bool:
+    """Return whether all vector dimensions are nonnegative."""
+    return all(v >= 0.0 for v in vec)
+
+
+def map_similarity_to_coherence(similarity: float, *, nonnegative_space: bool) -> float:
+    """Map cosine similarity into runtime/demo coherence in [0, 1]."""
+    if nonnegative_space:
+        return _clip(similarity)
+    return _clip((similarity + 1.0) / 2.0)
+
+
+def compute_signals(candidate: str, reference: str) -> tuple[float, float]:
+    """Return `(coherence, drift)` for shared runtime/demo signal estimation.
+
+    WARNING: this helper is for shared runtime/demo signal estimation only. It
+    is not a universal PoR signal contract, and must not replace benchmark,
+    evaluation, action-risk telemetry, SimpleQA, or LangChain signal semantics
+    unless those call sites are proven pure duplicates with identical behavior.
+    """
+    if not candidate.strip():
+        return 0.0, 1.0
+
+    candidate_vec = local_bow_embedding(candidate)
+    reference_vec = local_bow_embedding(reference)
+    nonnegative_space = is_nonnegative_vector(candidate_vec) and is_nonnegative_vector(
+        reference_vec
+    )
+    similarity = cosine_similarity(candidate_vec, reference_vec)
+    coherence = map_similarity_to_coherence(
+        similarity,
+        nonnegative_space=nonnegative_space,
+    )
+    return coherence, _clip(1.0 - coherence)

--- a/src/silence_as_control/types.py
+++ b/src/silence_as_control/types.py
@@ -1,0 +1,20 @@
+"""Shared public result types for Silence-as-Control."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class DecisionResult:
+    """Normalized release-control decision result.
+
+    This type is additive: existing dict/Pydantic response shapes remain stable
+    for backward compatibility.
+    """
+
+    status: str
+    output: str | None
+    coherence: float
+    drift: float
+    notes: list[str]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -287,3 +287,11 @@ def test_api_complete_returns_500_on_internal_failure(monkeypatch):
     )
     assert response.status_code == 500
     assert response.json()["detail"] == "por_complete_failed"
+
+
+def test_api_health_endpoint():
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy"}
+

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -27,3 +27,24 @@ def test_boundary_conditions_allow_output():
         "status": "ok",
         "output": "edge",
     }
+
+
+def test_exact_equality_threshold_edges_allow_output():
+    assert por_control("edge", coherence=0.7, drift=0.3) == {
+        "status": "ok",
+        "output": "edge",
+    }
+
+
+def test_boundary_just_beyond_drift_abstains():
+    assert por_control("edge", coherence=0.7, drift=0.3000001) == {
+        "status": "abstained",
+        "reason": "control_abstention",
+    }
+
+
+def test_boundary_just_below_coherence_abstains():
+    assert por_control("edge", coherence=0.6999999, drift=0.3) == {
+        "status": "abstained",
+        "reason": "control_abstention",
+    }

--- a/tests/test_por_runtime.py
+++ b/tests/test_por_runtime.py
@@ -53,6 +53,18 @@ def test_runtime_local_embedding_truncates_by_configured_max_chars(monkeypatch):
     assert vec_b != vec_c
 
 
+def test_runtime_max_embedding_chars_env_overrides_custom_default(monkeypatch):
+    monkeypatch.setenv("MAX_EMBEDDING_CHARS", "7")
+
+    assert por_runtime.get_max_embedding_chars(default=11) == 7
+
+
+def test_runtime_max_embedding_chars_invalid_env_falls_back_to_custom_default(monkeypatch):
+    monkeypatch.setenv("MAX_EMBEDDING_CHARS", "not-an-int")
+
+    assert por_runtime.get_max_embedding_chars(default=11) == 11
+
+
 def test_runtime_estimate_uses_custom_embedding_hook_by_default(monkeypatch):
     calls = {"count": 0}
 
@@ -77,3 +89,29 @@ def test_runtime_explicit_embedding_fn_overrides_custom_hook(monkeypatch):
 
     coherence, _ = por_runtime.estimate_coherence("p", "c", embedding_fn=explicit_embedding)
     assert coherence == 1.0
+
+
+def test_runtime_adaptive_threshold_clips_to_config_bounds():
+    config = por_runtime.AdaptiveThresholdConfig(alpha=1.0, minimum=0.25, maximum=0.50)
+    adapted_high = por_runtime.compute_adaptive_threshold(
+        base_threshold=0.39,
+        recent_drifts=[1.0],
+        recent_coherences=[0.0],
+        config=config,
+    )
+    adapted_low = por_runtime.compute_adaptive_threshold(
+        base_threshold=0.10,
+        recent_drifts=[],
+        recent_coherences=[],
+        config=config,
+    )
+
+    assert adapted_high == 0.50
+    assert adapted_low == 0.25
+
+
+def test_core_release_decision_exact_threshold_equality_proceeds():
+    from api.core_primitive import fixed_threshold_release_decision
+
+    assert fixed_threshold_release_decision(0.42, 0.42) == "PROCEED"
+    assert fixed_threshold_release_decision(0.4200001, 0.42) == "SILENCE"

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,28 @@
+"""Tests for shared runtime/demo signal utilities."""
+
+from silence_as_control.signals import compute_signals
+
+
+def test_compute_signals_returns_bounded_coherence_and_drift():
+    coherence, drift = compute_signals(
+        candidate="recursion is when a function calls itself",
+        reference="explain recursion function calls itself",
+    )
+
+    assert 0.0 <= coherence <= 1.0
+    assert 0.0 <= drift <= 1.0
+    assert drift == 1.0 - coherence
+
+
+def test_compute_signals_identical_text_has_high_coherence_low_drift():
+    coherence, drift = compute_signals("alpha beta", "alpha beta")
+
+    assert coherence > 0.95
+    assert drift < 0.05
+
+
+def test_compute_signals_empty_candidate_is_maximally_unstable():
+    coherence, drift = compute_signals("   ", "alpha beta")
+
+    assert coherence == 0.0
+    assert drift == 1.0

--- a/wiki/API-Walkthrough.md
+++ b/wiki/API-Walkthrough.md
@@ -47,3 +47,16 @@ Current documented endpoints in this repository:
 See:
 - `docs/api_walkthrough.md`
 - `api/main.py`
+
+## Release-control flow
+
+The API keeps candidate generation and release separate:
+
+1. `/por/complete` asks the configured generator for one or more candidates.
+2. Runtime estimators compute drift/coherence for the candidate set.
+3. The core PoR gate applies the threshold rule.
+4. The response releases output only on `PROCEED`; otherwise it returns a silence
+   token and notes.
+
+`/por/evaluate` skips generation and evaluates a caller-provided candidate.
+This is the safest entry point for wrapping an existing generation stack.

--- a/wiki/Current-Status.md
+++ b/wiki/Current-Status.md
@@ -24,3 +24,12 @@
 - Broader benchmark and domain-transfer testing.
 - Stronger applied demo surface for outsiders evaluating the release-control framing.
 - Continue strict claim-to-evidence discipline: separate what is demonstrated, partially established, and still pending.
+
+## Maintainability cleanup status
+
+- Configuration defaults now have a centralized module with environment-variable
+  overrides for runtime tunables.
+- Runtime/demo signal estimation has a shared helper, while benchmark/eval signal
+  contracts remain separate.
+- Package restructuring into deeper subpackages is deferred to avoid breaking
+  benchmark paths; see `docs/package_migration_plan.md`.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -23,6 +23,8 @@ Recent local SimpleQA/Ollama evidence indicates two different operating points: 
 
 - [Reading Order](Reading-Order)
 - [Threshold Regimes](Threshold-Regimes)
+- [Signal Contract](Signal-Contract)
+- [Threshold Calibration](Threshold-Calibration)
 - [Evaluation Summary](Evaluation-Summary)
 - [Evidence Map](Evidence-Map)
 - [Current Status](Current-Status)

--- a/wiki/Signal-Contract.md
+++ b/wiki/Signal-Contract.md
@@ -1,0 +1,28 @@
+# Signal Contract
+
+PoR release control consumes signal values; it does not make every signal source
+identical.
+
+## Runtime/demo signal helper
+
+`silence_as_control.signals.compute_signals(candidate, reference)` returns:
+
+- `coherence`: runtime/demo embedding overlap estimate in `[0, 1]`
+- `drift`: `1 - coherence` for that same local runtime/demo estimate
+
+This helper is intentionally scoped. It is not a universal PoR signal contract.
+
+## Contracts that remain separate
+
+- Core primitive: consumes `drift` and `coherence` and computes instability.
+- API runtime: may estimate coherence/drift with local or injected embeddings.
+- Benchmarks/evals: may use benchmark-specific signal definitions.
+- Action-risk detector telemetry: remains its own telemetry contract.
+- SimpleQA and LangChain benchmark signals: remain benchmark-specific unless a
+  call site is proven to be a pure duplicate with identical behavior.
+
+## Non-goal
+
+Do not reinterpret 0.39, 0.35, 0.42, or 0.43 as universal thresholds just
+because a signal helper exists. Threshold meaning depends on the signal regime,
+model, task, and acceptance-risk target.

--- a/wiki/Threshold-Calibration.md
+++ b/wiki/Threshold-Calibration.md
@@ -1,0 +1,40 @@
+# Threshold Calibration Guidance
+
+Thresholds in this repository are operating-regime choices, not universal
+constants. Calibrate them for each new model, task family, and signal contract.
+
+## Calibrating for a new model
+
+1. Freeze the task set and scoring protocol.
+2. Generate candidates without changing the release gate.
+3. Compute the model-specific signal distribution.
+4. Sweep candidate thresholds and record:
+   - coverage / silence rate,
+   - accepted wrong outputs,
+   - accepted precision,
+   - boundary cases near the threshold.
+5. Pick a threshold that matches the deployment risk tolerance.
+6. Re-run on a holdout slice before treating the threshold as operational.
+
+## Calibrating for a new task
+
+1. Keep generation separate from release.
+2. Define what counts as an accepted failure for the task.
+3. Verify the signal contract captures task-relevant instability.
+4. Run a small pilot sweep, then a larger validation sweep.
+5. Document the threshold regime and evidence artifact paths.
+
+## Telemetry-driven hardening workflow
+
+1. Log prompt, candidate metadata, signal values, gate decision, and review
+   outcome where policy permits.
+2. Audit accepted wrong outputs before optimizing for more coverage.
+3. Label boundary pockets separately from clear failures.
+4. Adjust detectors or threshold regimes only after evidence review.
+5. Preserve old artifacts so threshold changes remain auditable.
+
+## Guardrail boundary
+
+Guardrails classify or constrain. Silence-as-Control gates release. Do not merge
+these roles into a single binary decision if tri-state behavior is already part
+of a higher-level integration.

--- a/wiki/Threshold-Regimes.md
+++ b/wiki/Threshold-Regimes.md
@@ -25,3 +25,10 @@ Do not treat these labels as universal settings.
 For contract language and canonical interpretation, use:
 
 - [`docs/threshold_regime_contract.md`](../docs/threshold_regime_contract.md)
+
+## Calibration reminder
+
+The repository contains several threshold values because they come from different
+runs and regimes. Treat each as evidence-scoped. Do not apply `0.39`, `0.35`,
+`0.42`, or `0.43` universally without recalibrating the signal contract, model,
+and task family. See [Threshold Calibration](./Threshold-Calibration.md).

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -8,6 +8,8 @@ This wiki describes Silence-as-Control / Proof of Resonance (PoR) as a runtime r
 - [Current Status](./Current-Status.md)
 - [API Walkthrough](./API-Walkthrough.md)
 - [Threshold Regimes](./Threshold-Regimes.md)
+- [Signal Contract](./Signal-Contract.md)
+- [Threshold Calibration](./Threshold-Calibration.md)
 - [Evaluation Summary](./Evaluation-Summary.md)
 - [Evidence Map](./Evidence-Map.md)
 - [Reading Order](./Reading-Order.md)


### PR DESCRIPTION
### Motivation
- Centralize runtime and core defaults into a single configuration surface to make threshold and embedding tunables auditable and environment-overridable.
- Provide shared runtime/demo signal utilities and a small public `DecisionResult` type to reduce duplication between API, runtime, and demo code.
- Refactor API/runtime code to use the centralized config/signals so behavior remains deterministic for benchmarks while enabling safer runtime overrides and clearer docs.

### Description
- Added a centralized config module at `src/silence_as_control/config.py` and replaced scattered magic constants with calls to the new getters (e.g. core threshold, embedding limits, legacy generate cutoff).
- Introduced shared runtime/demo signal helpers in `src/silence_as_control/signals.py` and a lightweight `DecisionResult` dataclass in `src/silence_as_control/types.py` used by control and API layers.
- Updated deterministic control primitive in `api/core_primitive.py` and library `src/silence_as_control/control.py` to use config values and return normalized decision payloads; API runtime (`api/main.py`) now uses typed responses, `DecisionResult`, improved typing, and JSON-validity enforcement notes.
- Refactored runtime helpers in `api/por_runtime.py` to delegate embedding/coherence/drift utilities to the shared `signals` module and to read runtime defaults from `config`; added `api/_repo_path.py` and `api/__init__.py` to preserve direct-script import compatibility.
- Added docs and onboarding materials including `CHANGELOG.md`, `docs/package_migration_plan.md`, updated `README.md`, and several wiki pages describing signal contract and threshold calibration.
- Updated packaging (`pyproject.toml`) and exposed public package API from `src/silence_as_control/__init__.py` (re-exports for easier usage) and added/updated tests covering control logic, runtime estimators, API health, and shared signals.

### Testing
- Ran the automated unit test suite with `pytest` covering `tests/test_control.py`, `tests/test_por_runtime.py`, `tests/test_api.py`, and the new `tests/test_signals.py`.
- Tests exercise boundary conditions for thresholds, adaptive threshold clipping, runtime embedding/truncation behavior, API endpoints (`/health`, `/por/evaluate`, `/por/complete`), and JSON validity enforcement.
- All automated tests in the updated test suite passed locally (`pytest` succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb12df68e48326bfff22994dd4e74e)