### PR TITLE
docs: add policy surface architecture concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ It does **not** improve model weights. It controls release behavior.
 - [Sandbox channel adapters](docs/sandbox_channel_adapters.md) — conceptual intake connectors for sandbox evaluation flows.
 - [Deterministic replay architecture](docs/deterministic_replay_architecture.md) — conceptual replay and inspection layer for sandbox evaluation flows.
 - [Decision provenance architecture](docs/decision_provenance_architecture.md) — conceptual traceability layer for sandbox release decisions.
+- [Policy surface architecture](docs/policy_surface_architecture.md) — conceptual policy-aware interpretation layer for sandbox governance flows.
 - [Connector sandbox boundary](docs/connector_sandbox_boundary.md) — conceptual governance boundary for external communication surfaces.
 - [Sandbox evaluation telemetry](docs/sandbox_evaluation_telemetry.md) — conceptual visibility layer for sandbox governance flows.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - [Evaluation trace architecture](evaluation_trace_architecture.md) — conceptual inspection and traceability layer for sandbox evaluation flows.
 - [Review lane architecture](review_lane_architecture.md) — conceptual governance routing layer for sandbox evaluation flows.
 - [Sandbox evaluation telemetry](sandbox_evaluation_telemetry.md) — conceptual visibility layer for sandbox governance flows.
+- [Policy surface architecture](policy_surface_architecture.md) — conceptual policy-aware interpretation layer for sandbox governance flows.
 - [Connector sandbox boundary](connector_sandbox_boundary.md) — conceptual governance boundary for external communication surfaces.
 - `applied_bridges.md` — bounded notes on compatible applied bridges such as `por-copilot-bridge`.
 

--- a/docs/policy_surface_architecture.md
+++ b/docs/policy_surface_architecture.md
@@ -1,0 +1,110 @@
+# Policy Surface Architecture
+
+## Purpose
+
+Policy Surface Architecture is a conceptual governance layer for interpreting sandbox evaluation outcomes, review hints, telemetry summaries, and release-control decisions through bounded policy context.
+
+The purpose is not autonomous enforcement.
+The purpose is policy-aware review visibility.
+
+Policy surfaces may help reviewers understand how sandbox outcomes could be interpreted against explicit review constraints without treating the system as a compliance engine.
+
+## Core idea
+
+After release-control decisions, provenance, traces, review lanes, and telemetry are available, a policy surface may conceptually provide bounded interpretation for reviewers.
+
+```text
+Sandbox Evaluation Telemetry
+        ↓
+Evaluation Trace
+        ↓
+Decision Provenance
+        ↓
+Review Lane Routing
+        ↓
+Policy Surface
+        ↓
+Reviewer / Evidence Surface
+```
+
+Policy surfaces are interpretation surfaces, not autonomous enforcement.
+
+Policy visibility is not equivalent to compliance authority.
+
+## Why this matters
+
+- Reviewers may need bounded policy context when inspecting sandbox outcomes.
+- Review hints may become easier to interpret when connected to explicit constraints.
+- Policy surfaces may reduce ambiguity during review workflows.
+- Policy-aware visibility may support evidence-oriented governance.
+- Release-control decisions should remain separated from automatic compliance claims.
+
+## Example conceptual policy-surface record
+
+```json
+{
+  "policy_surface_id": "example-policy-001",
+  "trace_id": "example-trace-001",
+  "decision": "NEEDS_REVIEW",
+  "policy_context": {
+    "policy_mode": "bounded_review",
+    "release_constraint": "human_review_before_external_release",
+    "compliance_claim": false
+  },
+  "review_hint": "Check candidate against local review policy before release."
+}
+```
+
+This is only a conceptual policy-surface example used for architectural discussion.
+It is not a runtime schema, legal compliance artifact, policy engine, or enforcement guarantee.
+
+## What policy surfaces are
+
+Policy surfaces are:
+
+- a conceptual governance layer
+- a bounded interpretation surface
+- a way to connect review hints and release outcomes to explicit constraints
+- useful for review-oriented workflows
+- useful for evidence-oriented governance thinking
+- useful for sandbox experimentation
+
+## What policy surfaces are not
+
+They are not:
+
+- legal compliance systems
+- autonomous enforcement engines
+- production policy engines
+- security boundaries
+- guarantees of correctness
+- deployment requirements
+- runtime implementation commitments
+
+## Relationship to the current repo
+
+- `docs/reverse_integration_sandbox.md` explains the sandbox layer.
+- `docs/sandbox_channel_adapters.md` explains intake adapters.
+- `docs/intake_payload_schema.md` explains normalized intake payloads.
+- `docs/deterministic_replay_architecture.md` explains replay and inspection.
+- `docs/decision_provenance_architecture.md` explains provenance and review context.
+- `docs/evaluation_trace_architecture.md` explains evaluation trace visibility.
+- `docs/review_lane_architecture.md` explains governance routing.
+- `docs/connector_sandbox_boundary.md` explains connector boundary separation.
+- `docs/sandbox_evaluation_telemetry.md` explains bounded telemetry visibility.
+- `docs/agentic_release_control.md` explains release-control architecture.
+- `docs/project_navigation.md` explains navigation flow.
+- Issue #203 tracks roadmap/dependency evolution.
+
+## Possible future directions
+
+Possible future directions may include:
+
+- policy-linked review hints
+- bounded review constraints
+- policy-aware trace summaries
+- review-lane policy tags
+- evidence-linked policy records
+- reviewer-facing policy context views
+
+These possible directions are conceptual and do not represent implementation commitments.


### PR DESCRIPTION
### Motivation

- Introduce a conservative, conceptual governance layer that helps reviewers interpret sandbox evaluation outcomes, review hints, telemetry summaries, and release-control decisions through bounded policy context.
- Provide architecture-level guidance that improves review visibility without implying runtime enforcement, legal compliance, or production guarantees.
- Keep the change strictly documentation-only and aligned with existing PoR / Silence-as-Control evidence and governance surfaces.

### Description

- Add `docs/policy_surface_architecture.md` containing the required Purpose/Core idea/Why this matters/Example/Are/Are-not/Relationship/Possible future directions sections and the requested ASCII diagram and JSON example.  
- Update `docs/README.md` and the repository `README.md` to add a lightweight link to the new `policy_surface_architecture.md` near related sandbox governance entries.  
- Preserve conservative wording and explicitly avoid introducing APIs, runtime schemas, enforcement claims, or implementation commitments, and do not modify any code or runtime behavior.

### Testing

- Run `git diff --check` which produced no check failures.  
- Run `python -m pytest tests/test_api.py -q` which completed successfully (`15 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a104872287083269db8d7e715bea362)