### PR TITLE
Fix telemetry drift_samples recording and PowerShell walkthrough

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -404,7 +404,7 @@ def complete(req: CompleteRequest) -> CompleteResponse:
             **_runtime_event_common(result),
             "model": req.model,
             "use_adaptive_threshold": req.use_adaptive_threshold,
-            "drift_samples": req.drift_samples,
+            "drift_samples": sample_count,
             "enable_experimental_short_regen": resolve_experimental_short_regen_flag(req),
             "prompt_length": len(req.prompt),
             "regenerated": regenerated,

--- a/docs/runtime_observability.md
+++ b/docs/runtime_observability.md
@@ -19,9 +19,17 @@ In another terminal, send one deterministic evaluation request and print the
 local report:
 
 ```powershell
-curl.exe -s http://127.0.0.1:8000/por/evaluate `
-  -H "content-type: application/json" `
-  -d "{\"prompt\":\"Return valid JSON\",\"candidate\":\"not json\",\"threshold\":0.39}"
+$body = @{
+  prompt = "Return valid JSON"
+  candidate = "not json"
+  threshold = 0.39
+} | ConvertTo-Json -Compress
+
+Invoke-RestMethod `
+  -Uri "http://127.0.0.1:8000/por/evaluate" `
+  -Method Post `
+  -ContentType "application/json" `
+  -Body $body
 
 python scripts/runtime_observability_report.py
 ```

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -136,6 +136,44 @@ def test_api_complete_writes_telemetry_without_prompt_or_candidate_text(monkeypa
     assert candidate not in serialized_event
 
 
+def test_api_complete_telemetry_records_clamped_drift_sample_count(monkeypatch, tmp_path):
+    log_path = tmp_path / "events.jsonl"
+    prompt = "complete zero drift samples prompt"
+    candidate = "complete zero drift samples candidate"
+    monkeypatch.setenv("POR_TELEMETRY_ENABLED", "1")
+    monkeypatch.setenv("POR_TELEMETRY_LOG_PATH", str(log_path))
+
+    def fake_generate_candidate(*args, **kwargs):
+        return candidate
+
+    def fake_score_candidate_runtime(prompt, candidate, threshold, candidate_samples=None):
+        return {
+            "drift": 0.10,
+            "coherence": 0.95,
+            "instability_score": 0.075,
+            "threshold": threshold,
+            "decision": "PROCEED",
+            "release_output": candidate,
+            "silence_token": None,
+            "notes": ["stable"],
+        }
+
+    monkeypatch.setattr(api_main, "generate_candidate", fake_generate_candidate)
+    monkeypatch.setattr(api_main, "score_candidate_runtime", fake_score_candidate_runtime)
+
+    response = client.post(
+        "/por/complete",
+        json={"prompt": prompt, "threshold": 0.39, "drift_samples": 0},
+    )
+
+    assert response.status_code == 200
+    events = _read_jsonl(log_path)
+    assert len(events) == 1
+    event = events[0]
+    assert event["event_type"] == "por.complete"
+    assert event["drift_samples"] == 1
+
+
 def test_api_evaluate_telemetry_failure_does_not_break_endpoint(monkeypatch):
     def broken_write_runtime_event(event):
         raise RuntimeError("telemetry boom")


### PR DESCRIPTION
### Motivation
- Follow-up fixes for two post-merge review points: a fragile PowerShell example in the runtime observability walkthrough and mismatched telemetry semantics for `drift_samples` recorded by `/por/complete`.
- Telemetry should report the actual number of samples generated by the runtime loop rather than the raw client input to avoid misleading event data.
- Keep the change minimal and scoped: do not alter PoR core, threshold logic, telemetry schema, benchmarks, or add dependencies.

### Description
- Replaced the fragile `curl.exe -d ...` PowerShell example in `docs/runtime_observability.md` with a PowerShell-safe body construction using a hashtable piped to `ConvertTo-Json -Compress` and `Invoke-RestMethod` to post JSON reliably.
- Updated `/por/complete` telemetry in `api/main.py` to record the clamped runtime `sample_count` (`"drift_samples": sample_count`) instead of the raw `req.drift_samples` so telemetry reflects actual candidates generated.
- Added a focused regression test in `tests/test_telemetry.py` named `test_api_complete_telemetry_records_clamped_drift_sample_count` that posts `"drift_samples": 0` and asserts the telemetry event records `drift_samples == 1`.
- Changes are limited to `docs/runtime_observability.md`, `api/main.py`, and `tests/test_telemetry.py` and preserve core behavior and schema.

### Testing
- Ran `git diff --check` and it returned clean results.
- Ran `python -m pytest tests/test_telemetry.py -q` and the test suite passed.
- Ran `python -m pytest tests/test_runtime_observability_report.py -q` and the test suite passed.
- Ran `python -m pytest tests/test_api.py -q` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a002329c2f08326986842faf81746ef)