### PR TITLE
docs: add decision provenance architecture concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ It does **not** improve model weights. It controls release behavior.
 - [Reverse integration sandbox](docs/reverse_integration_sandbox.md) — controlled intake/evaluation concept.
 - [Sandbox channel adapters](docs/sandbox_channel_adapters.md) — conceptual intake connectors for sandbox evaluation flows.
 - [Deterministic replay architecture](docs/deterministic_replay_architecture.md) — conceptual replay and inspection layer for sandbox evaluation flows.
+- [Decision provenance architecture](docs/decision_provenance_architecture.md) — conceptual traceability layer for sandbox release decisions.
 
 ## Start here
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - [Sandbox channel adapters](sandbox_channel_adapters.md) — conceptual intake connectors for sandbox evaluation flows.
 - [Intake payload schema](intake_payload_schema.md) — conceptual normalization format for sandbox intake evaluation flows.
 - [Deterministic replay architecture](deterministic_replay_architecture.md) — conceptual replay and inspection layer for sandbox evaluation flows.
+- [Decision provenance architecture](decision_provenance_architecture.md) — conceptual traceability layer for sandbox release decisions.
 - `applied_bridges.md` — bounded notes on compatible applied bridges such as `por-copilot-bridge`.
 
 For paper/preprint context, see `../paper/README.md`.

--- a/docs/decision_provenance_architecture.md
+++ b/docs/decision_provenance_architecture.md
@@ -1,0 +1,106 @@
+# Decision Provenance Architecture
+
+## Purpose
+
+Decision Provenance Architecture is a conceptual traceability layer for explaining how a sandbox release decision was reached.
+
+The purpose is not autonomous authority. The purpose is inspectable decision context.
+
+A release decision should not be treated as a black box when it can be connected to candidate input, normalization context, replay traces, evaluation signals, and routing outcomes.
+
+## Core idea
+
+After a normalized candidate is evaluated, the result may be associated with a provenance record that helps reviewers understand the decision path.
+
+```text
+Normalized Intake Payload
+        ↓
+Replay / Inspection Layer
+        ↓
+PoR / Release Gate
+        ↓
+PROCEED / NEEDS_REVIEW / SILENCE
+        ↓
+Decision Provenance Record
+        ↓
+Reviewer / Evidence Surface
+```
+
+Decision provenance is for inspection, not automatic justification.
+
+A decision record should describe the path to a release outcome without pretending to prove universal correctness.
+
+## Why this matters
+
+Release decisions need traceability so reviewers can inspect the reasoning path behind routing outcomes.
+
+Reviewers need to understand why a candidate was released, reviewed, or silenced in a sandbox evaluation flow.
+
+Provenance records may help compare decisions across replay runs, especially when the same candidate family is evaluated under different contexts.
+
+Provenance thinking supports evidence-oriented evaluation workflows by keeping decision context explicit and reviewable.
+
+Traceable decisions reduce ambiguity during review and debugging by preserving a consistent inspection surface.
+
+## Example conceptual provenance record
+
+```json
+{
+  "provenance_id": "example-prov-001",
+  "replay_id": "example-replay-001",
+  "source_channel": "mattermost",
+  "candidate_type": "message",
+  "decision": "NEEDS_REVIEW",
+  "decision_context": {
+    "reason_category": "borderline_or_ambiguous_candidate",
+    "evaluation_mode": "sandbox_replay",
+    "normalization_version": "concept-v1"
+  },
+  "review_hint": "Route to human or policy review before release."
+}
+```
+
+This is only a conceptual provenance example used for architectural discussion. It is not a committed runtime schema, API contract, or explanation guarantee.
+
+## What decision provenance is
+
+Decision provenance is:
+- a conceptual traceability layer
+- an inspection-oriented record
+- a way to connect release decisions to normalized inputs
+- useful for replay comparison thinking
+- useful for review workflows
+- useful for evidence-oriented documentation
+
+## What decision provenance is not
+
+It is not:
+- proof of correctness
+- full model explainability
+- a legal audit guarantee
+- a security boundary
+- a production compliance system
+- autonomous justification
+- a runtime implementation commitment
+
+## Relationship to the current repo
+
+- `docs/reverse_integration_sandbox.md` explains the sandbox layer.
+- `docs/sandbox_channel_adapters.md` explains intake adapters.
+- `docs/intake_payload_schema.md` explains normalized intake payloads.
+- `docs/deterministic_replay_architecture.md` explains replay and inspection.
+- `docs/agentic_release_control.md` explains release-control architecture.
+- `docs/project_navigation.md` explains navigation flow.
+- Issue #203 tracks roadmap/dependency evolution.
+
+## Possible future directions
+
+Possible future directions may include:
+- provenance-oriented evaluation traces
+- decision reason categories
+- review hints
+- replay-to-provenance comparison
+- evidence-linked decision records
+- reviewer-facing trace summaries
+
+These directions are exploratory architectural considerations and are not promised features or implementation commitments.


### PR DESCRIPTION
### Motivation
- Introduce a conservative, architecture-level provenance/traceability concept to explain how sandbox PoR release decisions can be inspected and connected back to normalized inputs and replay traces. 
- Provide a clear inspection-oriented framing so reviewers can reason about routing outcomes without treating release decisions as opaque or as automated justification. 
- Keep the change documentation-only and avoid promising runtime, security, or explainability guarantees.

### Description
- Adds `docs/decision_provenance_architecture.md`, a conceptual design that includes purpose, core idea, an ASCII flow diagram, a JSON example provenance record, "is / is not" boundaries, repo relationship mapping, and conservative possible future directions. 
- Updates `docs/README.md` and the root `README.md` to link the new document near related sandbox/intake/replay architecture entries so the concept is discoverable from architecture and fast-orientation surfaces. 
- The document explicitly states that provenance is for inspection, not automatic justification, and that the example JSON is not a committed runtime schema, API contract, or explanation guarantee. 
- No code, APIs, runtime implementations, SDKs, Docker changes, or benchmark claims were added or modified; this is strictly documentation work.

### Testing
- Ran `git diff --check` and `python -m pytest tests/test_api.py -q` as validation checks. 
- All automated checks passed: `git diff --check` produced no issues and `pytest` completed with all tests passing (15 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1032d3ff048326852cee0aa6cfe26f)