### PR TITLE
Add .env.example and provider configuration docs for runtime onboarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# Silence-as-Control local runtime configuration
+#
+# No provider key is required for:
+# - tests
+# - GET /health
+# - POST /por/evaluate
+# - demo/canonical_runtime_demo.py
+# - local telemetry walkthrough for /por/evaluate
+#
+# Provider-backed completion requires XAI_API_KEY.
+# This is used by POST /por/complete when generating a candidate via the provider.
+XAI_API_KEY=
+XAI_MODEL=grok-4
+
+# Optional runtime gate threshold.
+# Current practical safe anchor in docs/evidence: 0.39
+POR_RUNTIME_GATE_THRESHOLD=0.39
+
+# Optional local JSONL telemetry.
+# Disabled by default. Set to 1 to write compact local runtime decision events.
+POR_TELEMETRY_ENABLED=0
+POR_TELEMETRY_LOG_PATH=runtime_logs/por_runtime_events.jsonl

--- a/README.md
+++ b/README.md
@@ -21,17 +21,45 @@ python -m pip install -r requirements.txt
 python -m pip install -e .
 ```
 
-### API key guidance
-- The deterministic core, local tests, and `demo/canonical_runtime_demo.py` do not
-  require provider API keys.
-- Provider-backed `/por/complete` currently uses the xAI-compatible runtime
-  wrapper and requires `XAI_API_KEY`; `XAI_MODEL` can override the default
-  provider model.
-- Docker Compose passes `XAI_API_KEY` and `XAI_MODEL` through to the container
-  for provider-backed completion.
-- OpenAI-backed demos or live benchmark scripts outside the Docker runtime path
-  should read credentials from environment variables such as `OPENAI_API_KEY`.
-- Do not commit API keys, prompt logs containing secrets, or provider tokens.
+## Configuration paths
+
+### No-key deterministic path
+
+These do not require provider API keys and work without any provider/API key:
+- `python demo/canonical_runtime_demo.py`
+- `GET /health`
+- `POST /por/evaluate`
+- telemetry smoke walkthrough using `/por/evaluate`
+- tests
+
+### Provider-backed completion path
+
+Provider-backed `/por/complete` requires provider configuration when it needs
+to generate candidate output and requires `XAI_API_KEY`. Configure:
+
+- `XAI_API_KEY`
+- `XAI_MODEL` (default example: `grok-4`)
+
+Use `.env.example` as the local template. For PowerShell/Windows:
+
+```powershell
+copy .env.example .env
+```
+
+For Bash/macOS/Linux:
+
+```bash
+cp .env.example .env
+```
+
+Docker Compose passes `XAI_API_KEY` and `XAI_MODEL` through to the container
+for provider-backed completion. For Docker Compose with the local template:
+
+```bash
+docker compose --env-file .env up --build
+```
+
+Do not commit API keys, prompt logs containing secrets, or provider tokens.
 
 
 ## Runtime Quickstart
@@ -53,13 +81,13 @@ http://127.0.0.1:8000/docs
 
 Run with Docker Compose:
 ```bash
-docker compose up --build
+docker compose --env-file .env up --build
 ```
 
 For provider-backed `/por/complete` through Docker Compose, set `XAI_API_KEY`
-before starting the service. Set `XAI_MODEL` only when overriding the default
-provider model. The deterministic health check, `/por/evaluate`, and canonical
-runtime demo do not require provider credentials.
+in `.env` before starting the service. Set `XAI_MODEL` only when overriding the
+default provider model. The deterministic health check, `/por/evaluate`, and
+canonical runtime demo do not require provider credentials.
 
 Docker smoke check from another terminal:
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - `experimental_features.md` — optional non-core MAYBE_SHORT_REGEN behavior.
 - `api_walkthrough.md` — broader API walkthrough.
 - `runtime_observability.md` — local telemetry smoke walkthrough and report shape.
+- `provider_configuration.md` — no-key vs provider-backed runtime configuration.
 - `threshold_regime_contract.md` — scoped threshold interpretation contract for SimpleQA/Ollama evidence.
 - `evidence_map.md` — claim-to-artifact navigation for core/runtime/benchmark surfaces.
 - `langchain_openai_action_risk_benchmark.md` — LangChain/OpenAI action-risk benchmark framing and Run 06 hardened v4 progression.

--- a/docs/evidence_map.md
+++ b/docs/evidence_map.md
@@ -20,6 +20,7 @@ These define the primitive thresholded release behavior (`PROCEED` / `SILENCE`).
 - `api/por_runtime.py`
 - `api/main.py`
 - `api/experimental_recovery.py` (explicitly experimental lane)
+- `docs/provider_configuration.md` (navigation/support for no-key vs provider-backed runtime setup)
 
 These define deployment-facing surfaces around, but not replacing, the primitive contract.
 

--- a/docs/provider_configuration.md
+++ b/docs/provider_configuration.md
@@ -1,0 +1,78 @@
+# Provider configuration
+
+This page separates deterministic local runtime paths from provider-backed
+candidate generation so local setup does not conflate PoR evaluation with API key
+configuration.
+
+## No-key deterministic path
+
+These paths work without any provider/API key:
+
+- `python demo/canonical_runtime_demo.py`
+- `GET /health`
+- `POST /por/evaluate`
+- local telemetry smoke walkthroughs that call `/por/evaluate`
+- tests
+
+The deterministic path evaluates already-supplied candidate text and signals. It
+does not need a provider to generate candidate output.
+
+## Provider-backed completion path
+
+`POST /por/complete` requires provider configuration when it needs to generate a
+candidate via the provider before applying the runtime gate.
+
+Configure:
+
+- `XAI_API_KEY` — provider key for candidate generation.
+- `XAI_MODEL` — provider model name. The local template uses `grok-4` as the
+  default example.
+
+Use the root `.env.example` file as a local template:
+
+PowerShell/Windows:
+
+```powershell
+copy .env.example .env
+```
+
+Bash/macOS/Linux:
+
+```bash
+cp .env.example .env
+```
+
+## Environment variables
+
+- `XAI_API_KEY` — required only for provider-backed candidate generation in
+  `/por/complete`.
+- `XAI_MODEL` — optional provider model override for `/por/complete`.
+- `POR_RUNTIME_GATE_THRESHOLD` — optional runtime gate threshold. The practical
+  safe anchor documented in current evidence is `0.39`; threshold behavior is
+  scoped and should be calibrated for new settings.
+- `POR_TELEMETRY_ENABLED` — optional local JSONL telemetry switch. It is disabled
+  by default; set to `1` to write compact local runtime decision events.
+- `POR_TELEMETRY_LOG_PATH` — optional path for local JSONL telemetry events.
+
+## Docker/local notes
+
+For a local Python runtime, export the variables in your shell or load them from
+`.env` with your usual local workflow before starting the API.
+
+For Docker Compose, use the repo-local template after copying it to `.env`:
+
+```bash
+docker compose --env-file .env up --build
+```
+
+The compose file passes `XAI_API_KEY` and `XAI_MODEL` into the container for the
+provider-backed completion path. No provider key is needed for `/health`,
+`/por/evaluate`, or the canonical runtime demo.
+
+## Scope boundaries
+
+- Provider configuration is only for candidate generation in `/por/complete`.
+- Provider configuration does not change PoR core.
+- Provider configuration does not change threshold logic.
+- This does not make the runtime production monitoring.
+- Telemetry remains opt-in and local.


### PR DESCRIPTION
### Motivation

- Clarify onboarding for new users about which runtime/API paths work without a provider key and which require a provider-backed key for candidate generation. 
- Keep the distinction between deterministic PoR evaluation and provider-backed candidate generation explicit, while leaving core PoR logic, thresholds, telemetry, and benchmarks unchanged.

### Description

- Add a root `.env.example` with `XAI_API_KEY`, `XAI_MODEL`, optional `POR_RUNTIME_GATE_THRESHOLD`, and opt-in `POR_TELEMETRY_*` settings. (added: `.env.example`)
- Add `docs/provider_configuration.md` describing the no-key deterministic path, the provider-backed `/por/complete` path, environment variables, Docker/local notes, and explicit scope boundaries. (added: `docs/provider_configuration.md`)
- Replace the old README onboarding block with a new `## Configuration paths` section that lists the no-key deterministic paths and provider-backed `/por/complete` guidance, shows `.env` copy commands for PowerShell and Bash, and points to Docker Compose `--env-file`. (modified: `README.md`)
- Link the new provider guide from `docs/README.md` and add it to `docs/evidence_map.md` as a navigation/support artifact only. (modified: `docs/README.md`, `docs/evidence_map.md`)

### Testing

- Ran `git diff --check` with no issues. (passed)
- Ran `python -m pytest tests/test_api.py -q` and all tests passed. (15 passed)
- Ran `python demo/canonical_runtime_demo.py` and the demo executed successfully. (ran)
- Ran `python -m pytest tests/test_telemetry.py -q` and `python -m pytest tests/test_runtime_observability_report.py -q` and both test suites passed. (9 passed and 4 passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a002841f13483268dced8db21eb26ae)