### PR TITLE
docs: add sandbox evaluation telemetry concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ It does **not** improve model weights. It controls release behavior.
 - [Deterministic replay architecture](docs/deterministic_replay_architecture.md) — conceptual replay and inspection layer for sandbox evaluation flows.
 - [Decision provenance architecture](docs/decision_provenance_architecture.md) — conceptual traceability layer for sandbox release decisions.
 - [Connector sandbox boundary](docs/connector_sandbox_boundary.md) — conceptual governance boundary for external communication surfaces.
+- [Sandbox evaluation telemetry](docs/sandbox_evaluation_telemetry.md) — conceptual visibility layer for sandbox governance flows.
 
 ## Start here
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,8 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - [Deterministic replay architecture](deterministic_replay_architecture.md) — conceptual replay and inspection layer for sandbox evaluation flows.
 - [Decision provenance architecture](decision_provenance_architecture.md) — conceptual traceability layer for sandbox release decisions.
 - [Evaluation trace architecture](evaluation_trace_architecture.md) — conceptual inspection and traceability layer for sandbox evaluation flows.
+- [Review lane architecture](review_lane_architecture.md) — conceptual governance routing layer for sandbox evaluation flows.
+- [Sandbox evaluation telemetry](sandbox_evaluation_telemetry.md) — conceptual visibility layer for sandbox governance flows.
 - [Connector sandbox boundary](connector_sandbox_boundary.md) — conceptual governance boundary for external communication surfaces.
 - `applied_bridges.md` — bounded notes on compatible applied bridges such as `por-copilot-bridge`.
 

--- a/docs/sandbox_evaluation_telemetry.md
+++ b/docs/sandbox_evaluation_telemetry.md
@@ -1,0 +1,119 @@
+# Sandbox Evaluation Telemetry
+
+## Purpose
+
+Sandbox Evaluation Telemetry is a conceptual visibility layer for summarizing sandbox evaluation activity across intake, replay, provenance, traces, review lanes, and connector boundaries.
+
+The purpose is not production monitoring.
+The purpose is bounded inspection visibility.
+
+Telemetry may help reviewers understand how sandbox evaluation flows behave without treating metrics as proof of correctness.
+
+## Core idea
+
+Sandbox evaluation activity may produce high-level visibility signals that summarize how candidates move through the governance stack.
+
+```text
+Connector Sandbox Boundary
+        ↓
+Channel Adapter
+        ↓
+Normalized Intake Payload
+        ↓
+Replay / Inspection Layer
+        ↓
+PoR / Release Gate
+        ↓
+Decision Provenance
+        ↓
+Evaluation Trace
+        ↓
+Review Lane Routing
+        ↓
+Sandbox Evaluation Telemetry
+        ↓
+Reviewer / Evidence Surface
+```
+
+Telemetry visibility is not proof of correctness.
+
+Sandbox telemetry is for inspection, not production compliance.
+
+## Why this matters
+
+- Reviewers may need summary visibility across sandbox evaluation flows.
+- Traces and provenance become easier to inspect when telemetry is bounded and explicit.
+- Review-lane activity may benefit from high-level visibility.
+- Connector-boundary behavior may be easier to reason about with conservative summaries.
+- Telemetry thinking supports evidence-oriented governance workflows.
+
+## Example conceptual telemetry record
+
+```json
+{
+  "telemetry_id": "example-telemetry-001",
+  "evaluation_mode": "sandbox_visibility",
+  "source_connector": "mattermost",
+  "candidate_type": "message",
+  "decision_summary": {
+    "proceed": 3,
+    "needs_review": 2,
+    "silence": 1
+  },
+  "review_lane_summary": {
+    "proceed_lane": 3,
+    "review_lane": 2,
+    "silence_lane": 1
+  }
+}
+```
+
+This is only a conceptual telemetry example used for architectural discussion.
+It is not a runtime schema, monitoring contract, compliance artifact, or production observability guarantee.
+
+## What sandbox telemetry is
+
+Sandbox telemetry is:
+- a conceptual visibility layer
+- a bounded inspection surface
+- a way to summarize sandbox evaluation activity
+- useful for review-oriented workflows
+- useful for evidence-oriented governance thinking
+- useful for comparing sandbox evaluation behavior
+
+## What sandbox telemetry is not
+
+It is not:
+- proof of correctness
+- production monitoring
+- compliance reporting
+- a security boundary
+- guaranteed observability
+- a deployment requirement
+- a runtime implementation commitment
+
+## Relationship to the current repo
+
+- `docs/reverse_integration_sandbox.md` explains the sandbox layer.
+- `docs/sandbox_channel_adapters.md` explains intake adapters.
+- `docs/intake_payload_schema.md` explains normalized intake payloads.
+- `docs/deterministic_replay_architecture.md` explains replay and inspection.
+- `docs/decision_provenance_architecture.md` explains provenance and review context.
+- `docs/evaluation_trace_architecture.md` explains evaluation trace visibility.
+- `docs/review_lane_architecture.md` explains governance routing.
+- `docs/connector_sandbox_boundary.md` explains connector boundary separation.
+- `docs/agentic_release_control.md` explains release-control architecture.
+- `docs/project_navigation.md` explains navigation flow.
+- Issue #203 tracks roadmap/dependency evolution.
+
+## Possible future directions
+
+Possible future directions may include:
+- telemetry-linked trace summaries
+- review-lane counters
+- connector-boundary visibility summaries
+- replay-to-telemetry comparison
+- evidence-linked telemetry reports
+- reviewer-facing visibility dashboards
+
+These directions are illustrative and do not commit the repository to runtime implementation or production deployment.


### PR DESCRIPTION
### Motivation

- Introduce a conservative, architecture-only visibility concept that summarizes sandbox evaluation activity across intake, replay, provenance, traces, review lanes, and connector boundaries.  
- Provide reviewers and architects a bounded inspection surface to reason about sandbox evaluation behavior without implying production monitoring or security guarantees.  
- Keep the change documentation-only and aligned with existing evidence- and review-oriented governance artifacts already in the repo.

### Description

- Add `docs/sandbox_evaluation_telemetry.md` containing the Purpose, Core idea (with the requested governance-flow diagram), conservative wording (`Telemetry visibility is not proof of correctness.` and `Sandbox telemetry is for inspection, not production compliance.`), a conceptual JSON example, "is / is not" lists, repo relationship mapping, and conservative future directions.  
- Update `docs/README.md` to include a `Review lane architecture` entry and a `Sandbox evaluation telemetry` link placed near related sandbox/review/trace/connector architecture links.  
- Add a lightweight entry in the root `README.md` under Fast orientation linking to `docs/sandbox_evaluation_telemetry.md` without changing runtime behavior.  
- No code, API, runtime telemetry, monitoring, SDKs, deployments, or security/assurance claims were added or modified.

### Testing

- Ran `git diff --check` and it reported no problems.  
- Ran the test suite with `python -m pytest tests/test_api.py -q` and the suite passed (`15 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1046419cac832683badadcaa163f84)