### PR TITLE
docs: add roadmap to July 2026 milestone

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ For pilot or integration interest, see `docs/release_control_services.md`.
 - Repository root: `./`
 - README: `README.md`
 - Docs index: `docs/README.md`
+- [Roadmap to July 4–8, 2026](docs/roadmap_2026.md)
 - External CLI integration: `docs/external_integration.md`
 - Package migration plan: `docs/package_migration_plan.md`
 - Changelog: `CHANGELOG.md`

--- a/docs/roadmap_2026.md
+++ b/docs/roadmap_2026.md
@@ -1,0 +1,121 @@
+# Silence-as-Control / PoR Roadmap to July 4–8, 2026
+
+This roadmap describes a conservative path for Silence-as-Control / Proof-of-Resonance (PoR) through the July 4–8, 2026 one-year milestone. It is a planning document, not a claim of production readiness or universal AI safety.
+
+The project is moving through four major stages:
+
+1. Crystallization
+2. Proof Surface
+3. Positioning
+4. Research / Integration Readiness
+
+The common thread across all phases is the same release-control distinction: generation is not release. A model may generate a candidate, but release behavior should be governed by explicit runtime signals, thresholds, and integration semantics.
+
+## Current State
+
+The repository already has the main ingredients of a release-control research-engineering surface:
+
+- a runtime release-control framing that treats generated output as a candidate rather than an automatic final answer;
+- PoR-style drift/coherence signals for evaluating candidate stability;
+- `PROCEED` / `SILENCE` / `NEEDS_REVIEW` semantics, with the review lane treated as an integration-level behavior where applicable;
+- benchmark and demo infrastructure for local, reproducible evaluation paths;
+- an API surface for evaluating and completing candidate outputs through runtime gating;
+- documentation and wiki-oriented evidence structure for connecting claims to artifacts;
+- public repository activity and reproducible artifacts that make the project inspectable.
+
+This state is meaningful but bounded. It does not establish universal AI safety, hallucination elimination, or production-grade deployment. The current evidence supports a narrower claim: release-control behavior can be made explicit, measured, and audited around model outputs.
+
+## Phase I — Crystallization
+
+Focus:
+
+- stabilize terminology across README, docs, and wiki materials;
+- clarify the core distinction: generation != release;
+- define what Silence-as-Control is and is not;
+- make README/wiki/docs language consistent without overloading the README;
+- keep the canonical demo path simple and easy to verify.
+
+Canonical demo command:
+
+```bash
+python demo/canonical_demo.py
+```
+
+Expected outcome: a new reader should be able to understand the project boundary quickly. Silence-as-Control should be presented as a lightweight runtime release-governance primitive, not as a new model, a training method, or a general-purpose safety solution.
+
+## Phase II — Proof Surface
+
+Focus:
+
+- harden benchmark reproducibility;
+- keep reports, CSVs, JSONL logs, and evaluation summaries aligned;
+- strengthen baseline-vs-PoR comparisons;
+- document threshold regimes clearly;
+- preserve limitations and scope alongside positive results.
+
+The project should avoid benchmark sprawl. A small number of clean, reproducible evaluation tracks is more useful than many loosely connected runs. Each benchmark track should make clear:
+
+- what was measured;
+- what threshold regime was used;
+- which artifacts support the summary;
+- what the result does and does not imply;
+- how baseline release behavior differs from PoR-gated release behavior.
+
+Expected outcome: the evidence surface should be navigable by a reviewer who wants to reproduce or challenge the claims, not only by someone already familiar with the repository.
+
+## Phase III — Positioning
+
+Focus:
+
+- use PR #200 as a milestone marker for project legibility;
+- provide a concise public explanation of the project’s role;
+- maintain a clean architecture diagram and visual identity;
+- explain ecosystem relevance to coding agents, approval fatigue, runtime trust boundaries, and release governance.
+
+Silence-as-Control is not trying to build a new model. It is exploring release-control behavior around model outputs. That distinction matters for positioning: the project belongs near runtime governance, abstention behavior, candidate evaluation, and release boundaries rather than model training or foundation-model capability improvement.
+
+Expected outcome: external readers should be able to place the project in the ecosystem without assuming exaggerated claims. The project should be understandable as a control layer that asks whether an output should be released, reviewed, or silenced.
+
+## Phase IV — Research / Integration Readiness
+
+Focus:
+
+- prepare stronger preprint and research documentation;
+- clarify operational definitions for drift, coherence, instability, thresholds, and release outcomes;
+- define integration paths for agent systems, coding copilots, and runtime inference pipelines;
+- explore future API and middleware use cases.
+
+This phase should convert the repository’s implementation and evidence into a more formal research and integration surface. The emphasis should remain operational: how release decisions are represented, measured, logged, and connected to downstream systems.
+
+Expected outcome: the project should be ready for more serious review by researchers, builders, and integration partners, while still clearly separating demonstrated behavior from future work.
+
+## Target State by July 4–8, 2026
+
+By the July 4–8, 2026 milestone, the target state is:
+
+- stable onboarding;
+- reproducible demos;
+- clear benchmark evidence;
+- mature documentation;
+- honest limitations;
+- visible release-control vocabulary;
+- credible research framing.
+
+This target state is about clarity, reproducibility, and disciplined framing. It does not require claiming that the system is complete, universally safe, or ready for every production environment.
+
+## Non-Goals
+
+This roadmap does not claim:
+
+- AGI;
+- universal AI safety;
+- hallucination elimination;
+- production-grade deployment;
+- model improvement;
+- guaranteed zero risk.
+
+Instead, it frames Silence-as-Control as a lightweight runtime release-governance primitive: a way to make release decisions explicit around generated outputs using measurable signals, thresholds, and integration semantics.
+
+## Final Principle
+
+> Generation is not authority. Release must be earned by stability.


### PR DESCRIPTION
### Motivation

- Provide a conservative, evidence-oriented roadmap that frames near-term work for Silence-as-Control / Proof-of-Resonance toward the July 4–8, 2026 one-year milestone. 
- Improve project legibility ahead of a milestone PR (#200) by clarifying phases, artifacts, and integration intents without inflating technical claims. 
- Surface a stable, discoverable place for planning and rubric-style guidance so detailed planning and evaluation live in `docs/` rather than bloating the README.

### Description

- Add `docs/roadmap_2026.md` which defines four phases (Crystallization, Proof Surface, Positioning, Research / Integration Readiness), a concise Current State, Target State, Non-Goals, and a Final Principle. 
- Update `README.md` to add a quick link to the new roadmap under the existing "Quick public links" section. 
- Keep language conservative and evidence-oriented, explicitly avoiding claims of production readiness, universal AI safety, model improvement, or guaranteed zero risk. 
- Include the canonical demo command `python demo/canonical_demo.py` and keep the document focused on reproducibility, benchmark hygiene, and integration-readiness rather than model training or capability claims.

### Testing

- Verified the canonical demo path exists with `test -f demo/canonical_demo.py`.
- Ran the full test suite with `python -m pytest` and observed `222 passed` test results. 
- No other automated formatting or link-breaking changes were introduced and existing documentation links were preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0821c93d6c8326bf1f1a0dab02a976)