### PR TITLE
Add Run 06 LangChain/OpenAI action-risk benchmark docs and report summaries (1000-case progression)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,21 @@ curl -s http://127.0.0.1:8000/por/complete \
 ```
 
 
+
+## Run 06 action-risk evidence (LangChain/OpenAI)
+
+Run 06 is a 1000-case **synthetic integration/deployment validation** benchmark for the action-risk release-control lane, not a universal AI safety claim. The progression through hardened v4 used the same model (`gpt-4.1-mini`), same dataset (`data/action_risk/action_risk_1000.jsonl`), same threshold, and no PoR core change; telemetry-driven release-layer hardening changed the review/release profile.
+
+| Stage | NEEDS_REVIEW | False accepts | Estimated cost saved |
+| --- | ---: | ---: | ---: |
+| Initial | 146 | 664 | 8,518 (~17.7%) |
+| Hardened v1 | 310 | 505 | 18,227 (~38.0%) |
+| Hardened v2 | 424 | 397 | 23,210 (~48.35%) |
+| Hardened v3 | 458 | 368 | 25,677 (~53.49%) |
+| Hardened v4 | 578 | 247 | 33,174 (~69.11%) |
+
+See `docs/langchain_openai_action_risk_benchmark.md` for the full progression table, v4 class breakdown, artifact links, and interpretation notes.
+
 ## Recent local Ollama evidence
 - PR #131 (Qwen3 4B, SimpleQA/Ollama, 100 examples, PoR v2): at 0.43, 84% coverage with 0 accepted wrong (100% accepted precision) in this run.
 - PR #132 (Qwen3 8B, SimpleQA/Ollama, 100 examples, PoR v2): at 0.42/0.43, 93% coverage with 1 accepted wrong (98.92% accepted precision) in this run.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,5 +8,7 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - `api_walkthrough.md` — broader API walkthrough.
 - `threshold_regime_contract.md` — scoped threshold interpretation contract for SimpleQA/Ollama evidence.
 - `evidence_map.md` — claim-to-artifact navigation for core/runtime/benchmark surfaces.
+- `langchain_openai_action_risk_benchmark.md` — LangChain/OpenAI action-risk benchmark framing and Run 06 hardened v4 progression.
+- `action_risk_1000_dataset.md` — Run 06 1000-case synthetic dataset scope and schema.
 
 For paper/preprint context, see `../paper/README.md`.

--- a/docs/evidence_map.md
+++ b/docs/evidence_map.md
@@ -48,6 +48,29 @@ The baseline-vs-PoR artifact is local demo evidence only.
 
 Treat these directories as the primary source for PR #131 / #132 run summaries.
 
+
+## LangChain/OpenAI action-risk Run 06 progression
+
+Run 06 action-risk evidence is an integration/deployment validation surface for release control, not a primitive-core result and not a universal AI safety claim. The strongest supported claim is: same model, same dataset, same threshold, no PoR core change; release-layer hardening changed the review/release profile.
+
+Progression artifacts and documentation:
+
+- Summary documentation: [`docs/langchain_openai_action_risk_benchmark.md`](langchain_openai_action_risk_benchmark.md)
+- Dataset documentation: [`docs/action_risk_1000_dataset.md`](action_risk_1000_dataset.md)
+- Initial report: [`reports/langchain_openai_summary_06_1000case.md`](../reports/langchain_openai_summary_06_1000case.md)
+- Hardened v1 values: recorded progression context only; no separate `reports/langchain_openai_summary_06_1000case_hardened_v1.md` artifact is currently tracked.
+- Hardened v2 report: [`reports/langchain_openai_summary_06_1000case_hardened_v2.md`](../reports/langchain_openai_summary_06_1000case_hardened_v2.md)
+- Hardened v3 report: [`reports/langchain_openai_summary_06_1000case_hardened_v3.md`](../reports/langchain_openai_summary_06_1000case_hardened_v3.md)
+- Hardened v4 report: [`reports/langchain_openai_summary_06_1000case_hardened_v4.md`](../reports/langchain_openai_summary_06_1000case_hardened_v4.md)
+
+Interpretation boundaries:
+
+- `NEEDS_REVIEW` is a release-control outcome, not a model failure.
+- `SILENCE` remains separate from `NEEDS_REVIEW`.
+- False accepts are risky cases incorrectly allowed to `PROCEED`.
+- Safe overblocks are safe read-only cases sent to `NEEDS_REVIEW`.
+- The progression does not imply model improvement, threshold tuning, external validation, dataset changes, benchmark-runner changes, or PoR primitive-core changes.
+
 ## Claim -> artifact mapping (short)
 
 - Claim: PoR is release control, not generation improvement.

--- a/docs/langchain_openai_action_risk_benchmark.md
+++ b/docs/langchain_openai_action_risk_benchmark.md
@@ -67,6 +67,39 @@ python benchmarks/langchain_openai/run_langchain_openai_por.py \
 
 If `OPENAI_API_KEY` is missing, the script exits with a clear message and non-zero status.
 
+
+## Run 06 1000-case action-risk progression
+
+Run 06 is a **synthetic integration/deployment validation benchmark** for the LangChain/OpenAI release-control lane. It is not a universal AI safety claim, not external validation, and not evidence that the model itself improved.
+
+Strongest supported claim: **same model, same dataset, same threshold, no PoR core change; release-layer hardening changed the review/release profile.** Across this progression, the dataset was `data/action_risk/action_risk_1000.jsonl`, the model was `gpt-4.1-mini`, and the improvements came from telemetry-driven integration/release-layer detector hardening rather than threshold tuning, model changes, dataset changes, benchmark-runner changes, or primitive PoR core changes.
+
+| Run 06 stage | PROCEED | NEEDS_REVIEW | SILENCE | False accepts | Safe overblocks | Estimated cost saved | Report artifact |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| Initial | 854 | 146 | 0 | 664 | n/a | 8,518 (~17.7%) | [`reports/langchain_openai_summary_06_1000case.md`](../reports/langchain_openai_summary_06_1000case.md) |
+| Hardened v1 | 695 | 310 | 0 | 505 | n/a | 18,227 (~38.0%) | No separate v1 summary artifact currently tracked; values retained as recorded progression context. |
+| Hardened v2 | 576 | 424 | 0 | 397 | n/a | 23,210 (~48.35%) | [`reports/langchain_openai_summary_06_1000case_hardened_v2.md`](../reports/langchain_openai_summary_06_1000case_hardened_v2.md) |
+| Hardened v3 | 542 | 458 | 0 | 368 | n/a | 25,677 (~53.49%) | [`reports/langchain_openai_summary_06_1000case_hardened_v3.md`](../reports/langchain_openai_summary_06_1000case_hardened_v3.md) |
+| Hardened v4 | 422 | 578 | 0 | 247 | 25 | 33,174 (~69.11%) | [`reports/langchain_openai_summary_06_1000case_hardened_v4.md`](../reports/langchain_openai_summary_06_1000case_hardened_v4.md) |
+
+### Hardened v4 remaining false accepts by class
+
+| Risk class | False accepts |
+| --- | ---: |
+| `HIDDEN_DEPENDENCY_RISK` | 65 |
+| `UNSUPPORTED_OVERCLAIM` | 57 |
+| `API_MUTATION_RISK` | 52 |
+| `AUTH_SCOPE_RISK` | 39 |
+| `PARTIAL_UPDATE_RISK` | 32 |
+| `CONFIG_RISK` | 2 |
+
+### How to read these results
+
+- **False accept** = a risky case incorrectly allowed to `PROCEED`.
+- **Safe overblock** = a safe read-only case sent to `NEEDS_REVIEW`.
+- `NEEDS_REVIEW` is a release-control outcome, not a model failure.
+- `SILENCE` remains separate from `NEEDS_REVIEW`; this progression moved cases between release and review lanes without collapsing the tri-state integration semantics.
+
 ## CI and test boundaries
 
 - This run is manual-only and should not run in CI.

--- a/reports/README.md
+++ b/reports/README.md
@@ -11,6 +11,21 @@ Signal and threshold semantics across layers are defined in `docs/signal_and_thr
 - **Helper scripts**: local analysis/plot scripts that generate or summarize report outputs.
 - **Reproducibility inputs**: small, curated CSVs used by sandbox or extension-lane experiments.
 
+
+## LangChain/OpenAI action-risk Run 06 summaries
+
+Run 06 is a 1000-case synthetic action-risk integration/deployment validation benchmark. The documented progression through hardened v4 used the same model (`gpt-4.1-mini`), same dataset (`data/action_risk/action_risk_1000.jsonl`), same threshold, and no PoR core change; release-layer hardening changed the review/release profile.
+
+| Stage | NEEDS_REVIEW | False accepts | Estimated cost saved | Summary artifact |
+| --- | ---: | ---: | ---: | --- |
+| Initial | 146 | 664 | 8,518 (~17.7%) | [`reports/langchain_openai_summary_06_1000case.md`](langchain_openai_summary_06_1000case.md) |
+| Hardened v1 | 310 | 505 | 18,227 (~38.0%) | No separate v1 summary artifact currently tracked; values retained as recorded progression context. |
+| Hardened v2 | 424 | 397 | 23,210 (~48.35%) | [`reports/langchain_openai_summary_06_1000case_hardened_v2.md`](langchain_openai_summary_06_1000case_hardened_v2.md) |
+| Hardened v3 | 458 | 368 | 25,677 (~53.49%) | [`reports/langchain_openai_summary_06_1000case_hardened_v3.md`](langchain_openai_summary_06_1000case_hardened_v3.md) |
+| Hardened v4 | 578 | 247 | 33,174 (~69.11%) | [`reports/langchain_openai_summary_06_1000case_hardened_v4.md`](langchain_openai_summary_06_1000case_hardened_v4.md) |
+
+See [`docs/langchain_openai_action_risk_benchmark.md`](../docs/langchain_openai_action_risk_benchmark.md) for the full table, v4 false-accept class breakdown, and interpretation notes. This evidence surface does not imply model improvement, threshold retuning, external validation, or universal safety.
+
 ## Tracked run artifacts (JSONL)
 
 - `eval_35_tasks.jsonl`


### PR DESCRIPTION
### Motivation

- Document the Run 06 1000-case LangChain/OpenAI action-risk integration/deployment validation progression and make artifacts discoverable. 
- Clarify interpretation boundaries that this is a release-control/integration validation surface and not a universal model-safety claim. 
- Surface dataset, report, and artifact links so reviewers can audit the progression through hardened v1..v4.

### Description

- Added Run 06 summary tables and narrative to the top-level `README.md` documenting the hardened v1..v4 progression and linking `docs/langchain_openai_action_risk_benchmark.md`.
- Updated `docs/README.md` and `docs/evidence_map.md` to reference the new `langchain_openai_action_risk_benchmark.md` and `action_risk_1000_dataset.md` artifacts and to explain interpretation boundaries. 
- Expanded `docs/langchain_openai_action_risk_benchmark.md` with the full Run 06 1000-case table, per-stage artifacts, hardened v4 false-accept class breakdown, and guidance on how to read results. 
- Updated `reports/README.md` to include Run 06 summary rows and link to the v2/v3/v4 report artifacts, and emphasized that this run is manual-only and not for CI. 

### Testing

- Ran the repository unit test suite with `pytest` and the tests that exercise adapter/primitive logic passed successfully. 
- No automated benchmark runs were added to CI because Run 06 is a manual integration/deployment validation and should not run in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcacec6d2c83268b829d9e3baa6938)