### PR TITLE
docs: add Applied bridges note referencing por-copilot-bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,12 @@ Open a GitHub issue if you want integration help, audit/evaluation support, or b
 - Not a claim of guaranteed truth.
 - Not a framework rewrite of inference stacks.
 
+## Applied bridges
+
+[`por-copilot-bridge`](https://github.com/SemeAIPletinnya/por-copilot-bridge) is a small deterministic release-governance bridge for AI coding-agent outputs. It demonstrates the same core separation: **generation is not release**.
+
+In that bridge, coding-agent output is treated as a release candidate. The bridge maps candidates to `PROCEED` / `NEEDS_REVIEW` / `SILENCE` so downstream release handling can remain explicit. It is dependency-free and compatible by state/schema; it is not a direct dependency of Silence-as-Control.
+
 ## Core primitive in 30 seconds
 PoR uses:
 - drift,

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,5 +14,6 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - `langchain_openai_action_risk_benchmark.md` — LangChain/OpenAI action-risk benchmark framing and Run 06 hardened v4 progression.
 - `action_risk_1000_dataset.md` — Run 06 1000-case synthetic dataset scope and schema.
 - `release_control_services.md` — pilot/integration overview for release-control use cases.
+- `applied_bridges.md` — bounded notes on compatible applied bridges such as `por-copilot-bridge`.
 
 For paper/preprint context, see `../paper/README.md`.

--- a/docs/applied_bridges.md
+++ b/docs/applied_bridges.md
@@ -1,0 +1,11 @@
+# Applied bridges
+
+Applied bridges are small integration-layer examples that reuse the Silence-as-Control separation between generation and release without changing the primitive core, runtime thresholds, or evaluation claims.
+
+## por-copilot-bridge
+
+[`por-copilot-bridge`](https://github.com/SemeAIPletinnya/por-copilot-bridge) is a small deterministic release-governance bridge for AI coding-agent outputs. It treats coding-agent output as a release candidate rather than an automatically releasable artifact.
+
+The bridge demonstrates the same core separation used here: generation is not release. It maps candidates to `PROCEED` / `NEEDS_REVIEW` / `SILENCE` so a downstream workflow can decide whether to release, route for review, or abstain.
+
+The bridge is dependency-free and compatible by state/schema. It is not a direct dependency of Silence-as-Control, and it does not imply a universal safety guarantee, automatic correctness, model improvement, or autonomous release authority.


### PR DESCRIPTION
### Motivation

- Provide a concise, repository-level pointer to an applied bridge example that demonstrates release-governance for coding-agent outputs while preserving the repo's core separation between generation and release. 
- Clarify integration compatibility (state/schema) without implying new runtime dependencies or overstated claims about safety, correctness, or autonomous release authority.

### Description

- Add an "Applied bridges" section to `README.md` that references `por-copilot-bridge` and restates the core separation that generation is not release. 
- Add `docs/applied_bridges.md` describing `por-copilot-bridge` as a small deterministic release-governance bridge that maps candidates to `PROCEED` / `NEEDS_REVIEW` / `SILENCE`, is dependency-free, and is compatible by state/schema rather than being a direct dependency. 
- Update `docs/README.md` to include the new `applied_bridges.md` entry in the docs index. 
- No runtime code, tests, thresholds, evaluation results, or claims beyond the bounded documentation language were changed. 

### Testing

- Ran unit tests with `python -m pytest -q` which completed successfully (`222 passed`).
- Ran a repository check with `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0095843ac08326ad29073eade8018e)