### PR TITLE
docs: add deterministic replay architecture concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ It does **not** improve model weights. It controls release behavior.
 - [Evidence map](docs/evidence_map.md) — connect claims to artifacts.
 - [Reverse integration sandbox](docs/reverse_integration_sandbox.md) — controlled intake/evaluation concept.
 - [Sandbox channel adapters](docs/sandbox_channel_adapters.md) — conceptual intake connectors for sandbox evaluation flows.
+- [Deterministic replay architecture](docs/deterministic_replay_architecture.md) — conceptual replay and inspection layer for sandbox evaluation flows.
 
 ## Start here
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - [Reverse integration sandbox](reverse_integration_sandbox.md) — controlled intake/evaluation concept for external candidate outputs.
 - [Sandbox channel adapters](sandbox_channel_adapters.md) — conceptual intake connectors for sandbox evaluation flows.
 - [Intake payload schema](intake_payload_schema.md) — conceptual normalization format for sandbox intake evaluation flows.
+- [Deterministic replay architecture](deterministic_replay_architecture.md) — conceptual replay and inspection layer for sandbox evaluation flows.
 - `applied_bridges.md` — bounded notes on compatible applied bridges such as `por-copilot-bridge`.
 
 For paper/preprint context, see `../paper/README.md`.

--- a/docs/deterministic_replay_architecture.md
+++ b/docs/deterministic_replay_architecture.md
@@ -1,0 +1,106 @@
+# Deterministic Replay Architecture
+
+## Purpose
+
+The Deterministic Replay Architecture is a conceptual inspection layer for replaying normalized candidate evaluations inside the Reverse Integration Sandbox.
+
+The purpose is not autonomous execution. The purpose is reproducible inspection and evaluation analysis.
+
+Replay allows candidate intake and release decisions to be inspected more consistently across evaluation paths.
+
+## Core idea
+
+Normalized intake payloads may be replayed through the same conceptual evaluation flow to inspect:
+- routing behavior
+- release decisions
+- evaluation traces
+- normalization consistency
+- transport-independent analysis paths
+
+```text
+Channel Adapter
+        ↓
+Normalized Intake Payload
+        ↓
+Replay / Inspection Layer
+        ↓
+PoR / Release Gate
+        ↓
+PROCEED / NEEDS_REVIEW / SILENCE
+        ↓
+Replay Trace
+```
+
+Replay is for inspection consistency, not autonomous authority.
+
+Deterministic replay reduces ambiguity during evaluation analysis.
+
+## Why this matters
+
+Different intake paths may produce different evaluation contexts, even when they eventually map to similar candidate intent.
+
+Replay allows repeated inspection of normalized candidate flows and may improve traceability and debugging across controlled evaluation conditions.
+
+Transport-independent replay may improve comparison workflows between intake channels while keeping analysis focused on normalized payload and decision semantics.
+
+Replay thinking also supports evidence-oriented evaluation architecture by making inspection paths easier to discuss and compare in documentation-first planning.
+
+## Example conceptual replay record
+
+```json
+{
+  "replay_id": "example-replay-001",
+  "source_channel": "mattermost",
+  "candidate_type": "message",
+  "requested_action": "release_evaluation",
+  "decision": "NEEDS_REVIEW",
+  "trace_metadata": {
+    "evaluation_mode": "sandbox_replay",
+    "normalization_version": "concept-v1"
+  }
+}
+```
+
+This is only a conceptual replay example used for architectural discussion. It is not a committed runtime schema or API contract.
+
+## What replay architecture is
+
+The Deterministic Replay Architecture is:
+- a conceptual replay layer
+- an inspection-oriented architecture
+- a traceability concept
+- useful for sandbox experimentation
+- useful for deterministic evaluation thinking
+- useful for evidence-oriented workflows
+
+## What replay architecture is not
+
+It is not:
+- autonomous execution
+- a production replay engine
+- guaranteed determinism
+- a deployment platform
+- a security boundary
+- a runtime orchestration commitment
+- a forensic guarantee system
+
+## Relationship to the current repo
+
+- `docs/reverse_integration_sandbox.md` explains the sandbox layer.
+- `docs/sandbox_channel_adapters.md` explains intake adapters.
+- `docs/intake_payload_schema.md` explains normalized intake payloads.
+- `docs/agentic_release_control.md` explains release-control architecture.
+- `docs/project_navigation.md` explains navigation flow.
+- Issue #203 tracks roadmap/dependency evolution.
+
+## Possible future directions
+
+Possible future directions may include:
+- replay-oriented evaluation traces
+- deterministic inspection workflows
+- replay comparison tooling
+- normalization-version tracking
+- intake replay telemetry
+- evidence-linked replay reports
+
+These are directional architecture notes only and do not represent committed runtime or product features.


### PR DESCRIPTION
### Motivation

- Introduce a conservative, conceptual replay/inspection layer to describe how normalized candidate evaluations can be replayed or inspected consistently inside the Reverse Integration Sandbox for reproducible evaluation analysis. 
- Keep the change documentation-only and architecture-focused, avoiding runtime claims, APIs, security guarantees, or production promises.

### Description

- Add `docs/deterministic_replay_architecture.md` that defines Purpose, Core idea, the requested flow diagram, required wording (including "Replay is for inspection consistency, not autonomous authority." and "Deterministic replay reduces ambiguity during evaluation analysis."), a conceptual JSON example, clear "is" / "is not" boundaries, repo relationships, and conservative future directions. 
- Update `docs/README.md` to include an index entry linking the new deterministic replay architecture doc placed adjacent to `intake_payload_schema.md` and `sandbox_channel_adapters.md`.
- Add a lightweight link in the repository `README.md` under Fast orientation to surface the new document without adding clutter. 
- No code, runtime implementations, APIs, SDKs, Docker changes, benchmarks, or security claims were introduced.

### Testing

- Ran `git diff --check` and found no whitespace or diff-check issues. 
- Ran `python -m pytest tests/test_api.py -q` with all tests passing (`15 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10308e2f2c8326bd8ad3edae65d799)