### PR TITLE
docs: add evaluation trace architecture concept

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - [Intake payload schema](intake_payload_schema.md) — conceptual normalization format for sandbox intake evaluation flows.
 - [Deterministic replay architecture](deterministic_replay_architecture.md) — conceptual replay and inspection layer for sandbox evaluation flows.
 - [Decision provenance architecture](decision_provenance_architecture.md) — conceptual traceability layer for sandbox release decisions.
+- [Evaluation trace architecture](evaluation_trace_architecture.md) — conceptual inspection and traceability layer for sandbox evaluation flows.
 - `applied_bridges.md` — bounded notes on compatible applied bridges such as `por-copilot-bridge`.
 
 For paper/preprint context, see `../paper/README.md`.

--- a/docs/evaluation_trace_architecture.md
+++ b/docs/evaluation_trace_architecture.md
@@ -1,0 +1,124 @@
+# Evaluation Trace Architecture
+
+## Purpose
+
+Evaluation Trace Architecture is a conceptual inspection layer for representing how a candidate moved through sandbox evaluation flow.
+
+The purpose is not autonomous execution.
+The purpose is consistent evaluation visibility.
+
+Evaluation traces may help reviewers inspect:
+- routing behavior
+- normalization flow
+- replay relationships
+- provenance linkage
+- release outcomes
+
+without treating release decisions as opaque events.
+
+## Core idea
+
+A normalized candidate may generate an evaluation trace describing its conceptual movement through intake, replay, release-control, and provenance layers.
+
+```text
+Channel Adapter
+        ↓
+Normalized Intake Payload
+        ↓
+Replay / Inspection Layer
+        ↓
+PoR / Release Gate
+        ↓
+PROCEED / NEEDS_REVIEW / SILENCE
+        ↓
+Decision Provenance Record
+        ↓
+Evaluation Trace
+        ↓
+Reviewer / Evidence Surface
+```
+
+Evaluation traces are inspection-oriented, not autonomous authority.
+
+A trace should describe evaluation flow without pretending to prove correctness.
+
+## Why this matters
+
+Reviewers may need visibility into evaluation flow when inspecting why a candidate reached a specific release outcome.
+
+Replay and provenance become easier to compare with shared traces across the same conceptual path.
+
+Traces may improve debugging and inspection consistency by giving teams a common flow language.
+
+Traces support evidence-oriented governance workflows where release discussion should remain inspectable.
+
+Transport-independent traces may reduce ambiguity during review when candidates originate from different channels.
+
+## Example conceptual evaluation trace
+
+```json
+{
+  "trace_id": "example-trace-001",
+  "source_channel": "telegram",
+  "candidate_type": "message",
+  "evaluation_flow": [
+    "channel_adapter",
+    "normalized_payload",
+    "sandbox_replay",
+    "release_gate",
+    "decision_provenance"
+  ],
+  "decision": "PROCEED",
+  "trace_context": {
+    "evaluation_mode": "sandbox_trace",
+    "normalization_version": "concept-v1"
+  }
+}
+```
+
+This is only a conceptual evaluation trace example used for architectural discussion.
+It is not a committed runtime schema, API contract, or audit guarantee.
+
+## What evaluation traces are
+
+Evaluation traces are:
+- a conceptual inspection layer
+- a traceability surface
+- a way to connect replay, provenance, and release flow
+- useful for sandbox experimentation
+- useful for replay comparison thinking
+- useful for evidence-oriented workflows
+
+## What evaluation traces are not
+
+They are not:
+- proof of correctness
+- guaranteed determinism
+- a legal audit system
+- a security boundary
+- a production observability platform
+- autonomous reasoning
+- a runtime implementation commitment
+
+## Relationship to the current repo
+
+- `docs/reverse_integration_sandbox.md` explains the sandbox layer.
+- `docs/sandbox_channel_adapters.md` explains intake adapters.
+- `docs/intake_payload_schema.md` explains normalized intake payloads.
+- `docs/deterministic_replay_architecture.md` explains replay and inspection.
+- `docs/decision_provenance_architecture.md` explains provenance and review context.
+- `docs/agentic_release_control.md` explains release-control architecture.
+- `docs/project_navigation.md` explains navigation flow.
+- Issue #203 tracks roadmap/dependency evolution.
+
+## Possible future directions
+
+Possible future directions may include:
+- replay-linked traces
+- provenance-linked traces
+- reviewer-facing trace summaries
+- trace comparison tooling
+- evaluation-flow inspection dashboards
+- evidence-linked trace reports
+
+These directions are exploratory and do not commit the repository to specific runtime features.


### PR DESCRIPTION
### Motivation

- Introduce a conservative, conceptual inspection layer that describes how a candidate moves through sandbox evaluation flows to improve consistent visibility across replay, provenance, routing, and review surfaces. 
- Keep the change strictly architectural and documentation-only so the project retains a clear separation between conceptual trace surfaces and any runtime or security claims.

### Description

- Add `docs/evaluation_trace_architecture.md` which defines the purpose, core idea, flow diagram, a conceptual JSON example, "what traces are / are not", repo relationships, and conservative future directions. 
- Update `docs/README.md` to include a link to the new evaluation trace document placed adjacent to the replay/provenance/intake architecture entries. 
- The change is documentation-only and does not introduce runtime code, APIs, SDKs, Docker changes, benchmarks, or security guarantees; affected files are `docs/evaluation_trace_architecture.md` and `docs/README.md`.
- Risk is minimal because this is a non-executable conceptual design intended to guide inspection and reviewer workflows rather than change behavior.

### Testing

- Ran `git diff --check` to validate whitespace and diff hygiene and it completed without issues. 
- Ran `python -m pytest tests/test_api.py -q` and the test run passed: `15 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10395731408326aca9648ffb607875)