### PR TITLE
docs: align README with project navigation map

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ It does **not** improve model weights. It controls release behavior.
 
 **Same model. Different decision.**
 
+## Fast orientation
+
+- [Plain-English pitch](docs/plain_english_pitch.md) — understand the idea simply.
+- [Project navigation map](docs/project_navigation.md) — choose the right entry point.
+- [First-run checklist](docs/first_run_checklist.md) — verify the no-key local path.
+- [Evidence map](docs/evidence_map.md) — connect claims to artifacts.
 
 ## Start here
 


### PR DESCRIPTION
### Motivation
- Add a minimal top-level navigation pointer so newcomers can quickly find the Plain-English pitch, the project navigation map, the first-run checklist, and the evidence map without bloating the README.

### Description
- Insert a `## Fast orientation` section after the thesis lines in `README.md` linking to `docs/plain_english_pitch.md`, `docs/project_navigation.md`, `docs/first_run_checklist.md`, and `docs/evidence_map.md`, and retain the existing `## Start here` section unchanged.

### Testing
- Ran `git diff --check` (no issues) and `python -m pytest tests/test_api.py -q` which completed successfully (`15 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1019844ad483268590b18ad38554e4)