### PR TITLE
Add release-control pilot/integration docs and README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,16 @@ See `docs/langchain_openai_action_risk_benchmark.md` for the full progression ta
 - Silence tradeoff: 4% (1/25), including one observed wrong answer case blocked by silencing.
 - This is a prototype benchmark observation on a local subset; broader validation on larger/harder sets is still required.
 
+## Pilot / integration interest
+
+Silence-as-Control may be relevant for teams building LLM agents, RAG/internal copilots, config/code assistants, or workflow automation where generated output can become an action.
+
+Core question:
+
+> Should this output be released at all?
+
+For pilot or integration interest, see `docs/release_control_services.md`.
+
 ## Quick public links
 - Repository root: `./`
 - README: `README.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,13 +2,14 @@
 
 You are here: documentation for architecture boundaries and public-facing guidance.
 
-- `architecture.md` вЂ” core vs runtime vs experimental split.
-- `runtime_extensions.md` вЂ” optional runtime deployment helpers.
-- `experimental_features.md` вЂ” optional non-core MAYBE_SHORT_REGEN behavior.
-- `api_walkthrough.md` вЂ” broader API walkthrough.
-- `threshold_regime_contract.md` вЂ” scoped threshold interpretation contract for SimpleQA/Ollama evidence.
-- `evidence_map.md` вЂ” claim-to-artifact navigation for core/runtime/benchmark surfaces.
-- `langchain_openai_action_risk_benchmark.md` вЂ” LangChain/OpenAI action-risk benchmark framing and Run 06 hardened v4 progression.
-- `action_risk_1000_dataset.md` вЂ” Run 06 1000-case synthetic dataset scope and schema.
+- `architecture.md` — core vs runtime vs experimental split.
+- `runtime_extensions.md` — optional runtime deployment helpers.
+- `experimental_features.md` — optional non-core MAYBE_SHORT_REGEN behavior.
+- `api_walkthrough.md` — broader API walkthrough.
+- `threshold_regime_contract.md` — scoped threshold interpretation contract for SimpleQA/Ollama evidence.
+- `evidence_map.md` — claim-to-artifact navigation for core/runtime/benchmark surfaces.
+- `langchain_openai_action_risk_benchmark.md` — LangChain/OpenAI action-risk benchmark framing and Run 06 hardened v4 progression.
+- `action_risk_1000_dataset.md` — Run 06 1000-case synthetic dataset scope and schema.
+- `release_control_services.md` — pilot/integration overview for release-control use cases.
 
 For paper/preprint context, see `../paper/README.md`.

--- a/docs/release_control_services.md
+++ b/docs/release_control_services.md
@@ -1,0 +1,74 @@
+# Release-Control Pilot Overview
+
+Silence-as-Control is framed here as a runtime release-control layer for LLM systems where generated output can become an action. This overview is intended for pilot and integration discussions, not as a claim of universal AI safety or model improvement.
+
+## Problem
+
+Many LLM systems optimize candidate generation. In agentic or workflow-connected systems, however, generated text may be converted into a real action: a tool call, configuration change, code suggestion, customer-facing response, escalation decision, or workflow update.
+
+Generation should not automatically mean release. A system can generate a candidate while still needing a separate decision about whether that candidate should proceed, move to review, or be withheld.
+
+## Solution
+
+Silence-as-Control adds a runtime release-control layer after generation. It does not change model weights or claim to improve the underlying model. Instead, it gates candidate release behavior.
+
+A release-control integration can expose three outcomes:
+
+- `PROCEED` — release the candidate through the configured output or action path.
+- `NEEDS_REVIEW` — route the candidate to a human, policy, or workflow review lane before release.
+- `SILENCE` — withhold the candidate from the release path.
+
+This distinction keeps generation separate from release. The model may still generate a candidate, but the release layer decides whether that candidate should leave the system boundary.
+
+## Evidence: Run 06 action-risk benchmark
+
+Run 06 provides scoped integration/deployment validation evidence for a LangChain/OpenAI action-risk release-control lane. It should be read as benchmark-path evidence, not as a universal AI safety claim.
+
+In the Run 06 1000-case synthetic action-risk benchmark:
+
+- Initial false accepts: 664.
+- Hardened v4 false accepts: 247.
+- Initial estimated cost saved: approximately 17.7%.
+- Hardened v4 estimated cost saved: approximately 69.11%.
+
+The progression used the same model (`gpt-4.1-mini`), the same dataset (`data/action_risk/action_risk_1000.jsonl`), the same threshold, and no PoR core change. The observed improvement is therefore framed as release-layer hardening within this benchmark path, not as model improvement or a general guarantee.
+
+The “estimated cost saved” metric is a benchmark heuristic for this evaluation setup. It is not a financial guarantee and should be recalibrated for any real deployment context.
+
+## Suitable pilot areas
+
+Silence-as-Control may be suitable to evaluate in systems where risky generated outputs need a release decision before they are acted on, including:
+
+- LLM agents.
+- RAG/internal copilots.
+- Config/code assistants.
+- Workflow automation.
+- Customer-support automation.
+- Review workflows for risky generated outputs.
+
+## Lightweight pilot/audit formats
+
+Pilot scope should be matched to the deployment risk, available telemetry, and review requirements. Three lightweight formats are:
+
+### Release-control audit
+
+A focused review of where generation currently becomes release, which outputs can trigger downstream action, what review lanes exist, and where false accepts or unnecessary silences should be measured.
+
+### Prototype release gate integration
+
+A small integration that inserts a release-control gate after generation and before release, with explicit `PROCEED`, `NEEDS_REVIEW`, and `SILENCE` handling for a selected workflow.
+
+### Runtime reliability package
+
+A broader deployment package covering release-gate integration, scoped benchmark design, telemetry review, threshold documentation, and operational guidance for monitoring accepted-risk and review behavior.
+
+## Contact / interest
+
+If you are building an LLM system where generated output can become an action, the core question is:
+
+> Should this output be released at all?
+
+For pilot or integration interest:
+
+- GitHub: `SemeAIPletinnya`
+- X/Twitter: `@adelayida210519`


### PR DESCRIPTION
### Motivation
- Provide pilot and integration guidance for the repository's "Silence-as-Control" release-control concept so teams can evaluate runtime gating for generated outputs.
- Surface the core question of whether generated output should be released and give practical outcomes (`PROCEED`, `NEEDS_REVIEW`, `SILENCE`) for integration planning.
- Link the new guidance into the repository index and main README so pilot material is discoverable from documentation navigation.

### Description
- Added a new documentation page `docs/release_control_services.md` that explains the problem, the proposed release-control solution, Run 06 benchmark evidence, suitable pilot areas, lightweight pilot formats, and contact pointers.
- Inserted a "Pilot / integration interest" section into the project `README.md` that points to `docs/release_control_services.md` and highlights the core deployment question.
- Updated `docs/README.md` to include a link to the new `release_control_services.md` entry in the docs index.

### Testing
- This is a documentation-only change and no automated unit or integration tests were executed for the update.
- No code paths were modified, so no test failures were observed or introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcda1952c883269fcc603e9773ad22)