### PR TITLE
docs: add project navigation map

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 
 You are here: documentation for architecture boundaries and public-facing guidance.
 
+- [Project navigation map](project_navigation.md) — where to start depending on what you need.
 - `architecture.md` — core vs runtime vs experimental split.
 - `runtime_extensions.md` — optional runtime deployment helpers.
 - `experimental_features.md` — optional non-core MAYBE_SHORT_REGEN behavior.

--- a/docs/project_navigation.md
+++ b/docs/project_navigation.md
@@ -1,0 +1,57 @@
+# Project Navigation Map
+
+## Purpose
+
+This file helps readers choose the right entry point without mixing the roles of the README, docs, issues, evidence, roadmap, and integration material.
+
+## High-level map
+
+```text
+README
+  ├─ Quick entry / project thesis
+  ├─ Plain-English pitch
+  ├─ Start here
+  └─ Quick public links
+
+docs/
+  ├─ plain_english_pitch.md          ← explain simply
+  ├─ first_run_checklist.md          ← verify locally
+  ├─ architecture.md                 ← core/runtime/experimental split
+  ├─ agentic_release_control.md      ← agentic release-control layer
+  ├─ evidence_map.md                 ← claims → artifacts
+  ├─ runtime_observability.md        ← telemetry verification
+  ├─ provider_configuration.md       ← API/provider setup
+  ├─ release_control_services.md     ← pilot/integration interest
+  └─ roadmap_2026.md                 ← milestone planning
+
+issues/
+  ├─ #202 memory capsule
+  └─ #203 roadmap/progress/dependency capsule
+```
+
+## Start depending on what you need
+
+| Need | Start here |
+| --- | --- |
+| Understand the idea simply | [Plain-English pitch](plain_english_pitch.md) |
+| Verify the project locally without keys | [First-run checklist](first_run_checklist.md) |
+| Understand the architecture split | [Architecture](architecture.md) |
+| Understand agentic release-control | [Agentic release-control](agentic_release_control.md) |
+| Check claims and artifacts | [Evidence map](evidence_map.md) |
+| Inspect runtime telemetry | [Runtime observability](runtime_observability.md) |
+| Configure provider-backed completion | [Provider configuration](provider_configuration.md) |
+| Understand pilot/integration fit | [Release-control services](release_control_services.md) |
+| See milestone planning | [Roadmap 2026](roadmap_2026.md) |
+| Recover current project memory | [Issue #202](https://github.com/SemeAIPletinnya/silence-as-control/issues/202) |
+| Track roadmap/progress/dependencies | [Issue #203](https://github.com/SemeAIPletinnya/silence-as-control/issues/203) |
+
+## Boundary rules
+
+- README is the front door, not the full documentation.
+- Plain-English pitch explains the idea simply.
+- First-run checklist verifies the no-key path.
+- Evidence map connects claims to artifacts.
+- Roadmap docs and issue #203 track development direction.
+- Issue #202 preserves current project state.
+- Pilot/integration docs should stay separate from research/evidence docs.
+- Do not duplicate large explanations across files.


### PR DESCRIPTION
### Motivation

- Provide a concise, architectural navigation map so readers choose the correct entry point without mixing the roles of the README, docs, issues, evidence, roadmap, and integration material. 
- Keep the repo's public entry surface clean after the addition of the Plain-English pitch and avoid duplication across docs. 
- Preserve the existing documentation boundaries (core vs runtime vs experimental vs integrations) and provide a single place that points readers to the right doc or issue.

### Description

- Adds a new documentation file `docs/project_navigation.md` containing Purpose, High-level map, a "Start depending on what you need" table with relative links, and Boundary rules. 
- Updates `docs/README.md` to include a concise link near the top: `- [Project navigation map](project_navigation.md) — where to start depending on what you need.` 
- Changes are documentation-only and conservative, with no code, benchmark, threshold, or claims introduced. 
- Aimed to reduce navigation friction by clarifying where to find the plain-English pitch, first-run checklist, architecture split, evidence map, runtime observability, provider configuration, release-control services, roadmap, and the two issue capsules (#202, #203).

### Testing

- Ran `git diff --check` with no issues reported. 
- Ran `python -m pytest tests/test_api.py -q` and received `15 passed` for the targeted test suite. 
- No additional automated tests were required because this change is documentation-only and does not affect runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1015135894832683cb871e6d4a06b6)