### PR TITLE
docs: add runtime governance stack map

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It does **not** improve model weights. It controls release behavior.
 
 - [Plain-English pitch](docs/plain_english_pitch.md) — understand the idea simply.
 - [Project navigation map](docs/project_navigation.md) — choose the right entry point.
+- [Runtime governance stack](docs/runtime_governance_stack.md) — canonical map of sandbox and release-control governance layers.
 - [First-run checklist](docs/first_run_checklist.md) — verify the no-key local path.
 - [Evidence map](docs/evidence_map.md) — connect claims to artifacts.
 - [Reverse integration sandbox](docs/reverse_integration_sandbox.md) — controlled intake/evaluation concept.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - `action_risk_1000_dataset.md` — Run 06 1000-case synthetic dataset scope and schema.
 - `release_control_services.md` — pilot/integration overview for release-control use cases.
 - `agentic_release_control.md` — deterministic release-control architecture for agentic workflows.
+- [Runtime governance stack](runtime_governance_stack.md) — canonical map of the sandbox and release-control governance layers.
 - [Reverse integration sandbox](reverse_integration_sandbox.md) — controlled intake/evaluation concept for external candidate outputs.
 - [Sandbox channel adapters](sandbox_channel_adapters.md) — conceptual intake connectors for sandbox evaluation flows.
 - [Intake payload schema](intake_payload_schema.md) — conceptual normalization format for sandbox intake evaluation flows.

--- a/docs/runtime_governance_stack.md
+++ b/docs/runtime_governance_stack.md
@@ -1,0 +1,113 @@
+# Runtime Governance Stack
+
+## Purpose
+
+Runtime Governance Stack is a canonical map of the conceptual governance layers used in Silence-as-Control / PoR sandbox and release-control architecture.
+
+The purpose is not to introduce a new runtime feature.
+The purpose is to show how existing conceptual documents fit together.
+
+This document should act as an orientation layer for reviewers, contributors, and future Codex/ChatGPT sessions.
+
+## Core stack
+
+```text
+External Transport / Connector
+        ↓
+Connector Sandbox Boundary
+        ↓
+Sandbox Channel Adapter
+        ↓
+Normalized Intake Payload
+        ↓
+Replay / Inspection Layer
+        ↓
+PoR / Release Gate
+        ↓
+Decision Provenance
+        ↓
+Evaluation Trace
+        ↓
+Review Lane Routing
+        ↓
+Sandbox Evaluation Telemetry
+        ↓
+Policy Surface
+        ↓
+Evidence Retention
+        ↓
+Reviewer / Evidence Surface
+```
+
+The stack separates transport, generation, evaluation, release authority, review visibility, and evidence continuity.
+
+This is a conceptual governance map, not a production runtime contract.
+
+## Layer responsibilities
+
+| Layer | Responsibility | Related doc |
+| --- | --- | --- |
+| Connector Sandbox Boundary | Separates external transport access from release authority. | `connector_sandbox_boundary.md` |
+| Sandbox Channel Adapter | Describes conceptual channel intake connectors. | `sandbox_channel_adapters.md` |
+| Normalized Intake Payload | Describes a shared evaluation envelope for candidate inputs. | `intake_payload_schema.md` |
+| Replay / Inspection Layer | Describes replay-oriented inspection of normalized candidates. | `deterministic_replay_architecture.md` |
+| PoR / Release Gate | Produces `PROCEED`, `NEEDS_REVIEW`, or `SILENCE`. | `agentic_release_control.md` |
+| Decision Provenance | Connects release decisions to inspectable context. | `decision_provenance_architecture.md` |
+| Evaluation Trace | Describes candidate movement through evaluation layers. | `evaluation_trace_architecture.md` |
+| Review Lane Routing | Separates proceed/review/silence routing visibility. | `review_lane_architecture.md` |
+| Sandbox Evaluation Telemetry | Summarizes sandbox activity for bounded inspection. | `sandbox_evaluation_telemetry.md` |
+| Policy Surface | Provides bounded policy-aware interpretation. | `policy_surface_architecture.md` |
+| Evidence Retention | Preserves references for bounded evidence continuity. | `evidence_retention_architecture.md` |
+| Reviewer / Evidence Surface | Final human-facing inspection and evidence layer. | `evidence_map.md` |
+
+## What the stack is
+
+The Runtime Governance Stack is:
+- a canonical architecture map
+- a navigation layer across existing docs
+- a way to understand conceptual dependencies
+- useful for reviewers and contributors
+- useful for future roadmap sessions
+- documentation-first and conservative
+
+## What the stack is not
+
+It is not:
+- a production runtime contract
+- a deployed system
+- a compliance framework
+- a security guarantee
+- a monitoring platform
+- an autonomous enforcement system
+- an API specification
+- a runtime implementation commitment
+
+## Relationship to roadmap and issues
+
+- `docs/roadmap_2026.md` is the strategic roadmap.
+- Issue #202 is the project memory capsule.
+- Issue #203 is the live roadmap/progress/dependency capsule.
+- This document is the canonical governance-stack map.
+- Individual architecture docs remain the source for each layer’s detailed explanation.
+
+## Suggested reading order
+
+1. `plain_english_pitch.md`
+2. `project_navigation.md`
+3. `agentic_release_control.md`
+4. `reverse_integration_sandbox.md`
+5. `runtime_governance_stack.md`
+6. Layer-specific docs as needed.
+7. `evidence_map.md`
+8. Issue #203 for live roadmap/dependency state.
+
+## Possible future directions
+
+Possible future directions may include:
+- a visual diagram version of the governance stack
+- reviewer-facing architecture summaries
+- evidence-linked stack walkthroughs
+- sandbox-stack onboarding examples
+- trace-to-policy-to-evidence navigation guides
+
+These are directional ideas and do not represent implementation commitments.


### PR DESCRIPTION
### Motivation

- Consolidate multiple conceptual governance documents into a single, canonical orientation layer for the Silence-as-Control / PoR sandbox and release-control architecture. 
- Provide a conservative, documentation-first map that helps reviewers, contributors, and future Codex/ChatGPT sessions navigate existing architecture notes without introducing runtime claims. 
- Keep the change strictly architectural and non-operational, avoiding any implication of production readiness, APIs, or security guarantees.

### Description

- Add `docs/runtime_governance_stack.md` containing the specified `Purpose`, the `Core stack` ASCII diagram, a `Layer responsibilities` table linking to existing docs, explicit “what the stack is / is not” language, roadmap/issue relationships, suggested reading order, and non-committal possible future directions. 
- Update `docs/README.md` to include a link to `runtime_governance_stack.md` adjacent to other governance architecture entries. 
- Update root `README.md` under `Fast orientation` to add a lightweight link to `docs/runtime_governance_stack.md`. 
- Changes are documentation-only and conservative: no code, no APIs, no runtime implementations, no SDKs, and no claims about security, compliance, or deployment.

### Testing

- Validation checklist: 
  - [ ] `git diff --check` (no issues found when run locally). 
  - [ ] `python -m pytest tests/test_api.py -q` (tests passed: `15 passed`).
- All automated tests referenced above completed successfully during validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a106d03f7c08326905bd16d34bcdc52)