### PR TITLE
docs: add review-lane architecture concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ It does **not** improve model weights. It controls release behavior.
 - [Sandbox channel adapters](docs/sandbox_channel_adapters.md) — conceptual intake connectors for sandbox evaluation flows.
 - [Deterministic replay architecture](docs/deterministic_replay_architecture.md) — conceptual replay and inspection layer for sandbox evaluation flows.
 - [Decision provenance architecture](docs/decision_provenance_architecture.md) — conceptual traceability layer for sandbox release decisions.
+- [Review-lane architecture](docs/review_lane_architecture.md) — conceptual governance-routing layer for sandbox evaluation outcomes.
 
 ## Start here
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,8 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - [Intake payload schema](intake_payload_schema.md) — conceptual normalization format for sandbox intake evaluation flows.
 - [Deterministic replay architecture](deterministic_replay_architecture.md) — conceptual replay and inspection layer for sandbox evaluation flows.
 - [Decision provenance architecture](decision_provenance_architecture.md) — conceptual traceability layer for sandbox release decisions.
+- [Evaluation trace architecture](evaluation_trace_architecture.md) — conceptual evaluation-trace visibility layer for sandbox release-control flows.
+- [Review-lane architecture](review_lane_architecture.md) — conceptual governance-routing layer for sandbox evaluation outcomes.
 - `applied_bridges.md` — bounded notes on compatible applied bridges such as `por-copilot-bridge`.
 
 For paper/preprint context, see `../paper/README.md`.

--- a/docs/review_lane_architecture.md
+++ b/docs/review_lane_architecture.md
@@ -1,0 +1,110 @@
+# Review-Lane Architecture
+
+## Purpose
+
+Review-Lane Architecture is a conceptual governance-routing layer for handling sandbox evaluation outcomes after release-control decisions are produced.
+
+The purpose is not autonomous authority. The purpose is bounded review visibility and controlled escalation thinking.
+
+Review lanes may help separate:
+- direct release outcomes
+- review-required outcomes
+- blocked/silenced outcomes
+
+without collapsing all decisions into a single execution path.
+
+## Core idea
+
+After replay, provenance, and evaluation traces are generated, release outcomes may conceptually route into different review lanes.
+
+```text
+Normalized Intake Payload
+        ↓
+Replay / Inspection Layer
+        ↓
+PoR / Release Gate
+        ↓
+PROCEED / NEEDS_REVIEW / SILENCE
+        ↓
+Decision Provenance
+        ↓
+Evaluation Trace
+        ↓
+Review Lane Routing
+        ├─ Proceed Lane
+        ├─ Review Lane
+        └─ Silence Lane
+```
+
+Review lanes are governance-oriented, not autonomous orchestration.
+
+Routing visibility is not equivalent to execution authority.
+
+## Why this matters
+
+Not all release outcomes should be handled identically. Reviewers may require bounded routing visibility, and review lanes may improve inspection consistency across sandbox governance flows.
+
+Separating lanes may reduce ambiguity during sandbox governance workflows, while routing-oriented review thinking supports evidence-oriented release-control architecture.
+
+## Example conceptual review-lane record
+
+```json
+{
+  "lane_record_id": "example-lane-001",
+  "trace_id": "example-trace-001",
+  "decision": "NEEDS_REVIEW",
+  "assigned_lane": "review_lane",
+  "routing_context": {
+    "evaluation_mode": "sandbox_review",
+    "review_priority": "bounded"
+  },
+  "review_hint": "Route to reviewer or policy surface before release."
+}
+```
+
+This is only a conceptual review-lane example used for architectural discussion. It is not a committed runtime schema, escalation engine, or workflow API.
+
+## What review lanes are
+
+Review lanes are:
+- a conceptual governance-routing layer
+- a bounded inspection surface
+- a way to separate release outcomes
+- useful for sandbox experimentation
+- useful for review-oriented workflows
+- useful for evidence-oriented governance thinking
+
+## What review lanes are not
+
+They are not:
+- autonomous escalation systems
+- production workflow orchestration
+- guaranteed-safe routing
+- a security boundary
+- a compliance engine
+- unrestricted automation
+- a runtime implementation commitment
+
+## Relationship to the current repo
+
+- `docs/reverse_integration_sandbox.md` explains the sandbox layer.
+- `docs/sandbox_channel_adapters.md` explains intake adapters.
+- `docs/intake_payload_schema.md` explains normalized intake payloads.
+- `docs/deterministic_replay_architecture.md` explains replay and inspection.
+- `docs/decision_provenance_architecture.md` explains provenance and review context.
+- `docs/evaluation_trace_architecture.md` explains evaluation trace visibility.
+- `docs/agentic_release_control.md` explains release-control architecture.
+- `docs/project_navigation.md` explains navigation flow.
+- Issue #203 tracks roadmap/dependency evolution.
+
+## Possible future directions
+
+Possible future directions may include:
+- bounded review queues
+- reviewer-facing routing summaries
+- trace-linked review records
+- replay-linked review inspection
+- lane-oriented telemetry
+- evidence-linked governance surfaces
+
+These are directional architecture considerations only and are not feature commitments.


### PR DESCRIPTION
### Motivation

- Introduce a conservative, architecture-level governance-routing concept that describes how sandbox evaluation outcomes may be routed into bounded review lanes before release decisions are acted on. 
- Provide a narrowly scoped conceptual surface to support review-oriented thinking and evidence-linked release-control architecture without committing to runtime implementation or security guarantees.

### Description

- Adds `docs/review_lane_architecture.md` which defines the Review-Lane Architecture, includes the requested routing diagram, the explicit conservative wording (e.g. "Review lanes are governance-oriented, not autonomous orchestration." and "Routing visibility is not equivalent to execution authority."), and a JSON example review-lane record. 
- Updates `docs/README.md` to include an index link to `evaluation_trace_architecture.md` and the new `review_lane_architecture.md` so the concept is grouped with related architecture docs. 
- Adds a lightweight link to `docs/review_lane_architecture.md` from the top-level `README.md` under Fast orientation to surface the doc without clutter. 
- All changes are documentation-only and explicitly avoid any APIs, runtime routing implementations, workflow engines, SDKs, or security claims.

### Testing

- Ran `git diff --check` to validate whitespace and diff hygiene, which completed with no issues. 
- Ran `python -m pytest tests/test_api.py -q` and all tests passed (`15 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a103d6e71b483268420f614acbdded0)