### PR TITLE
docs: restore review-lane architecture document

### DIFF
--- a/docs/review_lane_architecture.md
+++ b/docs/review_lane_architecture.md
@@ -1,0 +1,110 @@
+# Review-Lane Architecture
+
+## Purpose
+
+Review-Lane Architecture is a conceptual governance-routing layer for handling sandbox evaluation outcomes after release-control decisions are produced.
+
+The purpose is not autonomous authority. The purpose is bounded review visibility and controlled escalation thinking.
+
+Review lanes may help separate:
+- direct release outcomes
+- review-required outcomes
+- blocked/silenced outcomes
+
+without collapsing all decisions into a single execution path.
+
+## Core idea
+
+After replay, provenance, and evaluation traces are generated, release outcomes may conceptually route into different review lanes.
+
+```text
+Normalized Intake Payload
+        ↓
+Replay / Inspection Layer
+        ↓
+PoR / Release Gate
+        ↓
+PROCEED / NEEDS_REVIEW / SILENCE
+        ↓
+Decision Provenance
+        ↓
+Evaluation Trace
+        ↓
+Review Lane Routing
+        ├─ Proceed Lane
+        ├─ Review Lane
+        └─ Silence Lane
+```
+
+Review lanes are governance-oriented, not autonomous orchestration.
+
+Routing visibility is not equivalent to execution authority.
+
+## Why this matters
+
+Not all release outcomes should be handled identically. Reviewers may require bounded routing visibility, and review lanes may improve inspection consistency across sandbox governance flows.
+
+Separating lanes may reduce ambiguity during sandbox governance workflows, while routing-oriented review thinking supports evidence-oriented release-control architecture.
+
+## Example conceptual review-lane record
+
+```json
+{
+  "lane_record_id": "example-lane-001",
+  "trace_id": "example-trace-001",
+  "decision": "NEEDS_REVIEW",
+  "assigned_lane": "review_lane",
+  "routing_context": {
+    "evaluation_mode": "sandbox_review",
+    "review_priority": "bounded"
+  },
+  "review_hint": "Route to reviewer or policy surface before release."
+}
+```
+
+This is only a conceptual review-lane example used for architectural discussion. It is not a committed runtime schema, escalation engine, or workflow API.
+
+## What review lanes are
+
+Review lanes are:
+- a conceptual governance-routing layer
+- a bounded inspection surface
+- a way to separate release outcomes
+- useful for sandbox experimentation
+- useful for review-oriented workflows
+- useful for evidence-oriented governance thinking
+
+## What review lanes are not
+
+They are not:
+- autonomous escalation systems
+- production workflow orchestration
+- guaranteed-safe routing
+- a security boundary
+- a compliance engine
+- unrestricted automation
+- a runtime implementation commitment
+
+## Relationship to the current repo
+
+- `docs/reverse_integration_sandbox.md` explains the sandbox layer.
+- `docs/sandbox_channel_adapters.md` explains intake adapters.
+- `docs/intake_payload_schema.md` explains normalized intake payloads.
+- `docs/deterministic_replay_architecture.md` explains replay and inspection.
+- `docs/decision_provenance_architecture.md` explains provenance and review context.
+- `docs/evaluation_trace_architecture.md` explains evaluation trace visibility.
+- `docs/agentic_release_control.md` explains release-control architecture.
+- `docs/project_navigation.md` explains navigation flow.
+- Issue #203 tracks roadmap/dependency evolution.
+
+## Possible future directions
+
+Possible future directions may include:
+- bounded review queues
+- reviewer-facing routing summaries
+- trace-linked review records
+- replay-linked review inspection
+- lane-oriented telemetry
+- evidence-linked governance surfaces
+
+These are directional architecture considerations only and are not feature commitments.


### PR DESCRIPTION
## Summary
- restores `docs/review_lane_architecture.md`
- fixes broken references introduced in later governance-stack walkthrough and visualization docs
- restores review-routing continuity inside the canonical governance stack
- keeps the change documentation-only and conservative

## Validation
- [x] restores missing documentation target
- [x] fixes onboarding/navigation continuity
- [x] documentation-only change