### PR TITLE
docs: add governance stack visualization and architecture walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ It does **not** improve model weights. It controls release behavior.
 - [Plain-English pitch](docs/plain_english_pitch.md) — understand the idea simply.
 - [Project navigation map](docs/project_navigation.md) — choose the right entry point.
 - [Runtime governance stack](docs/runtime_governance_stack.md) — canonical map of sandbox and release-control governance layers.
+- [Governance stack walkthrough](docs/governance_stack_walkthrough.md) — guided architecture walkthrough of governance layers.
 - [First-run checklist](docs/first_run_checklist.md) — verify the no-key local path.
 - [Evidence map](docs/evidence_map.md) — connect claims to artifacts.
 - [Reverse integration sandbox](docs/reverse_integration_sandbox.md) — controlled intake/evaluation concept.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - `release_control_services.md` — pilot/integration overview for release-control use cases.
 - `agentic_release_control.md` — deterministic release-control architecture for agentic workflows.
 - [Runtime governance stack](runtime_governance_stack.md) — canonical map of the sandbox and release-control governance layers.
+- [Governance stack walkthrough](governance_stack_walkthrough.md) — guided walkthrough of the runtime governance stack.
 - [Reverse integration sandbox](reverse_integration_sandbox.md) — controlled intake/evaluation concept for external candidate outputs.
 - [Sandbox channel adapters](sandbox_channel_adapters.md) — conceptual intake connectors for sandbox evaluation flows.
 - [Intake payload schema](intake_payload_schema.md) — conceptual normalization format for sandbox intake evaluation flows.

--- a/docs/governance_stack_walkthrough.md
+++ b/docs/governance_stack_walkthrough.md
@@ -1,0 +1,153 @@
+# Governance Stack Walkthrough
+
+## Purpose
+
+This document is a guided walkthrough of the Runtime Governance Stack.
+
+The purpose is to help readers understand:
+- how conceptual layers connect
+- where release-control decisions occur
+- how replay/provenance/traceability fit together
+- how review visibility and evidence continuity relate to sandbox governance
+
+This document is documentation-oriented and conceptual.
+
+## Full governance flow
+
+```text
+External Transport / Connector
+        ↓
+Connector Sandbox Boundary
+        ↓
+Sandbox Channel Adapter
+        ↓
+Normalized Intake Payload
+        ↓
+Replay / Inspection Layer
+        ↓
+PoR / Release Gate
+        ↓
+Decision Provenance
+        ↓
+Evaluation Trace
+        ↓
+Review Lane Routing
+        ↓
+Sandbox Evaluation Telemetry
+        ↓
+Policy Surface
+        ↓
+Evidence Retention
+        ↓
+Reviewer / Evidence Surface
+```
+
+The governance stack separates:
+- transport
+- candidate generation
+- evaluation
+- release authority
+- review visibility
+- evidence continuity
+
+## Step-by-step walkthrough
+
+### 1. Transport and connector intake
+
+The governance flow starts at external communication surfaces. Connector-facing inputs are treated as bounded intake rather than implicit release decisions.
+
+The connector sandbox boundary and adapter layer help keep transport handling separate from release-control authority. Intake can be evaluated, normalized, and routed, but does not receive automatic release authority by virtue of arriving through a connector.
+
+References:
+- `connector_sandbox_boundary.md`
+- `sandbox_channel_adapters.md`
+
+### 2. Normalization and replay
+
+After intake, candidate payloads are mapped into a normalized intake payload shape. This improves consistency across heterogeneous connector surfaces and supports replay-oriented inspection.
+
+Replay-oriented inspection supports deterministic inspection thinking: the same normalized inputs and governance context should produce comparable inspection and control outcomes, making review and analysis easier to reason about.
+
+References:
+- `intake_payload_schema.md`
+- `deterministic_replay_architecture.md`
+
+### 3. Release-control decisions
+
+Release-control decisions remain explicit and bounded. A candidate evaluation may result in:
+- `PROCEED`
+- `NEEDS_REVIEW`
+- `SILENCE`
+
+This preserves a key governance distinction: generation and release are separate activities. Candidate generation can occur upstream, while release authority is determined at the release-control layer.
+
+Reference:
+- `agentic_release_control.md`
+
+### 4. Provenance and traces
+
+Provenance context captures how a release-control outcome was reached at a conceptual architecture level. Evaluation traces provide structured inspection context across the governance flow.
+
+Together, provenance and trace surfaces improve bounded inspection visibility: reviewers can see why a decision path was taken without collapsing governance boundaries into unbounded introspection.
+
+References:
+- `decision_provenance_architecture.md`
+- `evaluation_trace_architecture.md`
+
+### 5. Review routing and telemetry
+
+When review is needed, routing through review lanes helps preserve governance intent and responsibility boundaries. Review routing is paired with telemetry that is bounded to evaluation-governance needs.
+
+This supports review-oriented inspection while keeping visibility scoped: enough context for decision support and governance analysis, without presenting telemetry as release authority by itself.
+
+References:
+- `review_lane_architecture.md`
+- `sandbox_evaluation_telemetry.md`
+
+### 6. Policy interpretation and evidence continuity
+
+Policy surfaces provide policy-aware interpretation across governance outcomes and review flows. Evidence retention then preserves bounded evidence continuity across decisions and reviews.
+
+Together with evidence mapping and reviewer-facing surfaces, this supports traceable governance understanding over time without reframing the stack as a deployment contract.
+
+References:
+- `policy_surface_architecture.md`
+- `evidence_retention_architecture.md`
+- `evidence_map.md`
+
+## What this walkthrough is
+
+This walkthrough is:
+- an onboarding-oriented explanation
+- a governance-stack orientation layer
+- a conceptual architecture guide
+- a navigation surface across related docs
+
+## What this walkthrough is not
+
+It is not:
+- a production runtime specification
+- a compliance system
+- a deployment guide
+- a runtime API contract
+- a monitoring platform
+- an autonomous governance engine
+
+## Suggested reading path
+
+1. `plain_english_pitch.md`
+2. `project_navigation.md`
+3. `runtime_governance_stack.md`
+4. `governance_stack_walkthrough.md`
+5. Layer-specific docs as needed.
+6. `evidence_map.md`
+7. Issue #203 for live roadmap/dependency state.
+
+## Possible future directions
+
+Possible future directions may include:
+- visual PNG/SVG governance diagrams
+- reviewer-facing architecture summaries
+- stack navigation diagrams
+- evidence-linked walkthrough examples
+- onboarding-oriented governance maps


### PR DESCRIPTION
### Motivation

- Crystallize the Runtime Governance Stack into a single, human-readable walkthrough to improve architecture readability and onboarding clarity. 
- Bridge high-level onboarding content and layer-specific architecture docs so readers can understand governance-flow and where release-control decisions occur. 
- Keep changes documentation-only, conservative, and focused on architecture rather than adding runtime implementations or operational claims.

### Description

- Add `docs/governance_stack_walkthrough.md`, a guided architecture walkthrough that includes the requested full governance-flow text diagram and six step-by-step sections covering transport, normalization/replay, release-control decisions, provenance/traces, review/telemetry, and policy/evidence continuity. 
- Update `docs/README.md` to include a link to the new walkthrough adjacent to the `runtime_governance_stack.md` entry. 
- Add a lightweight link in the root `README.md` Fast orientation to point users to the new `docs/governance_stack_walkthrough.md` walkthrough. 
- All changes are documentation-only and scoped to the three files: `docs/governance_stack_walkthrough.md`, `docs/README.md`, and `README.md`.

### Testing

- Ran `git diff --check` and there were no whitespace or diff-check issues. 
- Ran `python -m pytest tests/test_api.py -q` and the test suite succeeded (`15 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1078bf64108326a9ec6ce8b3e57384)