### PR TITLE
docs: map runtime observability evidence

### DIFF
--- a/docs/evidence_map.md
+++ b/docs/evidence_map.md
@@ -23,6 +23,27 @@ These define the primitive thresholded release behavior (`PROCEED` / `SILENCE`).
 
 These define deployment-facing surfaces around, but not replacing, the primitive contract.
 
+## Runtime observability / local telemetry
+
+Runtime release-control decisions can be locally observed and summarized when telemetry is explicitly enabled.
+
+Artifacts:
+
+- `src/silence_as_control/telemetry.py`
+- `scripts/runtime_observability_report.py`
+- `docs/runtime_observability.md`
+- `tests/test_telemetry.py`
+- `tests/test_runtime_observability_report.py`
+
+Interpretation boundaries:
+
+- Telemetry is disabled by default.
+- Telemetry is local JSONL only.
+- Telemetry records compact decision metadata and numeric signals.
+- Telemetry does not log full prompt/candidate text by default.
+- This is not production monitoring.
+- This is not a universal AI safety claim.
+
 ## Benchmark / evaluation files
 
 - `eval_simpleqa_ollama.py`
@@ -80,6 +101,10 @@ Interpretation boundaries:
 - Claim: Threshold behavior is regime/scoped, not universal.
   - Evidence: threshold contract + run-specific artifacts.
   - Files: `docs/threshold_regime_contract.md`, `results/simpleqa_ollama_qwen3_4b_100_v2_retry/`, `results/simpleqa_ollama_qwen3_8b_100_v2/`.
+
+- Claim: Runtime release-control decisions can be locally observed and summarized.
+  - Evidence: opt-in JSONL telemetry writer, report script, smoke walkthrough, and tests.
+  - Files: `src/silence_as_control/telemetry.py`, `scripts/runtime_observability_report.py`, `docs/runtime_observability.md`, `tests/test_telemetry.py`, `tests/test_runtime_observability_report.py`.
 
 - Claim: Qwen3 4B reached zero accepted wrong at selected thresholds in this 100-example run.
   - Evidence: PR #131 artifacts and summary tables.


### PR DESCRIPTION
### Motivation

- Capture and surface the new runtime/local telemetry evidence so readers can verify that runtime release-control decisions are observable when telemetry is opt-in. 
- Keep the claim conservative and evidence-first by limiting scope to local JSONL telemetry and clarifying interpretation boundaries.

### Description

- Added a `## Runtime observability / local telemetry` section to `docs/evidence_map.md` that states the scoped claim and lists artifacts and interpretation boundaries. 
- Added a short Claim -> artifact mapping entry linking the claim to `src/silence_as_control/telemetry.py`, `scripts/runtime_observability_report.py`, `docs/runtime_observability.md`, `tests/test_telemetry.py`, and `tests/test_runtime_observability_report.py`. 
- No runtime, telemetry implementation, tests, benchmark artifacts, or PoR core code were changed. 
- `docs/README.md` already links to `runtime_observability.md`, so no index update was required.

### Testing

- Ran `git diff --check` with no issues. 
- Ran `python -m pytest tests/test_telemetry.py -q` and it passed. 
- Ran `python -m pytest tests/test_runtime_observability_report.py -q` and it passed. 
- Ran `python -m pytest tests/test_api.py -q` and `python demo/canonical_runtime_demo.py`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00248a1ac88326954c81a902dd5d2a)