### PR TITLE
docs: add sandbox channel adapter concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ It does **not** improve model weights. It controls release behavior.
 - [First-run checklist](docs/first_run_checklist.md) — verify the no-key local path.
 - [Evidence map](docs/evidence_map.md) — connect claims to artifacts.
 - [Reverse integration sandbox](docs/reverse_integration_sandbox.md) — controlled intake/evaluation concept.
+- [Sandbox channel adapters](docs/sandbox_channel_adapters.md) — conceptual intake connectors for sandbox evaluation flows.
 
 ## Start here
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - `release_control_services.md` — pilot/integration overview for release-control use cases.
 - `agentic_release_control.md` — deterministic release-control architecture for agentic workflows.
 - [Reverse integration sandbox](reverse_integration_sandbox.md) — controlled intake/evaluation concept for external candidate outputs.
+- [Sandbox channel adapters](sandbox_channel_adapters.md) — conceptual intake connectors for sandbox evaluation flows.
 - `applied_bridges.md` — bounded notes on compatible applied bridges such as `por-copilot-bridge`.
 
 For paper/preprint context, see `../paper/README.md`.

--- a/docs/sandbox_channel_adapters.md
+++ b/docs/sandbox_channel_adapters.md
@@ -1,0 +1,137 @@
+# Sandbox Channel Adapters
+
+## Purpose
+
+Sandbox Channel Adapters are lightweight intake connectors that allow external systems or communication channels to submit candidate outputs into the Reverse Integration Sandbox for evaluation.
+
+The purpose is not direct execution. The purpose is controlled intake and release evaluation.
+
+This concept is architectural and conservative: it describes intake boundaries for evaluation flows, not production orchestration.
+
+## Core architecture
+
+```text
+Telegram
+Slack
+Discord
+Mattermost
+Webhook
+GitHub Comment
+CLI
+Email
+        ↓
+Sandbox Intake Layer
+        ↓
+Normalization
+        ↓
+PoR / Release Gate
+        ↓
+PROCEED / NEEDS_REVIEW / SILENCE
+```
+
+Different channels may produce different output formats, message shapes, or metadata. The intake layer normalizes those candidate submissions into a consistent evaluation envelope before release evaluation.
+
+Transport channel is not release authority.
+
+Generation transport is not release authority.
+
+## Why this matters
+
+Generated outputs may arrive from multiple surfaces, including:
+
+- chat systems
+- self-hosted team communication platforms
+- coding assistants
+- support tools
+- workflow automation
+- external agents
+- repository bots
+- operational dashboards
+
+The architecture separates message transport from release authority so intake convenience does not bypass evaluation control.
+
+## What channel adapters are
+
+Channel adapters are:
+
+- intake connectors
+- normalization layers
+- controlled routing surfaces
+- evaluation entry points
+- useful for demos, pilots, and controlled experiments
+
+## What channel adapters are not
+
+They are not:
+
+- autonomous agents
+- trusted execution systems
+- deployment systems
+- guaranteed-safe integrations
+- production orchestration
+- unrestricted automation
+
+## Example flows
+
+### Telegram example
+
+```text
+Telegram bot
+→ candidate message
+→ sandbox intake
+→ release evaluation
+→ decision returned
+```
+
+### Mattermost example
+
+```text
+Mattermost message
+→ candidate operational output
+→ sandbox intake
+→ normalization
+→ release evaluation
+→ PROCEED / NEEDS_REVIEW / SILENCE
+```
+
+### GitHub example
+
+```text
+GitHub PR comment
+→ candidate patch/action
+→ sandbox intake
+→ release evaluation
+→ PROCEED / NEEDS_REVIEW / SILENCE
+```
+
+### Webhook example
+
+```text
+external webhook
+→ candidate payload
+→ normalization
+→ release evaluation
+→ decision response
+```
+
+## Relationship to the current repo
+
+- `docs/reverse_integration_sandbox.md` explains the sandbox layer.
+- `docs/agentic_release_control.md` explains release-control architecture.
+- `docs/project_navigation.md` explains navigation flow.
+- `docs/release_control_services.md` explains pilot/integration direction.
+- Issue #203 tracks roadmap/dependency evolution.
+
+## Possible future directions
+
+Possible future directions may include:
+
+- intake replay
+- structured candidate payloads
+- adapter-specific telemetry
+- review queues
+- deterministic replay/testing
+- evaluation dashboards
+- external comparison workflows
+
+These are exploratory directions only and are not promised features.


### PR DESCRIPTION
### Motivation

- Introduce a conservative, architectural description of Sandbox Channel Adapters as a multi-channel intake layer for the Reverse Integration Sandbox that accepts candidate outputs for evaluation but does not execute or release them. 
- Provide a discoverable, minimal-spec doc for pilots, demos, and architecture discussion while preserving the separation between message transport and release authority.

### Description

- Adds `docs/sandbox_channel_adapters.md` containing Purpose, Core architecture (diagram: channels → Sandbox Intake Layer → Normalization → PoR / Release Gate → PROCEED / NEEDS_REVIEW / SILENCE), example flows (Telegram, Mattermost, GitHub, Webhook), and conservative future directions. 
- Updates `docs/README.md` and the repository `README.md` to include a link to `docs/sandbox_channel_adapters.md` near `reverse_integration_sandbox.md` and related release-control docs for discoverability. 
- Keeps this change documentation-only with no code, runtime, API, SDK, or Docker changes and includes explicit boundary language such as "Transport channel is not release authority" and "Generation transport is not release authority." 
- Notes the conservative scope and risk posture: this documents intake and evaluation boundaries and does not promise production readiness, security guarantees, or autonomous execution. 

### Testing

- Ran `git diff --check` and there were no whitespace or diff errors. 
- Ran `python -m pytest tests/test_api.py -q` and the suite passed (`15 passed`). 
- No code-level or integration tests were added because the PR is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10282462488326ba0b9a832f2bd8e5)