### PR TITLE
Add local JSONL runtime telemetry with API hooks and reporting script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 logs/
 .DS_Store
 .env
+runtime_logs/

--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ Run the canonical local runtime demo:
 python demo/canonical_runtime_demo.py
 ```
 
+## Runtime observability
+
+Runtime telemetry is local JSONL and disabled by default. Enable it explicitly:
+
+```bash
+POR_TELEMETRY_ENABLED=1 uvicorn api.main:app --reload
+```
+
+By default events are written to `runtime_logs/por_runtime_events.jsonl`. Override
+the path with `POR_TELEMETRY_LOG_PATH`. Telemetry records decision metadata and
+numeric signals; it does not log full prompts or candidates by default. To print
+a concise local summary, run:
+
+```bash
+python scripts/runtime_observability_report.py
+```
+
 ### What this proves / what it does not prove
 
 Proves:

--- a/api/main.py
+++ b/api/main.py
@@ -10,12 +10,14 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, TypedDict
+import os
+from typing import Any, Mapping, TypedDict
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
 from silence_as_control.config import get_legacy_generate_coherence
+from silence_as_control.telemetry import write_runtime_event
 from silence_as_control.types import DecisionResult
 
 from api.core_primitive import (
@@ -43,6 +45,42 @@ LOGGER = logging.getLogger(__name__)
 # runtime configuration (`POR_RUNTIME_GATE_THRESHOLD`).
 RUNTIME_DEFAULT_THRESHOLD = get_runtime_threshold(CORE_FIXED_THRESHOLD)
 SILENCE_TOKEN = "[SILENCE: UNSTABLE OUTPUT BLOCKED]"
+_TRACE_ENABLED_VALUES = {"1", "true", "yes", "on"}
+
+
+def _trace_console_enabled() -> bool:
+    return os.getenv("POR_TRACE_CONSOLE", "").strip().lower() in _TRACE_ENABLED_VALUES
+
+
+def _record_runtime_event(event: Mapping[str, Any]) -> None:
+    """Best-effort runtime telemetry and optional compact console trace."""
+    try:
+        write_runtime_event(event)
+        if _trace_console_enabled():
+            LOGGER.info(
+                "por_trace event_type=%s decision=%s drift=%s coherence=%s instability_score=%s",
+                event.get("event_type"),
+                event.get("decision"),
+                event.get("drift"),
+                event.get("coherence"),
+                event.get("instability_score"),
+            )
+    except Exception:
+        LOGGER.warning("por_runtime_event_record_failed", exc_info=True)
+
+
+def _runtime_event_common(result: Mapping[str, Any]) -> dict[str, Any]:
+    decision = result.get("decision")
+    return {
+        "drift": result.get("drift"),
+        "coherence": result.get("coherence"),
+        "instability_score": result.get("instability_score"),
+        "threshold": result.get("threshold"),
+        "decision": decision,
+        "released": decision == "PROCEED",
+        "silenced": decision == "SILENCE",
+        "notes_count": len(result.get("notes") or []),
+    }
 
 
 class EvaluateRequest(BaseModel):
@@ -248,6 +286,17 @@ def evaluate(req: EvaluateRequest) -> EvaluateResponse:
             recent_coherences=req.recent_coherences,
         )
         result = score_candidate_runtime(req.prompt, req.candidate, threshold)
+        _record_runtime_event(
+            {
+                "event_type": "por.evaluate",
+                **_runtime_event_common(result),
+                "use_adaptive_threshold": req.use_adaptive_threshold,
+                "has_recent_drifts": bool(req.recent_drifts),
+                "has_recent_coherences": bool(req.recent_coherences),
+                "prompt_length": len(req.prompt),
+                "candidate_length": len(req.candidate),
+            }
+        )
         return EvaluateResponse(**result)
     except Exception:
         LOGGER.exception("por_evaluate_failed")
@@ -300,6 +349,8 @@ def complete(req: CompleteRequest) -> CompleteResponse:
             candidate_samples=candidates,
         )
 
+        regenerated = False
+
         # Experimental lane only: MAYBE_SHORT_REGEN is post-silence and non-core.
         if result["decision"] == "SILENCE":
 
@@ -343,12 +394,28 @@ def complete(req: CompleteRequest) -> CompleteResponse:
                 if regen_result["decision"] == "PROCEED":
                     result = regen_result
                     candidates[0] = regen_result["_regen_candidate"]
+                    regenerated = True
                 else:
                     result["notes"].append("experimental_maybe_short_regen_failed")
 
+        response_candidate = candidates[0] if result["decision"] == "PROCEED" else None
+        telemetry_event = {
+            "event_type": "por.complete",
+            **_runtime_event_common(result),
+            "model": req.model,
+            "use_adaptive_threshold": req.use_adaptive_threshold,
+            "drift_samples": req.drift_samples,
+            "enable_experimental_short_regen": resolve_experimental_short_regen_flag(req),
+            "prompt_length": len(req.prompt),
+            "regenerated": regenerated,
+        }
+        if response_candidate is not None:
+            telemetry_event["candidate_length"] = len(response_candidate)
+        _record_runtime_event(telemetry_event)
+
         return CompleteResponse(
             model=req.model,
-            candidate=candidates[0] if result["decision"] == "PROCEED" else None,
+            candidate=response_candidate,
             drift=result["drift"],
             coherence=result["coherence"],
             instability_score=result["instability_score"],

--- a/scripts/runtime_observability_report.py
+++ b/scripts/runtime_observability_report.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+"""Summarize local JSONL runtime telemetry events."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Iterable
+
+DEFAULT_TELEMETRY_LOG_PATH = Path("runtime_logs/por_runtime_events.jsonl")
+
+
+def get_default_report_path() -> Path:
+    configured_path = os.getenv("POR_TELEMETRY_LOG_PATH")
+    if configured_path and configured_path.strip():
+        return Path(configured_path).expanduser()
+    return DEFAULT_TELEMETRY_LOG_PATH
+
+
+def load_events(path: Path) -> tuple[list[dict[str, Any]], int]:
+    events: list[dict[str, Any]] = []
+    malformed_lines = 0
+
+    if not path.exists():
+        return events, malformed_lines
+
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    event = json.loads(stripped)
+                except json.JSONDecodeError:
+                    malformed_lines += 1
+                    continue
+                if isinstance(event, dict):
+                    events.append(event)
+                else:
+                    malformed_lines += 1
+    except OSError:
+        return events, malformed_lines + 1
+
+    return events, malformed_lines
+
+
+def _average(events: Iterable[dict[str, Any]], field: str) -> float | None:
+    values: list[float] = []
+    for event in events:
+        value = event.get(field)
+        if isinstance(value, (int, float)):
+            values.append(float(value))
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def summarize_events(events: list[dict[str, Any]], malformed_lines: int = 0) -> dict[str, Any]:
+    events_by_type = Counter(str(event.get("event_type", "unknown")) for event in events)
+    decisions_by_type: dict[str, Counter[str]] = defaultdict(Counter)
+
+    for event in events:
+        event_type = str(event.get("event_type", "unknown"))
+        decision = event.get("decision")
+        if decision is not None:
+            decisions_by_type[event_type][str(decision)] += 1
+
+    return {
+        "total_events": len(events),
+        "malformed_lines": malformed_lines,
+        "events_by_type": dict(sorted(events_by_type.items())),
+        "decisions_by_type": {
+            key: dict(sorted(value.items())) for key, value in sorted(decisions_by_type.items())
+        },
+        "release_count": sum(1 for event in events if event.get("released") is True),
+        "silence_count": sum(1 for event in events if event.get("silenced") is True),
+        "average_drift": _average(events, "drift"),
+        "average_coherence": _average(events, "coherence"),
+        "average_instability_score": _average(events, "instability_score"),
+    }
+
+
+def _format_value(value: Any) -> str:
+    if isinstance(value, float):
+        return f"{value:.4f}"
+    return json.dumps(value, sort_keys=True)
+
+
+def print_summary(summary: dict[str, Any], path: Path) -> None:
+    print(f"path: {path}")
+    for key in (
+        "total_events",
+        "malformed_lines",
+        "events_by_type",
+        "decisions_by_type",
+        "release_count",
+        "silence_count",
+        "average_drift",
+        "average_coherence",
+        "average_instability_score",
+    ):
+        print(f"{key}: {_format_value(summary[key])}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Summarize PoR runtime JSONL telemetry.")
+    parser.add_argument("--path", type=Path, default=None, help="Path to JSONL telemetry log.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    path = args.path if args.path is not None else get_default_report_path()
+    events, malformed_lines = load_events(path)
+    summary = summarize_events(events, malformed_lines=malformed_lines)
+    print_summary(summary, path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/silence_as_control/telemetry.py
+++ b/src/silence_as_control/telemetry.py
@@ -1,0 +1,60 @@
+"""Local JSONL telemetry helpers for runtime release-control events."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+LOGGER = logging.getLogger(__name__)
+
+_ENABLED_VALUES = {"1", "true", "yes", "on"}
+_DEFAULT_TELEMETRY_LOG_PATH = Path("runtime_logs/por_runtime_events.jsonl")
+
+
+def _env_flag_enabled(value: str | None) -> bool:
+    return (value or "").strip().lower() in _ENABLED_VALUES
+
+
+def telemetry_enabled() -> bool:
+    """Return whether local runtime telemetry is explicitly enabled."""
+    return _env_flag_enabled(os.getenv("POR_TELEMETRY_ENABLED"))
+
+
+def get_telemetry_log_path() -> Path:
+    """Resolve the local JSONL telemetry path."""
+    configured_path = os.getenv("POR_TELEMETRY_LOG_PATH")
+    if configured_path and configured_path.strip():
+        return Path(configured_path).expanduser()
+    return _DEFAULT_TELEMETRY_LOG_PATH
+
+
+def write_runtime_event(event: Mapping[str, Any]) -> bool:
+    """Append one local JSONL runtime event when telemetry is enabled.
+
+    Telemetry is best-effort only: disabled telemetry or write failures return
+    False and never raise to callers.
+    """
+    if not telemetry_enabled():
+        return False
+
+    try:
+        event_record = dict(event)
+        event_record.setdefault(
+            "timestamp_utc",
+            datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        )
+        event_record.setdefault("schema_version", "1")
+
+        log_path = get_telemetry_log_path()
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event_record, sort_keys=True, separators=(",", ":")))
+            handle.write("\n")
+        return True
+    except Exception:
+        LOGGER.warning("por_telemetry_write_failed", exc_info=True)
+        return False

--- a/tests/test_runtime_observability_report.py
+++ b/tests/test_runtime_observability_report.py
@@ -1,0 +1,104 @@
+"""Tests for the local runtime observability report."""
+
+from __future__ import annotations
+
+import json
+
+from scripts import runtime_observability_report as report
+
+
+def test_runtime_observability_report_summarizes_events(tmp_path, capsys):
+    log_path = tmp_path / "events.jsonl"
+    rows = [
+        {
+            "event_type": "por.evaluate",
+            "decision": "PROCEED",
+            "released": True,
+            "silenced": False,
+            "drift": 0.1,
+            "coherence": 0.9,
+            "instability_score": 0.1,
+        },
+        {
+            "event_type": "por.complete",
+            "decision": "SILENCE",
+            "released": False,
+            "silenced": True,
+            "drift": 0.7,
+            "coherence": 0.2,
+            "instability_score": 0.75,
+        },
+    ]
+    log_path.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
+
+    assert report.main(["--path", str(log_path)]) == 0
+
+    output = capsys.readouterr().out
+    assert "total_events: 2" in output
+    assert 'events_by_type: {"por.complete": 1, "por.evaluate": 1}' in output
+    assert "release_count: 1" in output
+    assert "silence_count: 1" in output
+    assert "average_drift: 0.4000" in output
+    assert "average_coherence: 0.5500" in output
+    assert "average_instability_score: 0.4250" in output
+
+
+def test_runtime_observability_report_handles_missing_file(tmp_path, capsys):
+    missing_path = tmp_path / "missing.jsonl"
+
+    assert report.main(["--path", str(missing_path)]) == 0
+
+    output = capsys.readouterr().out
+    assert "total_events: 0" in output
+    assert "release_count: 0" in output
+    assert "silence_count: 0" in output
+
+
+def test_runtime_observability_report_handles_malformed_jsonl(tmp_path, capsys):
+    log_path = tmp_path / "events.jsonl"
+    log_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "event_type": "por.evaluate",
+                        "decision": "PROCEED",
+                        "released": True,
+                        "silenced": False,
+                    }
+                ),
+                "not-json",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert report.main(["--path", str(log_path)]) == 0
+
+    output = capsys.readouterr().out
+    assert "total_events: 1" in output
+    assert "malformed_lines: 1" in output
+
+
+def test_runtime_observability_report_uses_env_path_when_no_cli_path(
+    monkeypatch, tmp_path, capsys
+):
+    log_path = tmp_path / "env-events.jsonl"
+    log_path.write_text(
+        json.dumps(
+            {
+                "event_type": "por.evaluate",
+                "decision": "PROCEED",
+                "released": True,
+                "silenced": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("POR_TELEMETRY_LOG_PATH", str(log_path))
+
+    assert report.main([]) == 0
+
+    output = capsys.readouterr().out
+    assert f"path: {log_path}" in output
+    assert "total_events: 1" in output

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,197 @@
+"""Tests for local runtime telemetry and API integration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+import api.main as api_main
+from api.main import app
+from silence_as_control.telemetry import write_runtime_event
+
+client = TestClient(app)
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_telemetry_disabled_by_default_returns_false_and_does_not_create_file(
+    monkeypatch, tmp_path
+):
+    log_path = tmp_path / "events.jsonl"
+    monkeypatch.delenv("POR_TELEMETRY_ENABLED", raising=False)
+    monkeypatch.setenv("POR_TELEMETRY_LOG_PATH", str(log_path))
+
+    assert write_runtime_event({"event_type": "unit"}) is False
+    assert not log_path.exists()
+
+
+def test_telemetry_enabled_writes_one_jsonl_event_with_defaults(monkeypatch, tmp_path):
+    log_path = tmp_path / "nested" / "events.jsonl"
+    monkeypatch.setenv("POR_TELEMETRY_ENABLED", "true")
+    monkeypatch.setenv("POR_TELEMETRY_LOG_PATH", str(log_path))
+
+    assert write_runtime_event({"event_type": "unit", "drift": 0.1}) is True
+
+    events = _read_jsonl(log_path)
+    assert len(events) == 1
+    assert events[0]["event_type"] == "unit"
+    assert events[0]["drift"] == 0.1
+    assert events[0]["schema_version"] == "1"
+    assert "timestamp_utc" in events[0]
+
+
+def test_telemetry_parent_directory_is_created(monkeypatch, tmp_path):
+    log_path = tmp_path / "a" / "b" / "events.jsonl"
+    monkeypatch.setenv("POR_TELEMETRY_ENABLED", "1")
+    monkeypatch.setenv("POR_TELEMETRY_LOG_PATH", str(log_path))
+
+    assert write_runtime_event({"event_type": "unit"}) is True
+    assert log_path.exists()
+
+
+def test_telemetry_failed_write_returns_false_and_does_not_raise(monkeypatch, tmp_path):
+    log_path = tmp_path / "events_as_directory"
+    log_path.mkdir()
+    monkeypatch.setenv("POR_TELEMETRY_ENABLED", "yes")
+    monkeypatch.setenv("POR_TELEMETRY_LOG_PATH", str(log_path))
+
+    assert write_runtime_event({"event_type": "unit"}) is False
+
+
+def test_api_evaluate_writes_telemetry_without_prompt_or_candidate_text(monkeypatch, tmp_path):
+    log_path = tmp_path / "events.jsonl"
+    prompt = "secret prompt text should not be logged"
+    candidate = "secret candidate text should not be logged"
+    monkeypatch.setenv("POR_TELEMETRY_ENABLED", "on")
+    monkeypatch.setenv("POR_TELEMETRY_LOG_PATH", str(log_path))
+
+    response = client.post(
+        "/por/evaluate",
+        json={
+            "prompt": prompt,
+            "candidate": candidate,
+            "threshold": 0.39,
+            "use_adaptive_threshold": False,
+        },
+    )
+
+    assert response.status_code == 200
+    event = _read_jsonl(log_path)[0]
+    serialized_event = json.dumps(event, sort_keys=True)
+    assert event["event_type"] == "por.evaluate"
+    assert "drift" in event
+    assert "coherence" in event
+    assert "instability_score" in event
+    assert event["threshold"] == 0.39
+    assert event["decision"] == response.json()["decision"]
+    assert event["prompt_length"] == len(prompt)
+    assert event["candidate_length"] == len(candidate)
+    assert prompt not in serialized_event
+    assert candidate not in serialized_event
+
+
+def test_api_complete_writes_telemetry_without_prompt_or_candidate_text(monkeypatch, tmp_path):
+    log_path = tmp_path / "events.jsonl"
+    prompt = "complete secret prompt"
+    candidate = "complete secret candidate"
+    monkeypatch.setenv("POR_TELEMETRY_ENABLED", "1")
+    monkeypatch.setenv("POR_TELEMETRY_LOG_PATH", str(log_path))
+
+    def fake_generate_candidate(*args, **kwargs):
+        return candidate
+
+    def fake_score_candidate_runtime(prompt, candidate, threshold, candidate_samples=None):
+        return {
+            "drift": 0.10,
+            "coherence": 0.95,
+            "instability_score": 0.075,
+            "threshold": threshold,
+            "decision": "PROCEED",
+            "release_output": candidate,
+            "silence_token": None,
+            "notes": ["stable"],
+        }
+
+    monkeypatch.setattr(api_main, "generate_candidate", fake_generate_candidate)
+    monkeypatch.setattr(api_main, "score_candidate_runtime", fake_score_candidate_runtime)
+
+    response = client.post(
+        "/por/complete",
+        json={"prompt": prompt, "threshold": 0.39, "drift_samples": 1},
+    )
+
+    assert response.status_code == 200
+    event = _read_jsonl(log_path)[0]
+    serialized_event = json.dumps(event, sort_keys=True)
+    assert event["event_type"] == "por.complete"
+    assert event["model"] == response.json()["model"]
+    assert event["decision"] == "PROCEED"
+    assert event["candidate_length"] == len(candidate)
+    assert event["regenerated"] is False
+    assert prompt not in serialized_event
+    assert candidate not in serialized_event
+
+
+def test_api_evaluate_telemetry_failure_does_not_break_endpoint(monkeypatch):
+    def broken_write_runtime_event(event):
+        raise RuntimeError("telemetry boom")
+
+    monkeypatch.setattr(api_main, "write_runtime_event", broken_write_runtime_event)
+
+    response = client.post(
+        "/por/evaluate",
+        json={"prompt": "Explain recursion", "candidate": "A function calls itself."},
+    )
+
+    assert response.status_code == 200
+    assert "decision" in response.json()
+
+
+def test_api_complete_omits_candidate_length_for_silenced_candidate(monkeypatch, tmp_path):
+    log_path = tmp_path / "events.jsonl"
+    prompt = "complete silenced prompt"
+    candidate = "silenced candidate text should not be logged"
+    monkeypatch.setenv("POR_TELEMETRY_ENABLED", "1")
+    monkeypatch.setenv("POR_TELEMETRY_LOG_PATH", str(log_path))
+
+    def fake_generate_candidate(*args, **kwargs):
+        return candidate
+
+    def fake_score_candidate_runtime(prompt, candidate, threshold, candidate_samples=None):
+        return {
+            "drift": 0.80,
+            "coherence": 0.20,
+            "instability_score": 0.80,
+            "threshold": threshold,
+            "decision": "SILENCE",
+            "release_output": None,
+            "silence_token": api_main.SILENCE_TOKEN,
+            "notes": ["initial_silence"],
+        }
+
+    monkeypatch.setattr(api_main, "generate_candidate", fake_generate_candidate)
+    monkeypatch.setattr(api_main, "score_candidate_runtime", fake_score_candidate_runtime)
+
+    response = client.post(
+        "/por/complete",
+        json={
+            "prompt": prompt,
+            "threshold": 0.39,
+            "drift_samples": 1,
+            "enable_experimental_short_regen": False,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["decision"] == "SILENCE"
+    event = _read_jsonl(log_path)[0]
+    serialized_event = json.dumps(event, sort_keys=True)
+    assert event["event_type"] == "por.complete"
+    assert event["silenced"] is True
+    assert "candidate_length" not in event
+    assert prompt not in serialized_event
+    assert candidate not in serialized_event


### PR DESCRIPTION
### Motivation
- Provide lightweight local runtime observability for release-control decisions without enabling by default.  
- Capture numeric signals and metadata (not full prompt/candidate text) to enable debugging and monitoring of gate behavior.  
- Offer a compact local reporting tool and optional console trace to inspect telemetry files easily.

### Description
- Add a telemetry helper module `src/silence_as_control/telemetry.py` that appends best-effort JSONL events to a configurable path and is enabled via the `POR_TELEMETRY_ENABLED` env flag.  
- Wire telemetry into the API by calling `write_runtime_event` from `api/main.py` for `/por/evaluate` and `/por/complete`, include common decision fields via `_runtime_event_common`, and add an optional console trace controlled by `POR_TRACE_CONSOLE`.  
- Add a local summary script `scripts/runtime_observability_report.py` that reads the JSONL log at `runtime_logs/por_runtime_events.jsonl` (or `POR_TELEMETRY_LOG_PATH`) and prints aggregated metrics.  
- Add tests (`tests/test_telemetry.py`, `tests/test_runtime_observability_report.py`), update `README.md` with usage and add `runtime_logs/` to `.gitignore`.

### Testing
- Ran the new telemetry unit tests `tests/test_telemetry.py` which exercise `write_runtime_event` behavior and API integration, and they passed.  
- Ran the reporting tests `tests/test_runtime_observability_report.py` which validate JSONL parsing and summary output, and they passed.  
- Telemetry writes are best-effort and tested to not break endpoints when telemetry fails or is disabled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a001ae05b1083269cb9b0ad20ce5832)