### PR TITLE
Pass PoR runtime env through Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ For Bash/macOS/Linux:
 cp .env.example .env
 ```
 
-Docker Compose passes `XAI_API_KEY` and `XAI_MODEL` through to the container
-for provider-backed completion. For Docker Compose with the local template:
+Docker Compose maps `XAI_*`, `POR_RUNTIME_GATE_THRESHOLD`, and
+`POR_TELEMETRY_*` into the API container. For Docker Compose with the local
+template:
 
 ```bash
 docker compose --env-file .env up --build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,6 @@ services:
     environment:
       XAI_API_KEY: ${XAI_API_KEY:-}
       XAI_MODEL: ${XAI_MODEL:-}
+      POR_RUNTIME_GATE_THRESHOLD: ${POR_RUNTIME_GATE_THRESHOLD:-0.39}
+      POR_TELEMETRY_ENABLED: ${POR_TELEMETRY_ENABLED:-0}
+      POR_TELEMETRY_LOG_PATH: ${POR_TELEMETRY_LOG_PATH:-runtime_logs/por_runtime_events.jsonl}

--- a/docs/provider_configuration.md
+++ b/docs/provider_configuration.md
@@ -65,9 +65,10 @@ For Docker Compose, use the repo-local template after copying it to `.env`:
 docker compose --env-file .env up --build
 ```
 
-The compose file passes `XAI_API_KEY` and `XAI_MODEL` into the container for the
-provider-backed completion path. No provider key is needed for `/health`,
-`/por/evaluate`, or the canonical runtime demo.
+Docker Compose maps `XAI_*`, `POR_RUNTIME_GATE_THRESHOLD`, and
+`POR_TELEMETRY_*` into the API container when using `--env-file .env`. No
+provider key is needed for `/health`, `/por/evaluate`, or the canonical runtime
+demo.
 
 ## Scope boundaries
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,11 +14,17 @@ client = TestClient(app)
 # Runtime provider configuration docs
 # ------------------------------
 
-def test_docker_compose_passes_xai_provider_environment():
+def test_docker_compose_passes_runtime_environment():
     compose = Path("docker-compose.yml").read_text()
 
     assert "XAI_API_KEY: ${XAI_API_KEY:-}" in compose
     assert "XAI_MODEL: ${XAI_MODEL:-}" in compose
+    assert "POR_RUNTIME_GATE_THRESHOLD: ${POR_RUNTIME_GATE_THRESHOLD:-0.39}" in compose
+    assert "POR_TELEMETRY_ENABLED: ${POR_TELEMETRY_ENABLED:-0}" in compose
+    assert (
+        "POR_TELEMETRY_LOG_PATH: "
+        "${POR_TELEMETRY_LOG_PATH:-runtime_logs/por_runtime_events.jsonl}"
+    ) in compose
     assert "OPENAI_API_KEY: ${OPENAI_API_KEY:-}" not in compose
     assert "OPENAI_MODEL: ${OPENAI_MODEL:-}" not in compose
 
@@ -29,7 +35,8 @@ def test_readme_documents_xai_provider_completion_guidance():
 
     assert "Provider-backed `/por/complete`" in readme
     assert "requires `XAI_API_KEY`" in readme
-    assert "Docker Compose passes `XAI_API_KEY` and `XAI_MODEL`" in readme
+    assert "Docker Compose maps `XAI_*`, `POR_RUNTIME_GATE_THRESHOLD`, and" in readme
+    assert "`POR_TELEMETRY_*` into the API container" in readme
     assert "demo/canonical_runtime_demo.py" in readme
     assert "do not require provider API keys" in normalized_readme
 


### PR DESCRIPTION
### Motivation
- Ensure the runtime gate and telemetry variables documented in `.env.example` actually reach the API container when using Docker Compose with `--env-file .env` so documentation and behavior are consistent.

### Description
- Added `POR_RUNTIME_GATE_THRESHOLD`, `POR_TELEMETRY_ENABLED`, and `POR_TELEMETRY_LOG_PATH` to the API service `environment` in `docker-compose.yml` with defaults matching `.env.example` (`${POR_RUNTIME_GATE_THRESHOLD:-0.39}`, `${POR_TELEMETRY_ENABLED:-0}`, `${POR_TELEMETRY_LOG_PATH:-runtime_logs/por_runtime_events.jsonl}`).
- Updated `docs/provider_configuration.md` and `README.md` to state that Docker Compose maps `XAI_*`, `POR_RUNTIME_GATE_THRESHOLD`, and `POR_TELEMETRY_*` into the API container when using `--env-file .env`.
- Extended `tests/test_api.py` assertions to verify the new Compose environment mappings and adjusted README guidance assertions to match the updated wording.
- Files changed: `docker-compose.yml`, `docs/provider_configuration.md`, `README.md`, `tests/test_api.py`.

### Testing
- Ran `git diff --check` with no issues detected.
- `docker compose config` could not be executed in this environment because the Docker CLI is unavailable (`docker: command not found`).
- Ran `python -m pytest tests/test_api.py -q` and all tests in that suite passed.
- Ran the canonical runtime demo with `python demo/canonical_runtime_demo.py` which executed successfully.
- Ran `python -m pytest tests/test_telemetry.py -q` and `python -m pytest tests/test_runtime_observability_report.py -q` and both suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0032c1a4f48326b30df6171559764a)