### PR TITLE
docs: add no-key first-run checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Do not commit API keys, prompt logs containing secrets, or provider tokens.
 
 ## Runtime Quickstart
 
+For a no-key first-run verification path, see `docs/first_run_checklist.md`.
+
 Local editable install:
 ```bash
 python -m pip install -e .

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - `experimental_features.md` — optional non-core MAYBE_SHORT_REGEN behavior.
 - `api_walkthrough.md` — broader API walkthrough.
 - `runtime_observability.md` — local telemetry smoke walkthrough and report shape.
+- `first_run_checklist.md` — no-key first-run verification path.
 - `provider_configuration.md` — no-key vs provider-backed runtime configuration.
 - `threshold_regime_contract.md` — scoped threshold interpretation contract for SimpleQA/Ollama evidence.
 - `evidence_map.md` — claim-to-artifact navigation for core/runtime/benchmark surfaces.

--- a/docs/evidence_map.md
+++ b/docs/evidence_map.md
@@ -21,6 +21,7 @@ These define the primitive thresholded release behavior (`PROCEED` / `SILENCE`).
 - `api/main.py`
 - `api/experimental_recovery.py` (explicitly experimental lane)
 - `docs/provider_configuration.md` (navigation/support for no-key vs provider-backed runtime setup)
+- `docs/first_run_checklist.md` (navigation/support for no-key first-run verification)
 
 These define deployment-facing surfaces around, but not replacing, the primitive contract.
 

--- a/docs/first_run_checklist.md
+++ b/docs/first_run_checklist.md
@@ -1,0 +1,82 @@
+# First-run checklist
+
+This checklist verifies the no-key local path first. It does not require provider credentials.
+
+## What this checks
+
+- package/import path works
+- API tests pass
+- canonical runtime demo runs
+- deterministic /por/evaluate path is available
+- telemetry can be enabled and summarized locally
+- provider-backed /por/complete remains separate and requires provider configuration
+
+## 1. Install
+
+Run:
+
+    python -m venv .venv
+    source .venv/bin/activate  # Windows: .venv\Scripts\activate
+    python -m pip install --upgrade pip
+    python -m pip install -r requirements.txt
+    python -m pip install -e .
+
+## 2. Run no-key tests
+
+Run:
+
+    python -m pytest tests/test_api.py -q
+
+Expected:
+
+    passed
+
+## 3. Run canonical runtime demo
+
+Run:
+
+    python demo/canonical_runtime_demo.py
+
+Expected:
+- the demo prints baseline release behavior
+- the PoR gate returns PROCEED / NEEDS_REVIEW / SILENCE examples
+- no provider key is required
+
+## 4. Start local API
+
+Run:
+
+    uvicorn api.main:app --reload
+
+In another terminal, run:
+
+    curl http://127.0.0.1:8000/health
+
+Expected:
+- HTTP response from the local API
+- no provider key required
+
+## 5. Optional telemetry smoke check
+
+For local telemetry verification, see:
+
+    docs/runtime_observability.md
+
+Keep this section short. Do not duplicate the full telemetry guide.
+
+## 6. Provider-backed completion
+
+For provider-backed completion setup, see:
+
+    docs/provider_configuration.md
+
+State clearly:
+- /por/complete may require XAI_API_KEY when generating candidate output
+- deterministic checks above do not require a provider key
+
+## Scope boundaries
+
+- This checklist verifies local onboarding only.
+- This is not a production deployment guide.
+- This is not a benchmark result.
+- This is not a universal AI safety claim.


### PR DESCRIPTION
### Motivation

- Provide a concise onboarding checklist that verifies the no-key local path without requiring provider credentials.
- Surface a minimal verification path that confirms package importability, API health, deterministic runtime demo, and optional local telemetry.

### Description

- Added `docs/first_run_checklist.md` containing a short step-by-step first-run checklist for no-key verification.
- Linked the checklist from `docs/README.md` and added a concise pointer to it in `README.md` near the Runtime Quickstart.
- Added `docs/first_run_checklist.md` as a navigation/support artifact in `docs/evidence_map.md` under the Runtime/API area without making broad new claims.
- Changes are documentation-only and preserve core/runtime/telemetry/docker/benchmark code and behavior.

### Testing

- Ran `git diff --check` with no issues.
- Ran `python -m pytest tests/test_api.py -q` and `python -m pytest tests/test_telemetry.py -q` which passed.
- Ran `python -m pytest tests/test_runtime_observability_report.py -q` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00377326208326afc371b6cbd8ed82)