### PR TITLE
docs: add runtime governance visual map

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ It does **not** improve model weights. It controls release behavior.
 - [Project navigation map](docs/project_navigation.md) — choose the right entry point.
 - [Runtime governance stack](docs/runtime_governance_stack.md) — canonical map of sandbox and release-control governance layers.
 - [Governance stack walkthrough](docs/governance_stack_walkthrough.md) — guided architecture walkthrough of governance layers.
+- [Runtime governance visual map](docs/runtime_governance_visual_map.md) — visual-oriented governance architecture reference.
 - [First-run checklist](docs/first_run_checklist.md) — verify the no-key local path.
 - [Evidence map](docs/evidence_map.md) — connect claims to artifacts.
 - [Reverse integration sandbox](docs/reverse_integration_sandbox.md) — controlled intake/evaluation concept.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - `agentic_release_control.md` — deterministic release-control architecture for agentic workflows.
 - [Runtime governance stack](runtime_governance_stack.md) — canonical map of the sandbox and release-control governance layers.
 - [Governance stack walkthrough](governance_stack_walkthrough.md) — guided walkthrough of the runtime governance stack.
+- [Runtime governance visual map](runtime_governance_visual_map.md) — visual-oriented map of governance and release-control layers.
 - [Reverse integration sandbox](reverse_integration_sandbox.md) — controlled intake/evaluation concept for external candidate outputs.
 - [Sandbox channel adapters](sandbox_channel_adapters.md) — conceptual intake connectors for sandbox evaluation flows.
 - [Intake payload schema](intake_payload_schema.md) — conceptual normalization format for sandbox intake evaluation flows.

--- a/docs/runtime_governance_visual_map.md
+++ b/docs/runtime_governance_visual_map.md
@@ -1,0 +1,170 @@
+# Runtime Governance Visual Map
+
+## Purpose
+
+This document provides a visual-oriented overview of the Runtime Governance Stack used in Silence-as-Control / PoR governance architecture.
+
+The goal is:
+- onboarding clarity
+- governance readability
+- conceptual stack visualization
+- architecture orientation
+
+This document is conceptual and documentation-oriented.
+
+## Canonical governance map
+
+```text
+┌─────────────────────────────────────┐
+│ External Transport / Connector      │
+└─────────────────────────────────────┘
+                    ↓
+┌─────────────────────────────────────┐
+│ Connector Sandbox Boundary          │
+└─────────────────────────────────────┘
+                    ↓
+┌─────────────────────────────────────┐
+│ Sandbox Channel Adapter             │
+└─────────────────────────────────────┘
+                    ↓
+┌─────────────────────────────────────┐
+│ Normalized Intake Payload           │
+└─────────────────────────────────────┘
+                    ↓
+┌─────────────────────────────────────┐
+│ Replay / Inspection Layer           │
+└─────────────────────────────────────┘
+                    ↓
+┌─────────────────────────────────────┐
+│ PoR / Release Gate                  │
+│ PROCEED / NEEDS_REVIEW / SILENCE    │
+└─────────────────────────────────────┘
+                    ↓
+┌─────────────────────────────────────┐
+│ Decision Provenance                 │
+└─────────────────────────────────────┘
+                    ↓
+┌─────────────────────────────────────┐
+│ Evaluation Trace                    │
+└─────────────────────────────────────┘
+                    ↓
+┌─────────────────────────────────────┐
+│ Review Lane Routing                 │
+└─────────────────────────────────────┘
+                    ↓
+┌─────────────────────────────────────┐
+│ Sandbox Evaluation Telemetry        │
+└─────────────────────────────────────┘
+                    ↓
+┌─────────────────────────────────────┐
+│ Policy Surface                      │
+└─────────────────────────────────────┘
+                    ↓
+┌─────────────────────────────────────┐
+│ Evidence Retention                  │
+└─────────────────────────────────────┘
+                    ↓
+┌─────────────────────────────────────┐
+│ Reviewer / Evidence Surface         │
+└─────────────────────────────────────┘
+```
+
+The governance stack separates:
+- transport
+- candidate intake
+- evaluation
+- release authority
+- review visibility
+- evidence continuity
+
+This visual map is conceptual and does not represent a production runtime contract.
+
+## Layer groups
+
+### Intake and transport layers
+
+Includes:
+- connector boundary
+- adapters
+- normalized payloads
+
+References:
+- `connector_sandbox_boundary.md`
+- `sandbox_channel_adapters.md`
+- `intake_payload_schema.md`
+
+### Evaluation and release-control layers
+
+Includes:
+- replay
+- PoR gate
+- release decisions
+
+References:
+- `deterministic_replay_architecture.md`
+- `agentic_release_control.md`
+
+### Traceability and review layers
+
+Includes:
+- provenance
+- traces
+- review routing
+- telemetry
+
+References:
+- `decision_provenance_architecture.md`
+- `evaluation_trace_architecture.md`
+- `review_lane_architecture.md`
+- `sandbox_evaluation_telemetry.md`
+
+### Governance continuity layers
+
+Includes:
+- policy interpretation
+- evidence retention
+- reviewer/evidence surfaces
+
+References:
+- `policy_surface_architecture.md`
+- `evidence_retention_architecture.md`
+- `evidence_map.md`
+
+## Suggested onboarding flow
+
+1. `plain_english_pitch.md`
+2. `project_navigation.md`
+3. `runtime_governance_stack.md`
+4. `governance_stack_walkthrough.md`
+5. `runtime_governance_visual_map.md`
+6. Layer-specific docs as needed.
+7. Issue #203 for roadmap/dependency state.
+
+## What this visual map is
+
+This visual map is:
+- a governance visualization layer
+- a runtime-governance orientation surface
+- a conceptual architecture map
+- an onboarding-oriented reference
+
+## What this visual map is not
+
+It is not:
+- a runtime specification
+- a deployment contract
+- a compliance framework
+- a monitoring system
+- a production architecture guarantee
+- an autonomous governance engine
+
+## Possible future directions
+
+Possible future directions may include:
+- SVG/PNG governance diagrams
+- interactive architecture navigation
+- reviewer-facing architecture summaries
+- evidence-linked flow diagrams
+- onboarding-oriented visual maps
+
+These are directional possibilities and are not commitments.


### PR DESCRIPTION
### Motivation

- Provide a canonical, visual-first overview of the Runtime Governance Stack to improve onboarding clarity, governance readability, and architecture orientation. 
- Keep the change conservative and documentation-only so the repository retains a clear architecture surface without introducing runtime, API, or implementation claims.

### Description

- Add `docs/runtime_governance_visual_map.md` containing the requested ASCII governance diagram, layer-group breakdowns, suggested onboarding flow, "is / is not" scope boundaries, and conservative future-direction notes. 
- Add a lightweight link to the new visual map in `docs/README.md` next to the runtime governance stack and walkthrough entries. 
- Add a lightweight link to the new visual map under `Fast orientation` in the top-level `README.md`. 
- Changes are documentation-only and do not add images, SVG tooling, runtime code, or production/security claims.

### Testing

- Ran `git diff --check` to ensure no trailing whitespace or index issues and it completed with no errors. 
- Ran `python -m pytest tests/test_api.py -q` and the test suite passed (`15 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a109edd17c4832684cac798250c9ee8)