### PR TITLE
Add README Start here section

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ It does **not** improve model weights. It controls release behavior.
 **Same model. Different decision.**
 
 
+## Start here
+
+New users should start with the no-key path:
+
+1. Run the first-run checklist: `docs/first_run_checklist.md`
+2. Run the canonical demo: `python demo/canonical_runtime_demo.py`
+3. Inspect runtime observability: `docs/runtime_observability.md`
+4. Configure provider-backed completion only if needed: `docs/provider_configuration.md`
+5. Follow the claim-to-artifact map: `docs/evidence_map.md`
+
+The deterministic path does not require provider credentials.
+Provider-backed `/por/complete` may require `XAI_API_KEY` when generating candidate output.
+
+
 ## Installation and dependency setup
 
 ### From a fresh checkout


### PR DESCRIPTION
### Motivation
- The repository recently gained onboarding artifacts (first-run checklist, demo, telemetry, provider docs, evidence map) but lacked a clear front door for new technical readers. 
- New users need a concise, no-key-first-run path that separates deterministic usage from provider-backed completion. 

### Description
- Added a new `## Start here` section near the top of `README.md` that links to `docs/first_run_checklist.md`, `python demo/canonical_runtime_demo.py`, `docs/runtime_observability.md`, `docs/provider_configuration.md`, and `docs/evidence_map.md`.
- Clarified that the deterministic/no-key path does not require provider credentials and that provider-backed `/por/complete` may require `XAI_API_KEY` for candidate generation.
- Kept the README as a front door only and did not duplicate the full first-run checklist or modify any runtime/telemetry/Docker/benchmark code.

### Testing
- Ran `git diff --check` with no warnings.
- Ran `python -m pytest tests/test_api.py -q` which passed (15 tests passed).
- Ran `python demo/canonical_runtime_demo.py` which executed successfully and produced the canonical demo output.
- Ran `python -m pytest tests/test_runtime_observability_report.py -q` and `python -m pytest tests/test_telemetry.py -q`, both of which passed (reported test counts: 9 and 4 respectively).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0039338aa0832684b1d3c7d0d6928b)