### PR TITLE
docs: add intake payload schema concept

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - `agentic_release_control.md` — deterministic release-control architecture for agentic workflows.
 - [Reverse integration sandbox](reverse_integration_sandbox.md) — controlled intake/evaluation concept for external candidate outputs.
 - [Sandbox channel adapters](sandbox_channel_adapters.md) — conceptual intake connectors for sandbox evaluation flows.
+- [Intake payload schema](intake_payload_schema.md) — conceptual normalization format for sandbox intake evaluation flows.
 - `applied_bridges.md` — bounded notes on compatible applied bridges such as `por-copilot-bridge`.
 
 For paper/preprint context, see `../paper/README.md`.

--- a/docs/intake_payload_schema.md
+++ b/docs/intake_payload_schema.md
@@ -1,0 +1,100 @@
+# Intake Payload Schema
+
+## Purpose
+
+The Intake Payload Schema is a conceptual normalization format for candidate outputs entering the Reverse Integration Sandbox.
+
+The purpose is not execution. The purpose is consistent evaluation and release-control routing.
+
+Different transport channels may produce different message formats, metadata structures, or candidate types. The schema provides a common evaluation envelope before release decisions are made.
+
+## Core idea
+
+Sandbox Channel Adapters may normalize incoming candidate outputs into a shared structure before release evaluation.
+
+Normalization reduces transport-specific ambiguity before evaluation.
+
+```text
+Telegram
+Slack
+Discord
+Mattermost
+Webhook
+GitHub Comment
+CLI
+Email
+        ↓
+Channel Adapter
+        ↓
+Normalized Intake Payload
+        ↓
+PoR / Release Gate
+        ↓
+PROCEED / NEEDS_REVIEW / SILENCE
+```
+
+## Example conceptual payload
+
+```json
+{
+  "source_channel": "telegram",
+  "candidate_type": "message",
+  "candidate_payload": "example candidate output",
+  "requested_action": "release_evaluation",
+  "metadata": {
+    "origin": "sandbox_adapter",
+    "transport_mode": "chat"
+  }
+}
+```
+
+This is only a conceptual example used to describe architectural normalization ideas. It is not a committed runtime contract.
+
+## Why this matters
+
+- Different channels produce inconsistent formats.
+- Release evaluation should not depend on transport-specific layouts.
+- Normalization allows more consistent replay, inspection, and evaluation.
+- A shared intake envelope may improve deterministic analysis paths.
+
+## What the schema is
+
+The Intake Payload Schema is:
+
+- a conceptual normalization layer
+- a shared intake structure
+- a routing/evaluation envelope
+- useful for replay and inspection thinking
+- useful for sandbox experimentation
+
+## What the schema is not
+
+It is not:
+
+- a production API contract
+- a deployment protocol
+- a security boundary
+- a guarantee of correctness
+- a stable interoperability standard
+- a runtime implementation commitment
+
+## Relationship to the current repo
+
+- `docs/reverse_integration_sandbox.md` explains the sandbox layer.
+- `docs/sandbox_channel_adapters.md` explains intake adapters.
+- `docs/agentic_release_control.md` explains release-control architecture.
+- `docs/project_navigation.md` explains navigation flow.
+- Issue #203 tracks roadmap/dependency evolution.
+
+## Possible future directions
+
+Possible future directions may include:
+
+- replay-friendly payload structures
+- adapter-specific metadata envelopes
+- structured evaluation traces
+- deterministic replay workflows
+- evaluation comparison tooling
+- intake telemetry surfaces
+
+These are exploratory directions only and are not commitments to runtime implementation.


### PR DESCRIPTION
### Motivation

- Introduce a conservative, architecture-only Intake Payload Schema to describe how candidate outputs can be normalized before entering the Reverse Integration Sandbox for release evaluation.
- Provide a common evaluation envelope that reduces transport-specific ambiguity across channels and supports consistent replay, inspection, and routing decisions.
- Keep the proposal explicitly non-runtime, non-production, and non-security-claiming so it serves only as an architectural thinking layer.

### Description

- Add `docs/intake_payload_schema.md` which defines purpose, core idea, required diagram, a conceptual JSON example payload, "what this is" and "what this is not" sections, repo relationships, and conservative future directions.
- Include the requested normalization flow diagram and the example payload JSON to illustrate conceptual normalization and the phrase "Normalization reduces transport-specific ambiguity before evaluation." in the doc.
- Update `docs/README.md` to add a link to the new intake payload schema entry adjacent to `reverse_integration_sandbox.md` and `sandbox_channel_adapters.md`.
- All changes are documentation-only, committed on branch `docs/intake-payload-schema`, and do not add runtime code, APIs, SDKs, or security guarantees.

### Testing

- Ran `git diff --check` and there were no whitespace or index errors reported.
- Ran `python -m pytest tests/test_api.py -q` and the test suite completed successfully (`15 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a102e47d3bc8326b4681cdcd34cc179)