### PR TITLE
docs: add runtime observability smoke walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,17 @@ POR_TELEMETRY_ENABLED=1 uvicorn api.main:app --reload
 ```
 
 By default events are written to `runtime_logs/por_runtime_events.jsonl`. Override
-the path with `POR_TELEMETRY_LOG_PATH`. Telemetry records decision metadata and
-numeric signals; it does not log full prompts or candidates by default. To print
-a concise local summary, run:
+the path with `POR_TELEMETRY_LOG_PATH`. Telemetry records compact decision
+metadata and numeric signals; it does not log full prompts or candidates by
+default. To print a concise local summary, run:
 
 ```bash
 python scripts/runtime_observability_report.py
 ```
+
+See `docs/runtime_observability.md` for a local smoke walkthrough you can verify
+in about two minutes, including Windows/PowerShell and Bash examples plus the
+expected report shape.
 
 ### What this proves / what it does not prove
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - `runtime_extensions.md` — optional runtime deployment helpers.
 - `experimental_features.md` — optional non-core MAYBE_SHORT_REGEN behavior.
 - `api_walkthrough.md` — broader API walkthrough.
+- `runtime_observability.md` — local telemetry smoke walkthrough and report shape.
 - `threshold_regime_contract.md` — scoped threshold interpretation contract for SimpleQA/Ollama evidence.
 - `evidence_map.md` — claim-to-artifact navigation for core/runtime/benchmark surfaces.
 - `langchain_openai_action_risk_benchmark.md` — LangChain/OpenAI action-risk benchmark framing and Run 06 hardened v4 progression.

--- a/docs/runtime_observability.md
+++ b/docs/runtime_observability.md
@@ -1,0 +1,75 @@
+# Runtime observability smoke walkthrough
+
+This walkthrough verifies the local runtime telemetry path for `/por/evaluate` in
+about two minutes. Telemetry is disabled by default and must be enabled
+explicitly with `POR_TELEMETRY_ENABLED`.
+
+## Windows / PowerShell
+
+Start from a clean local telemetry file, enable telemetry, and run the API:
+
+```powershell
+Remove-Item -Recurse -Force runtime_logs -ErrorAction SilentlyContinue
+$env:POR_TELEMETRY_ENABLED="1"
+$env:POR_TELEMETRY_LOG_PATH="runtime_logs/por_runtime_events.jsonl"
+uvicorn api.main:app --reload
+```
+
+In another terminal, send one deterministic evaluation request and print the
+local report:
+
+```powershell
+curl.exe -s http://127.0.0.1:8000/por/evaluate `
+  -H "content-type: application/json" `
+  -d "{\"prompt\":\"Return valid JSON\",\"candidate\":\"not json\",\"threshold\":0.39}"
+
+python scripts/runtime_observability_report.py
+```
+
+## Bash / macOS / Linux
+
+Start from a clean local telemetry file, enable telemetry, and run the API:
+
+```bash
+rm -rf runtime_logs
+POR_TELEMETRY_ENABLED=1 POR_TELEMETRY_LOG_PATH=runtime_logs/por_runtime_events.jsonl uvicorn api.main:app --reload
+```
+
+In another terminal, send one deterministic evaluation request and print the
+local report:
+
+```bash
+curl -s http://127.0.0.1:8000/por/evaluate \
+  -H 'content-type: application/json' \
+  -d '{"prompt":"Return valid JSON","candidate":"not json","threshold":0.39}'
+
+python scripts/runtime_observability_report.py
+```
+
+## Expected report shape
+
+The exact decision and numeric values depend on the evaluation result, so treat
+floating-point fields as approximate. After one request, the report should have
+this shape:
+
+```text
+path: runtime_logs/por_runtime_events.jsonl
+total_events: 1
+malformed_lines: 0
+events_by_type: {"por.evaluate": 1}
+decisions_by_type: ...
+release_count: ...
+silence_count: ...
+average_drift: ...
+average_coherence: ...
+average_instability_score: ...
+```
+
+## Privacy and scope
+
+- Telemetry writes to a local JSONL file only.
+- Telemetry is disabled by default.
+- Events record compact metadata and numeric signals.
+- Events do not log full prompt or candidate text by default.
+- This smoke walkthrough is not production monitoring.
+- This smoke walkthrough is not a universal safety claim.


### PR DESCRIPTION
### Motivation
- Provide a concise, reproducible local smoke walkthrough so a new user can verify runtime telemetry in about two minutes.
- Make the README concise while offering a dedicated `docs/runtime_observability.md` for step-by-step Windows and Bash examples and the expected report shape.

### Description
- Add `docs/runtime_observability.md` containing PowerShell and Bash flows to enable telemetry, call `/por/evaluate`, run `python scripts/runtime_observability_report.py`, show an expected report shape, and state privacy/scope notes.
- Update `README.md` to clarify telemetry wording and add a short pointer to the new walkthrough in `docs/runtime_observability.md`.
- Update `docs/README.md` to include the new `runtime_observability.md` in the docs index; this is documentation-only and does not change PoR core, threshold logic, API behavior, telemetry implementation, or benchmark artifacts.
- Files changed: `docs/runtime_observability.md` (new), `README.md` (edited), and `docs/README.md` (edited).

### Testing
- Ran `git diff --check` with no issues detected.
- Ran `python -m pytest tests/test_telemetry.py -q` which succeeded (`8 passed`).
- Ran `python -m pytest tests/test_runtime_observability_report.py -q` which succeeded (`4 passed`).
- Ran `python -m pytest tests/test_api.py -q` which succeeded (`15 passed`).
- Ran `python demo/canonical_runtime_demo.py` which executed the canonical demo output successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a001edf8c248326b40f47e610f45fb5)