### PR TITLE
Support XAI provider configuration for runtime completions; add default-model handling, docs, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,15 @@ python -m pip install -e .
 ```
 
 ### API key guidance
-- The deterministic core and local tests do not require an OpenAI API key.
-- OpenAI-backed demos or live benchmark scripts should read credentials from
-  environment variables such as `OPENAI_API_KEY`.
+- The deterministic core, local tests, and `demo/canonical_runtime_demo.py` do not
+  require provider API keys.
+- Provider-backed `/por/complete` currently uses the xAI-compatible runtime
+  wrapper and requires `XAI_API_KEY`; `XAI_MODEL` can override the default
+  provider model.
+- Docker Compose passes `XAI_API_KEY` and `XAI_MODEL` through to the container
+  for provider-backed completion.
+- OpenAI-backed demos or live benchmark scripts outside the Docker runtime path
+  should read credentials from environment variables such as `OPENAI_API_KEY`.
 - Do not commit API keys, prompt logs containing secrets, or provider tokens.
 
 
@@ -49,6 +55,11 @@ Run with Docker Compose:
 ```bash
 docker compose up --build
 ```
+
+For provider-backed `/por/complete` through Docker Compose, set `XAI_API_KEY`
+before starting the service. Set `XAI_MODEL` only when overriding the default
+provider model. The deterministic health check, `/por/evaluate`, and canonical
+runtime demo do not require provider credentials.
 
 Docker smoke check from another terminal:
 ```bash

--- a/api/main.py
+++ b/api/main.py
@@ -33,7 +33,7 @@ from api.por_runtime import (
     estimate_drift,
     get_runtime_threshold,
 )
-from api.xai_wrapper import DEFAULT_MODEL, generate_candidate
+from api.xai_wrapper import generate_candidate, get_default_model
 
 app = FastAPI(title="silence-as-control")
 LOGGER = logging.getLogger(__name__)
@@ -71,7 +71,7 @@ class CompleteRequest(BaseModel):
     use_adaptive_threshold: bool = False
     recent_drifts: list[float] = Field(default_factory=list)
     recent_coherences: list[float] = Field(default_factory=list)
-    model: str = DEFAULT_MODEL
+    model: str = Field(default_factory=get_default_model)
     system_prompt: str = "You are a precise technical assistant."
     temperature: float = 0.0
     drift_samples: int = 3

--- a/api/xai_wrapper.py
+++ b/api/xai_wrapper.py
@@ -3,8 +3,12 @@ import logging
 from openai import OpenAI
 
 XAI_BASE_URL = "https://api.x.ai/v1"
-DEFAULT_MODEL = "grok-4"
+FALLBACK_MODEL = "grok-4"
+DEFAULT_MODEL = FALLBACK_MODEL
 LOGGER = logging.getLogger(__name__)
+
+def get_default_model() -> str:
+    return os.getenv("XAI_MODEL") or FALLBACK_MODEL
 
 def get_client() -> OpenAI:
     api_key = os.getenv("XAI_API_KEY")
@@ -18,11 +22,12 @@ def get_client() -> OpenAI:
 def generate_candidate(
     prompt: str,
     system_prompt: str = "You are a precise technical assistant.",
-    model: str = DEFAULT_MODEL,
+    model: str | None = None,
     temperature: float = 0.0,
     timeout: float = 30.0,
 ) -> str:
     try:
+        model = model or get_default_model()
         client = get_client()
         resp = client.chat.completions.create(
             model=model,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,5 @@ services:
     ports:
       - "8000:8000"
     environment:
-      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
-      OPENAI_MODEL: ${OPENAI_MODEL:-}
+      XAI_API_KEY: ${XAI_API_KEY:-}
+      XAI_MODEL: ${XAI_MODEL:-}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,11 +1,37 @@
 """API tests across legacy, runtime, and experimental lanes."""
 
+from pathlib import Path
+
 from fastapi.testclient import TestClient
 
 import api.main as api_main
 from api.main import app
 
 client = TestClient(app)
+
+
+# ------------------------------
+# Runtime provider configuration docs
+# ------------------------------
+
+def test_docker_compose_passes_xai_provider_environment():
+    compose = Path("docker-compose.yml").read_text()
+
+    assert "XAI_API_KEY: ${XAI_API_KEY:-}" in compose
+    assert "XAI_MODEL: ${XAI_MODEL:-}" in compose
+    assert "OPENAI_API_KEY: ${OPENAI_API_KEY:-}" not in compose
+    assert "OPENAI_MODEL: ${OPENAI_MODEL:-}" not in compose
+
+
+def test_readme_documents_xai_provider_completion_guidance():
+    readme = Path("README.md").read_text(encoding="utf-8-sig")
+    normalized_readme = " ".join(readme.split())
+
+    assert "Provider-backed `/por/complete`" in readme
+    assert "requires `XAI_API_KEY`" in readme
+    assert "Docker Compose passes `XAI_API_KEY` and `XAI_MODEL`" in readme
+    assert "demo/canonical_runtime_demo.py" in readme
+    assert "do not require provider API keys" in normalized_readme
 
 
 # ------------------------------
@@ -87,6 +113,43 @@ def test_api_evaluate_can_silence_on_low_coherence_runtime_signal():
     assert payload["drift"] == 0.0
     assert payload["coherence"] < 0.25
     assert payload["decision"] == "SILENCE"
+
+
+def test_api_complete_uses_runtime_xai_model_default(monkeypatch):
+    monkeypatch.setenv("XAI_MODEL", "runtime-env-model")
+    captured = {}
+
+    def fake_generate_candidate(*args, **kwargs):
+        captured["model"] = kwargs["model"]
+        return "first candidate"
+
+    def fake_score_candidate_runtime(prompt, candidate, threshold, candidate_samples=None):
+        return {
+            "drift": 0.10,
+            "coherence": 0.95,
+            "instability_score": 0.075,
+            "threshold": threshold,
+            "decision": "PROCEED",
+            "release_output": candidate,
+            "silence_token": None,
+            "notes": ["runtime_env_model"],
+        }
+
+    monkeypatch.setattr(api_main, "generate_candidate", fake_generate_candidate)
+    monkeypatch.setattr(api_main, "score_candidate_runtime", fake_score_candidate_runtime)
+
+    response = client.post(
+        "/por/complete",
+        json={
+            "prompt": "Say hello",
+            "threshold": 0.39,
+            "drift_samples": 1,
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured["model"] == "runtime-env-model"
+    assert response.json()["model"] == "runtime-env-model"
 
 
 # ---------------------------------

--- a/tests/test_xai_wrapper.py
+++ b/tests/test_xai_wrapper.py
@@ -21,6 +21,31 @@ class _FakeClient:
         self.chat = SimpleNamespace(completions=completions)
 
 
+def test_get_default_model_returns_fallback_when_xai_model_unset(monkeypatch):
+    monkeypatch.delenv("XAI_MODEL", raising=False)
+
+    assert xai_wrapper.get_default_model() == "grok-4"
+
+
+def test_get_default_model_returns_env_value(monkeypatch):
+    monkeypatch.setenv("XAI_MODEL", "grok-test")
+
+    assert xai_wrapper.get_default_model() == "grok-test"
+
+
+def test_get_default_model_returns_fallback_when_xai_model_empty(monkeypatch):
+    monkeypatch.setenv("XAI_MODEL", "")
+
+    assert xai_wrapper.get_default_model() == "grok-4"
+
+
+def test_get_client_raises_when_xai_api_key_missing(monkeypatch):
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="XAI_API_KEY is not set"):
+        xai_wrapper.get_client()
+
+
 def test_generate_candidate_passes_timeout_and_returns_trimmed(monkeypatch):
     completions = _FakeCompletions()
     monkeypatch.setattr(xai_wrapper, "get_client", lambda: _FakeClient(completions))
@@ -29,6 +54,28 @@ def test_generate_candidate_passes_timeout_and_returns_trimmed(monkeypatch):
 
     assert result == "result"
     assert completions.kwargs["timeout"] == 12.5
+
+
+def test_generate_candidate_uses_explicit_model_over_xai_model(monkeypatch):
+    completions = _FakeCompletions()
+    monkeypatch.setenv("XAI_MODEL", "env-model")
+    monkeypatch.setattr(xai_wrapper, "get_client", lambda: _FakeClient(completions))
+
+    result = xai_wrapper.generate_candidate("hello", model="explicit-model")
+
+    assert result == "result"
+    assert completions.kwargs["model"] == "explicit-model"
+
+
+def test_generate_candidate_uses_xai_model_when_model_not_provided(monkeypatch):
+    completions = _FakeCompletions()
+    monkeypatch.setenv("XAI_MODEL", "env-model")
+    monkeypatch.setattr(xai_wrapper, "get_client", lambda: _FakeClient(completions))
+
+    result = xai_wrapper.generate_candidate("hello")
+
+    assert result == "result"
+    assert completions.kwargs["model"] == "env-model"
 
 
 def test_generate_candidate_logs_and_raises_runtime_error_on_failure(monkeypatch):


### PR DESCRIPTION
### Motivation
- Replace legacy OpenAI environment usage with an xAI-compatible runtime wrapper and allow runtime model selection via environment to enable provider-backed `/por/complete` while keeping deterministic local paths keyless.
- Make the runtime model selection explicit and discoverable so containerized deployments can pass `XAI_API_KEY` and `XAI_MODEL` through Docker Compose.
- Improve robustness by using a fallback model and making `generate_candidate` accept an explicit override while defaulting to the configured runtime model.

### Description
- Added `FALLBACK_MODEL` and `get_default_model()` to `api/xai_wrapper.py` and made `generate_candidate()` accept an optional `model` parameter that falls back to `get_default_model()` when not provided.
- Replaced direct import of `DEFAULT_MODEL` in `api/main.py` and set `CompleteRequest.model` to `Field(default_factory=get_default_model)` so API requests default to the runtime-configured model.
- Updated `docker-compose.yml` to export `XAI_API_KEY` and `XAI_MODEL` instead of OpenAI environment variables.
- Clarified README guidance about which demos and endpoints require provider credentials and how Docker Compose handles `XAI_API_KEY`/`XAI_MODEL`.
- Extended tests: added runtime/provider configuration and README checks to `tests/test_api.py`, and added unit tests for `get_default_model`, client key errors, and model precedence to `tests/test_xai_wrapper.py` while keeping existing generation and regeneration tests.

### Testing
- Ran unit tests in `tests/test_xai_wrapper.py` which verify `get_default_model()` behavior, `get_client()` error on missing `XAI_API_KEY`, and `generate_candidate()` model selection, and they passed.
- Ran API-level tests in `tests/test_api.py` that assert Docker Compose env contents, README docs, runtime default model usage via monkeypatching, and existing API behavior, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0016aac22c8326aa80351afa3531bf)