### PR TITLE
docs: add reverse integration sandbox concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ It does **not** improve model weights. It controls release behavior.
 - [Project navigation map](docs/project_navigation.md) — choose the right entry point.
 - [First-run checklist](docs/first_run_checklist.md) — verify the no-key local path.
 - [Evidence map](docs/evidence_map.md) — connect claims to artifacts.
+- [Reverse integration sandbox](docs/reverse_integration_sandbox.md) — controlled intake/evaluation concept.
 
 ## Start here
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,8 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - `langchain_openai_action_risk_benchmark.md` — LangChain/OpenAI action-risk benchmark framing and Run 06 hardened v4 progression.
 - `action_risk_1000_dataset.md` — Run 06 1000-case synthetic dataset scope and schema.
 - `release_control_services.md` — pilot/integration overview for release-control use cases.
+- `agentic_release_control.md` — deterministic release-control architecture for agentic workflows.
+- [Reverse integration sandbox](reverse_integration_sandbox.md) — controlled intake/evaluation concept for external candidate outputs.
 - `applied_bridges.md` — bounded notes on compatible applied bridges such as `por-copilot-bridge`.
 
 For paper/preprint context, see `../paper/README.md`.

--- a/docs/reverse_integration_sandbox.md
+++ b/docs/reverse_integration_sandbox.md
@@ -1,0 +1,91 @@
+# Reverse Integration Sandbox
+
+## Purpose
+
+A Reverse Integration Sandbox is a controlled evaluation layer where external candidate outputs can be tested against Silence-as-Control before any real integration or deployment.
+
+The goal is not immediate automation. The goal is controlled inspection and release evaluation.
+
+## Core idea
+
+Most integrations normally work like this:
+
+external system
+→ direct execution or release
+
+Silence-as-Control proposes an intermediate layer:
+
+external candidate
+→ sandbox intake
+→ release evaluation
+→ PROCEED / NEEDS_REVIEW / SILENCE
+
+```text
+external candidate output
+        ↓
+reverse integration sandbox
+        ↓
+PoR / release-control evaluation
+        ↓
+PROCEED / NEEDS_REVIEW / SILENCE
+```
+
+## Why this matters
+
+Generated outputs may become:
+
+- shell commands
+- config mutations
+- repository edits
+- workflow actions
+- API calls
+- outbound messages
+- operational decisions
+
+The sandbox allows these outputs to be inspected before any trusted execution path exists.
+
+## What the sandbox is
+
+The Reverse Integration Sandbox is:
+
+- a controlled intake layer
+- a pre-integration evaluation lane
+- a safe experimentation surface
+- useful for pilots, demos, and external evaluation
+- useful for comparing release-by-default vs gated release behavior
+
+## What the sandbox is not
+
+It is not:
+
+- production enforcement
+- guaranteed safety
+- autonomous execution
+- a replacement for review
+- a security boundary
+- a deployment platform
+- an AGI system
+- a fully isolated execution environment
+
+## Relationship to the current repo
+
+- `docs/plain_english_pitch.md` explains the core idea.
+- `docs/project_navigation.md` explains where to start.
+- `docs/agentic_release_control.md` explains the release-control architecture.
+- `docs/evidence_map.md` connects claims to artifacts.
+- `docs/release_control_services.md` explains pilot/integration direction.
+- Issue #203 tracks roadmap/dependency evolution.
+
+## Possible future directions
+
+Possible future directions may include:
+
+- candidate replay
+- intake logging
+- release-decision comparison
+- review queues
+- external evaluation workflows
+- deterministic replay/testing
+- benchmark-side sandbox experiments
+
+These are exploration directions only and are not commitments or production promises.


### PR DESCRIPTION
### Motivation

- Introduce a conservative architectural concept for a Reverse Integration Sandbox to evaluate external candidate outputs against Silence-as-Control before any real integration or deployment.
- Provide a safe, non-production discussion surface that complements the existing onboarding, release-control, and evidence-mapping docs without increasing runtime or operational scope.

### Description

- Add `docs/reverse_integration_sandbox.md` documenting Purpose, Core idea (with a plain-text flow diagram), Why this matters, What the sandbox is / is not, Relationship to the repo, and conservative Possible future directions.
- Update `docs/README.md` to link the new doc near existing release/integration architecture references and update the root `README.md` Fast orientation list with a lightweight link to `docs/reverse_integration_sandbox.md` for discoverability.
- Changes are documentation-only, deliberately conservative in language, and do not introduce code, runtime behavior, APIs, deployment artifacts, or security guarantees.
- Affected files: `docs/reverse_integration_sandbox.md`, `docs/README.md`, and `README.md`.

### Testing

- Ran `git diff --check` and observed no whitespace or diff errors.
- Ran `python -m pytest tests/test_api.py -q` which completed successfully with `15 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1021097f14832689e749c48a63588b)