### PR TITLE
docs: add evidence retention architecture concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ It does **not** improve model weights. It controls release behavior.
 - [Deterministic replay architecture](docs/deterministic_replay_architecture.md) — conceptual replay and inspection layer for sandbox evaluation flows.
 - [Decision provenance architecture](docs/decision_provenance_architecture.md) — conceptual traceability layer for sandbox release decisions.
 - [Policy surface architecture](docs/policy_surface_architecture.md) — conceptual policy-aware interpretation layer for sandbox governance flows.
+- [Evidence retention architecture](docs/evidence_retention_architecture.md) — conceptual evidence-continuity layer for sandbox governance flows.
 - [Connector sandbox boundary](docs/connector_sandbox_boundary.md) — conceptual governance boundary for external communication surfaces.
 - [Sandbox evaluation telemetry](docs/sandbox_evaluation_telemetry.md) — conceptual visibility layer for sandbox governance flows.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,10 +22,11 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - [Intake payload schema](intake_payload_schema.md) — conceptual normalization format for sandbox intake evaluation flows.
 - [Deterministic replay architecture](deterministic_replay_architecture.md) — conceptual replay and inspection layer for sandbox evaluation flows.
 - [Decision provenance architecture](decision_provenance_architecture.md) — conceptual traceability layer for sandbox release decisions.
-- [Evaluation trace architecture](evaluation_trace_architecture.md) — conceptual inspection and traceability layer for sandbox evaluation flows.
-- [Review lane architecture](review_lane_architecture.md) — conceptual governance routing layer for sandbox evaluation flows.
 - [Sandbox evaluation telemetry](sandbox_evaluation_telemetry.md) — conceptual visibility layer for sandbox governance flows.
 - [Policy surface architecture](policy_surface_architecture.md) — conceptual policy-aware interpretation layer for sandbox governance flows.
+- [Evidence retention architecture](evidence_retention_architecture.md) — conceptual evidence-continuity layer for sandbox governance flows.
+- [Evaluation trace architecture](evaluation_trace_architecture.md) — conceptual inspection and traceability layer for sandbox evaluation flows.
+- [Review lane architecture](review_lane_architecture.md) — conceptual governance routing layer for sandbox evaluation flows.
 - [Connector sandbox boundary](connector_sandbox_boundary.md) — conceptual governance boundary for external communication surfaces.
 - `applied_bridges.md` — bounded notes on compatible applied bridges such as `por-copilot-bridge`.
 

--- a/docs/evidence_retention_architecture.md
+++ b/docs/evidence_retention_architecture.md
@@ -1,0 +1,113 @@
+# Evidence Retention Architecture
+
+## Purpose
+
+Evidence Retention Architecture is a conceptual governance layer for thinking about how sandbox evaluation evidence may be referenced, retained, bounded, and reviewed.
+
+The purpose is not legal archiving.
+The purpose is bounded evidence continuity.
+
+Evidence retention may help reviewers understand which traces, provenance records, telemetry summaries, review-lane records, and policy-surface references were relevant to a release-control decision.
+
+## Core idea
+
+After evaluation traces, decision provenance, telemetry summaries, review lanes, and policy surfaces are available, an evidence retention layer may conceptually preserve references to the relevant artifacts for later inspection.
+
+```text
+Policy Surface
+        ↓
+Evaluation Trace
+        ↓
+Decision Provenance
+        ↓
+Sandbox Evaluation Telemetry
+        ↓
+Review Lane Record
+        ↓
+Evidence Retention Layer
+        ↓
+Reviewer / Evidence Surface
+```
+
+Evidence retention is for bounded continuity, not legal proof.
+
+Retained evidence references should support inspection without pretending to guarantee correctness.
+
+## Why this matters
+
+- Reviewers may need to understand which evidence was associated with a sandbox decision.
+- Replay, provenance, traces, telemetry, and review lanes become easier to inspect when linked by retained references.
+- Retention boundaries may reduce ambiguity during review workflows.
+- Evidence lifecycle thinking supports governance continuity.
+- Retained references should remain separate from compliance or forensic claims.
+
+## Example conceptual evidence-retention record
+
+```json
+{
+  "evidence_retention_id": "example-retention-001",
+  "trace_id": "example-trace-001",
+  "provenance_id": "example-prov-001",
+  "telemetry_id": "example-telemetry-001",
+  "policy_surface_id": "example-policy-001",
+  "retention_context": {
+    "mode": "sandbox_review_reference",
+    "legal_archive": false,
+    "forensic_claim": false
+  },
+  "review_hint": "Retain references for later sandbox review, not as proof of correctness."
+}
+```
+
+This is only a conceptual evidence-retention example used for architectural discussion.
+It is not a runtime schema, legal archive, audit trail, forensic guarantee, or compliance artifact.
+
+## What evidence retention is
+
+Evidence retention is:
+- a conceptual governance layer
+- a bounded evidence-continuity surface
+- a way to connect traces, provenance, telemetry, review lanes, and policy context
+- useful for review-oriented workflows
+- useful for evidence-oriented governance thinking
+- useful for sandbox experimentation
+
+## What evidence retention is not
+
+It is not:
+- a legal archive
+- a forensic audit trail
+- proof of correctness
+- immutable storage
+- compliance reporting
+- a security boundary
+- a production evidence system
+- a runtime implementation commitment
+
+## Relationship to the current repo
+
+- `docs/reverse_integration_sandbox.md` explains the sandbox layer.
+- `docs/sandbox_channel_adapters.md` explains intake adapters.
+- `docs/intake_payload_schema.md` explains normalized intake payloads.
+- `docs/deterministic_replay_architecture.md` explains replay and inspection.
+- `docs/decision_provenance_architecture.md` explains provenance and review context.
+- `docs/evaluation_trace_architecture.md` explains evaluation trace visibility.
+- `docs/review_lane_architecture.md` explains governance routing.
+- `docs/connector_sandbox_boundary.md` explains connector boundary separation.
+- `docs/sandbox_evaluation_telemetry.md` explains bounded telemetry visibility.
+- `docs/policy_surface_architecture.md` explains policy-aware interpretation.
+- `docs/agentic_release_control.md` explains release-control architecture.
+- `docs/project_navigation.md` explains navigation flow.
+- Issue #203 tracks roadmap/dependency evolution.
+
+## Possible future directions
+
+Possible future directions may include:
+- evidence-linked review summaries
+- retention-scope labels
+- replay-linked evidence references
+- provenance-linked evidence bundles
+- evidence lifecycle notes
+- reviewer-facing evidence context views
+
+These are potential conceptual directions for future discussion and do not represent implementation commitments.


### PR DESCRIPTION
### Motivation

- Introduce a conservative, architectural layer for thinking about bounded evidence continuity across sandbox evaluation artifacts without implying production, legal, or forensic guarantees.
- Help reviewers and architects reason about which traces, provenance records, telemetry summaries, review-lane records, and policy-surface references were relevant to a release-control decision.
- Make the concept discoverable from the docs index so it can be referenced alongside related architecture notes (policy, telemetry, provenance, replay, review lanes).

### Description

- Add `docs/evidence_retention_architecture.md` containing Purpose, Core idea (with the requested diagram), the required wording (including "Evidence retention is for bounded continuity, not legal proof." and "Retained evidence references should support inspection without pretending to guarantee correctness."), a conceptual JSON example, explicit "is / is not" boundaries, repo relationship links, and conservative future directions language.
- Update `docs/README.md` and the top-level `README.md` to add a lightweight index link to the new documentation file placed near the policy/telemetry/provenance architectural cluster for discoverability.
- This change is documentation-only, makes no runtime/API/storage/archival/security claims, and explicitly avoids promising implementation features.

### Testing

- Ran `git diff --check` to validate diff cleanliness and whitespace issues, which reported no problems.
- Ran `python -m pytest tests/test_api.py -q` and all tests passed (`15 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a104c6d48fc8326a62f96f0e965c100)