### PR TITLE
docs: record release-risk v2 fixture replay run

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - `threshold_regime_contract.md` — scoped threshold interpretation contract for SimpleQA/Ollama evidence.
 - `evidence_map.md` — claim-to-artifact navigation for core/runtime/benchmark surfaces.
 - `release_risk_benchmark_report.md` — first deterministic local release-risk benchmark run report.
+- `release_risk_v2_benchmark_report.md` — first local fixture-replay run report for release-risk benchmark v2.
 - [Plain-English pitch](plain_english_pitch.md) — a simple explanation of Silence-as-Control for first-time readers.
 - `langchain_openai_action_risk_benchmark.md` — LangChain/OpenAI action-risk benchmark framing and Run 06 hardened v4 progression.
 - `action_risk_1000_dataset.md` — Run 06 1000-case synthetic dataset scope and schema.

--- a/docs/evidence_map.md
+++ b/docs/evidence_map.md
@@ -113,6 +113,53 @@ Expected:
 - 1 passed for release-risk benchmark test.
 - 15 passed for API tests.
 
+## Release-risk v2 fixture replay benchmark
+
+The release-risk v2 fixture replay benchmark evaluates release-routing behavior over candidate outputs using local deterministic fixtures. It compares baseline release-by-default against SaC-style routing on 50 fixture candidate outputs. It is not live provider/model generation evidence and not a production safety guarantee.
+
+Artifacts:
+
+- `benchmarks/release_risk_v2/README.md`
+- `benchmarks/release_risk_v2/run_release_risk_v2.py`
+- `benchmarks/release_risk_v2/data/release_risk_prompts_50.jsonl`
+- `benchmarks/release_risk_v2/candidates/fixture_candidates_50.jsonl`
+- `benchmarks/release_risk_v2/results/release_risk_v2_summary.json`
+- `benchmarks/release_risk_v2/results/release_risk_v2_summary.csv`
+- `benchmarks/release_risk_v2/results/release_risk_v2_replay.jsonl`
+- `tests/test_release_risk_v2_benchmark.py`
+- `docs/release_risk_v2_benchmark_report.md`
+
+Recorded local run:
+
+- total_cases: 50
+- baseline_unsafe_released: 20
+- sac_unsafe_released: 0
+- unsafe_release_reduction_percent: 100.0
+- safe_proceed_rate: 90.0
+- candidate_source: fixture
+- generation_mode: fixture
+- num_replayed_candidates: 50
+
+Interpretation boundary:
+
+This shows fixture replay release-routing behavior over local candidate outputs. It does not evaluate live model generation quality.
+
+Validation:
+
+Run:
+
+```bash
+python -m pytest tests/test_release_risk_v2_benchmark.py -q
+python -m pytest tests/test_release_risk_benchmark.py -q
+python -m pytest tests/test_api.py -q
+```
+
+Expected:
+
+- 1 passed for v2 benchmark test.
+- 1 passed for v1 benchmark test.
+- 15 passed for API tests.
+
 ## LangChain/OpenAI action-risk Run 06 progression
 
 Run 06 action-risk evidence is an integration/deployment validation surface for release control, not a primitive-core result and not a universal AI safety claim. The strongest supported claim is: same model, same dataset, same threshold, no PoR core change; release-layer hardening changed the review/release profile.

--- a/docs/release_risk_v2_benchmark_report.md
+++ b/docs/release_risk_v2_benchmark_report.md
@@ -1,0 +1,75 @@
+# Release-Risk v2 Benchmark Report
+
+## Scope
+
+This report records the first local fixture-replay run for Release-risk Benchmark v2.
+
+Release-risk v2 evaluates release behavior over candidate outputs. In fixture mode, candidate outputs are deterministic and local, and no provider/API keys are required.
+
+This report is not live model-output generation evidence and not a production safety guarantee.
+
+## Commands
+
+```bash
+python benchmarks/release_risk_v2/run_release_risk_v2.py --mode fixture
+python -m pytest tests/test_release_risk_v2_benchmark.py -q
+python -m pytest tests/test_release_risk_benchmark.py -q
+python -m pytest tests/test_api.py -q
+```
+
+## Results
+
+- total_cases: 50
+- baseline_released: 50
+- baseline_unsafe_released: 20
+- sac_proceed: 9
+- sac_needs_review: 25
+- sac_silence: 16
+- sac_unsafe_released: 0
+- unsafe_release_reduction_percent: 100.0
+- safe_proceed_rate: 90.0
+- candidate_source: fixture
+- generation_mode: fixture
+- num_generation_failures: 0
+- num_empty_candidates: 0
+- num_replayed_candidates: 50
+
+| Metric | Value |
+| --- | ---: |
+| total_cases | 50 |
+| baseline_released | 50 |
+| baseline_unsafe_released | 20 |
+| sac_proceed | 9 |
+| sac_needs_review | 25 |
+| sac_silence | 16 |
+| sac_unsafe_released | 0 |
+| unsafe_release_reduction_percent | 100.0 |
+| safe_proceed_rate | 90.0 |
+| candidate_source | fixture |
+| generation_mode | fixture |
+| num_generation_failures | 0 |
+| num_empty_candidates | 0 |
+| num_replayed_candidates | 50 |
+
+## Test validation
+
+- `tests/test_release_risk_v2_benchmark.py`: 1 passed
+- `tests/test_release_risk_benchmark.py`: 1 passed
+- `tests/test_api.py`: 15 passed
+
+## Interpretation
+
+This run demonstrates that, on the included deterministic fixture candidate-output dataset, baseline release-by-default releases all 50 candidates, including 20 unsafe candidates, while SaC-style routing releases 0 unsafe candidates and routes the rest to PROCEED / NEEDS_REVIEW / SILENCE.
+
+This should be interpreted as fixture replay release-control behavior evidence, not as live provider/model generation safety evidence.
+
+## Artifacts
+
+- [`../benchmarks/release_risk_v2/README.md`](../benchmarks/release_risk_v2/README.md)
+- [`../benchmarks/release_risk_v2/run_release_risk_v2.py`](../benchmarks/release_risk_v2/run_release_risk_v2.py)
+- [`../benchmarks/release_risk_v2/data/release_risk_prompts_50.jsonl`](../benchmarks/release_risk_v2/data/release_risk_prompts_50.jsonl)
+- [`../benchmarks/release_risk_v2/candidates/fixture_candidates_50.jsonl`](../benchmarks/release_risk_v2/candidates/fixture_candidates_50.jsonl)
+- [`../benchmarks/release_risk_v2/results/release_risk_v2_summary.json`](../benchmarks/release_risk_v2/results/release_risk_v2_summary.json)
+- [`../benchmarks/release_risk_v2/results/release_risk_v2_summary.csv`](../benchmarks/release_risk_v2/results/release_risk_v2_summary.csv)
+- [`../benchmarks/release_risk_v2/results/release_risk_v2_replay.jsonl`](../benchmarks/release_risk_v2/results/release_risk_v2_replay.jsonl)
+- [`../tests/test_release_risk_v2_benchmark.py`](../tests/test_release_risk_v2_benchmark.py)


### PR DESCRIPTION
### Motivation

- Record the first local fixture-replay run for the newly added Release-risk Benchmark v2 as conservative evidence and navigation for reviewers. 
- Preserve a clear interpretation boundary that this is deterministic fixture replay evidence only and not live provider/model-generation or production safety evidence. 
- Surface the exact observed metrics and the commands used to reproduce the run for auditability and follow-up.

### Description

- Added `docs/release_risk_v2_benchmark_report.md` containing scope, reproduction `python benchmarks/release_risk_v2/run_release_risk_v2.py --mode fixture` and `pytest` commands, exact recorded metrics, a markdown summary table, interpretation boundary, and artifact links. 
- Updated `docs/README.md` to include a lightweight index entry for the new v2 fixture-replay report. 
- Updated `docs/evidence_map.md` with a conservative `Release-risk v2 fixture replay benchmark` section that lists artifacts, recorded run values, interpretation boundary, and validation expectations. 
- No benchmark or runtime code was changed; this PR is documentation-only and preserves existing logic and artifacts.

### Testing

- Ran `python -m pytest tests/test_release_risk_v2_benchmark.py -q` which returned `1 passed`. 
- Ran `python -m pytest tests/test_release_risk_benchmark.py -q` which returned `1 passed`. 
- Ran `python -m pytest tests/test_api.py -q` which returned `15 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11838785ac8326b70129e320e371ed)