### PR TITLE
docs: record release-risk benchmark run

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - `provider_configuration.md` — no-key vs provider-backed runtime configuration.
 - `threshold_regime_contract.md` — scoped threshold interpretation contract for SimpleQA/Ollama evidence.
 - `evidence_map.md` — claim-to-artifact navigation for core/runtime/benchmark surfaces.
+- `release_risk_benchmark_report.md` — first deterministic local release-risk benchmark run report.
 - [Plain-English pitch](plain_english_pitch.md) — a simple explanation of Silence-as-Control for first-time readers.
 - `langchain_openai_action_risk_benchmark.md` — LangChain/OpenAI action-risk benchmark framing and Run 06 hardened v4 progression.
 - `action_risk_1000_dataset.md` — Run 06 1000-case synthetic dataset scope and schema.

--- a/docs/evidence_map.md
+++ b/docs/evidence_map.md
@@ -72,6 +72,47 @@ The baseline-vs-PoR artifact is local demo evidence only.
 Treat these directories as the primary source for PR #131 / #132 run summaries.
 
 
+
+## Deterministic release-risk benchmark
+
+The release-risk benchmark is a local deterministic release-control behavior check. It compares baseline release-by-default against SaC-style routing on 50 handcrafted release-risk cases. It is not a live model-output benchmark and not a production safety guarantee.
+
+Artifacts:
+
+- `benchmarks/release_risk/README.md`
+- `benchmarks/release_risk/run_release_risk.py`
+- `benchmarks/release_risk/data/release_risk_50.jsonl`
+- `benchmarks/release_risk/results/release_risk_summary.json`
+- `benchmarks/release_risk/results/release_risk_summary.csv`
+- `tests/test_release_risk_benchmark.py`
+- `docs/release_risk_benchmark_report.md`
+
+Recorded local run:
+
+- total_cases: 50
+- baseline_unsafe_released: 24
+- sac_unsafe_released: 0
+- unsafe_release_reduction_percent: 100.0
+- safe_proceed_rate: 100.0
+
+Interpretation boundary:
+
+This shows deterministic release-routing behavior on the included dataset. It does not evaluate live model generation quality.
+
+Validation:
+
+Run:
+
+```bash
+python -m pytest tests/test_release_risk_benchmark.py -q
+python -m pytest tests/test_api.py -q
+```
+
+Expected:
+
+- 1 passed for release-risk benchmark test.
+- 15 passed for API tests.
+
 ## LangChain/OpenAI action-risk Run 06 progression
 
 Run 06 action-risk evidence is an integration/deployment validation surface for release control, not a primitive-core result and not a universal AI safety claim. The strongest supported claim is: same model, same dataset, same threshold, no PoR core change; release-layer hardening changed the review/release profile.

--- a/docs/release_risk_benchmark_report.md
+++ b/docs/release_risk_benchmark_report.md
@@ -1,0 +1,70 @@
+# Release-Risk Benchmark Report
+
+## Scope
+
+This report records the first deterministic local release-risk benchmark run.
+
+- It measures release behavior, not model intelligence.
+- The baseline path releases every candidate by default.
+- SaC-style deterministic routing maps candidates to `PROCEED` / `NEEDS_REVIEW` / `SILENCE`.
+- The run uses a deterministic local dataset with 50 cases.
+- The run does not require provider credentials or API keys.
+- This is not a production safety guarantee.
+
+## Commands
+
+The recorded local commands were:
+
+```bash
+python benchmarks/release_risk/run_release_risk.py
+python -m pytest tests/test_release_risk_benchmark.py -q
+python -m pytest tests/test_api.py -q
+```
+
+## Results
+
+Recorded benchmark summary:
+
+```text
+total_cases: 50
+baseline_released: 50
+baseline_unsafe_released: 24
+sac_proceed: 14
+sac_needs_review: 14
+sac_silence: 22
+sac_unsafe_released: 0
+unsafe_release_reduction_percent: 100.0
+safe_proceed_rate: 100.0
+```
+
+| Metric | Value |
+| --- | ---: |
+| total_cases | 50 |
+| baseline_released | 50 |
+| baseline_unsafe_released | 24 |
+| sac_proceed | 14 |
+| sac_needs_review | 14 |
+| sac_silence | 22 |
+| sac_unsafe_released | 0 |
+| unsafe_release_reduction_percent | 100.0 |
+| safe_proceed_rate | 100.0 |
+
+## Test validation
+
+- `tests/test_release_risk_benchmark.py`: 1 passed
+- `tests/test_api.py`: 15 passed
+
+## Interpretation
+
+This run demonstrates that, on the included deterministic dataset, release-by-default behavior releases all candidates, including 24 unsafe candidates, while the SaC-style deterministic route releases 0 unsafe candidates and routes the rest to `PROCEED` / `NEEDS_REVIEW` / `SILENCE`.
+
+This should be interpreted as a local release-control behavior check, not as external model safety evidence.
+
+## Artifacts
+
+- [`../benchmarks/release_risk/README.md`](../benchmarks/release_risk/README.md)
+- [`../benchmarks/release_risk/run_release_risk.py`](../benchmarks/release_risk/run_release_risk.py)
+- [`../benchmarks/release_risk/data/release_risk_50.jsonl`](../benchmarks/release_risk/data/release_risk_50.jsonl)
+- [`../benchmarks/release_risk/results/release_risk_summary.json`](../benchmarks/release_risk/results/release_risk_summary.json)
+- [`../benchmarks/release_risk/results/release_risk_summary.csv`](../benchmarks/release_risk/results/release_risk_summary.csv)
+- [`../tests/test_release_risk_benchmark.py`](../tests/test_release_risk_benchmark.py)


### PR DESCRIPTION
### Motivation

- Record a conservative execution report for the first deterministic local release-risk benchmark run to capture exact metrics and preserve interpretation boundaries.
- Make the evidence surface explicit that this benchmark measures release-routing behavior on a local deterministic 50-case dataset and is not a live model-output or production safety claim.

### Description

- Add `docs/release_risk_benchmark_report.md` which includes scope, recorded commands (`python benchmarks/release_risk/run_release_risk.py`, `python -m pytest tests/test_release_risk_benchmark.py -q`, `python -m pytest tests/test_api.py -q`), exact benchmark metrics, test validation, interpretation notes, and artifact links.
- Update `docs/README.md` to add a lightweight index entry linking `release_risk_benchmark_report.md`.
- Update `docs/evidence_map.md` to add a `Deterministic release-risk benchmark` section that lists the benchmark artifacts, records the local run metrics, provides validation commands, and states conservative interpretation boundaries.

### Testing

- Ran `python -m pytest tests/test_release_risk_benchmark.py -q` resulting in `1 passed`.
- Ran `python -m pytest tests/test_api.py -q` resulting in `15 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a117bba1a4483269be1403caa24bd54)