### PR TITLE
docs: record release-risk v3 fixture generation replay run

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - `evidence_map.md` — claim-to-artifact navigation for core/runtime/benchmark surfaces.
 - `release_risk_benchmark_report.md` — first deterministic local release-risk benchmark run report.
 - `release_risk_v2_benchmark_report.md` — first local fixture-replay run report for release-risk benchmark v2.
+- `release_risk_v3_benchmark_report.md` — first local fixture-generation/replay run report for release-risk benchmark v3.
 - [Plain-English pitch](plain_english_pitch.md) — a simple explanation of Silence-as-Control for first-time readers.
 - `langchain_openai_action_risk_benchmark.md` — LangChain/OpenAI action-risk benchmark framing and Run 06 hardened v4 progression.
 - `action_risk_1000_dataset.md` — Run 06 1000-case synthetic dataset scope and schema.

--- a/docs/evidence_map.md
+++ b/docs/evidence_map.md
@@ -160,6 +160,59 @@ Expected:
 - 1 passed for v1 benchmark test.
 - 15 passed for API tests.
 
+## Release-risk v3 fixture generation/replay benchmark
+
+The release-risk v3 fixture generation/replay benchmark validates generated-candidate schema handling, fixture generation, and replay routing over locally generated fixture candidates. It compares baseline release-by-default against SaC-style routing. It is not live provider/model generation evidence and not a production safety guarantee.
+
+Artifacts:
+
+- `benchmarks/release_risk_v3/README.md`
+- `benchmarks/release_risk_v3/generate_candidates_v3.py`
+- `benchmarks/release_risk_v3/run_release_risk_v3.py`
+- `benchmarks/release_risk_v3/data/release_risk_prompts_50.jsonl`
+- `benchmarks/release_risk_v3/candidates/fixture_generated_candidates_50.jsonl`
+- `benchmarks/release_risk_v3/candidates/generated_candidates_fixture.jsonl`
+- `benchmarks/release_risk_v3/results/release_risk_v3_summary.json`
+- `benchmarks/release_risk_v3/results/release_risk_v3_summary.csv`
+- `benchmarks/release_risk_v3/results/release_risk_v3_replay.jsonl`
+- `tests/test_release_risk_v3_benchmark.py`
+- `docs/release_risk_v3_benchmark_report.md`
+
+Recorded local run:
+
+- total_cases: 50
+- baseline_unsafe_released: 25
+- sac_unsafe_released: 0
+- unsafe_release_reduction_percent: 100.0
+- safe_proceed_rate: 90.0
+- candidate_source: fixture
+- generation_mode: fixture
+- provider: null
+- model: fixture-generated-candidates-v1
+- num_replayed_candidates: 50
+
+Interpretation boundary:
+
+This validates deterministic fixture generation/replay routing behavior over locally generated fixture candidates. It does not evaluate live provider/model generation quality.
+
+Validation:
+
+Run:
+
+```bash
+python -m pytest tests/test_release_risk_v3_benchmark.py -q
+python -m pytest tests/test_release_risk_v2_benchmark.py -q
+python -m pytest tests/test_release_risk_benchmark.py -q
+python -m pytest tests/test_api.py -q
+```
+
+Expected:
+
+- v3 benchmark test: 1 passed
+- v2 benchmark test: 1 passed
+- v1 benchmark test: 1 passed
+- API tests: 15 passed
+
 ## LangChain/OpenAI action-risk Run 06 progression
 
 Run 06 action-risk evidence is an integration/deployment validation surface for release control, not a primitive-core result and not a universal AI safety claim. The strongest supported claim is: same model, same dataset, same threshold, no PoR core change; release-layer hardening changed the review/release profile.

--- a/docs/release_risk_v3_benchmark_report.md
+++ b/docs/release_risk_v3_benchmark_report.md
@@ -1,0 +1,102 @@
+# Release-Risk v3 Benchmark Report
+
+## Scope
+
+This report records the first local fixture-generation/replay run for Release-risk Benchmark v3 after PR #232.
+
+Release-risk v3 validates the generated-candidate schema and replay-routing surface for candidate-based release control.
+
+Fixture generation mode is deterministic and local.
+
+Provider/local generation remains placeholder-only in this benchmark scaffold.
+
+No provider or API keys are required for this fixture generation/replay path.
+
+This is not live provider/model generation evidence.
+
+This is not a production safety guarantee.
+
+## Commands
+
+```bash
+python benchmarks/release_risk_v3/generate_candidates_v3.py --mode fixture
+python benchmarks/release_risk_v3/run_release_risk_v3.py --mode fixture
+
+python -m pytest tests/test_release_risk_v3_benchmark.py -q
+python -m pytest tests/test_release_risk_v2_benchmark.py -q
+python -m pytest tests/test_release_risk_benchmark.py -q
+python -m pytest tests/test_api.py -q
+```
+
+## Candidate generation output
+
+```text
+Wrote fixture-generated candidates to:
+benchmarks/release_risk_v3/candidates/generated_candidates_fixture.jsonl
+```
+
+## Results
+
+```text
+total_cases: 50
+baseline_released: 50
+baseline_unsafe_released: 25
+sac_proceed: 9
+sac_needs_review: 18
+sac_silence: 23
+sac_unsafe_released: 0
+unsafe_release_reduction_percent: 100.0
+safe_proceed_rate: 90.0
+candidate_source: fixture
+generation_mode: fixture
+provider: null
+model: fixture-generated-candidates-v1
+num_generation_failures: 0
+num_empty_candidates: 0
+num_replayed_candidates: 50
+```
+
+| Metric | Value |
+| --- | ---: |
+| total_cases | 50 |
+| baseline_released | 50 |
+| baseline_unsafe_released | 25 |
+| sac_proceed | 9 |
+| sac_needs_review | 18 |
+| sac_silence | 23 |
+| sac_unsafe_released | 0 |
+| unsafe_release_reduction_percent | 100.0 |
+| safe_proceed_rate | 90.0 |
+| candidate_source | fixture |
+| generation_mode | fixture |
+| provider | null |
+| model | fixture-generated-candidates-v1 |
+| num_generation_failures | 0 |
+| num_empty_candidates | 0 |
+| num_replayed_candidates | 50 |
+
+## Test validation
+
+- `tests/test_release_risk_v3_benchmark.py`: 1 passed
+- `tests/test_release_risk_v2_benchmark.py`: 1 passed
+- `tests/test_release_risk_benchmark.py`: 1 passed
+- `tests/test_api.py`: 15 passed
+
+## Interpretation
+
+This run demonstrates fixture-generation/replay release-routing behavior over locally generated fixture candidates. Baseline release-by-default releases all replayed candidates, including 25 unsafe candidates, while SaC-style routing releases 0 unsafe candidates and routes the rest to PROCEED / NEEDS_REVIEW / SILENCE.
+
+This should be interpreted as deterministic fixture generation/replay evidence, not as live provider/model generation evidence.
+
+## Artifacts
+
+- [`../benchmarks/release_risk_v3/README.md`](../benchmarks/release_risk_v3/README.md)
+- [`../benchmarks/release_risk_v3/generate_candidates_v3.py`](../benchmarks/release_risk_v3/generate_candidates_v3.py)
+- [`../benchmarks/release_risk_v3/run_release_risk_v3.py`](../benchmarks/release_risk_v3/run_release_risk_v3.py)
+- [`../benchmarks/release_risk_v3/data/release_risk_prompts_50.jsonl`](../benchmarks/release_risk_v3/data/release_risk_prompts_50.jsonl)
+- [`../benchmarks/release_risk_v3/candidates/fixture_generated_candidates_50.jsonl`](../benchmarks/release_risk_v3/candidates/fixture_generated_candidates_50.jsonl)
+- [`../benchmarks/release_risk_v3/candidates/generated_candidates_fixture.jsonl`](../benchmarks/release_risk_v3/candidates/generated_candidates_fixture.jsonl)
+- [`../benchmarks/release_risk_v3/results/release_risk_v3_summary.json`](../benchmarks/release_risk_v3/results/release_risk_v3_summary.json)
+- [`../benchmarks/release_risk_v3/results/release_risk_v3_summary.csv`](../benchmarks/release_risk_v3/results/release_risk_v3_summary.csv)
+- [`../benchmarks/release_risk_v3/results/release_risk_v3_replay.jsonl`](../benchmarks/release_risk_v3/results/release_risk_v3_replay.jsonl)
+- [`../tests/test_release_risk_v3_benchmark.py`](../tests/test_release_risk_v3_benchmark.py)


### PR DESCRIPTION
### Motivation

- Record a conservative, auditable report for the first local fixture-generation/replay run of the Release-risk v3 benchmark to capture schema/replay validation evidence. 
- Validate and document the deterministic fixture generation path and replay-routing surface added by the v3 scaffold while preserving interpretation boundaries (not provider-backed or production safety evidence). 

### Description

- Added `docs/release_risk_v3_benchmark_report.md` containing scope, exact commands to reproduce, candidate-generation output, full metrics block and markdown table, test validation results, interpretation boundaries, and artifact links. 
- Updated `docs/README.md` to include an index entry for the new v3 benchmark report and updated `docs/evidence_map.md` to add a conservative "Release-risk v3 fixture generation/replay benchmark" section that maps artifacts and records the observed run metrics. 
- Changes are documentation-only and do not modify benchmark logic, test code, or result artifacts; affected files are `docs/release_risk_v3_benchmark_report.md`, `docs/README.md`, and `docs/evidence_map.md`. 

### Testing

- Ran `python -m pytest tests/test_release_risk_v3_benchmark.py -q`, which passed (`1 passed`).
- Ran `python -m pytest tests/test_release_risk_v2_benchmark.py -q` and `python -m pytest tests/test_release_risk_benchmark.py -q`, which each passed (`1 passed`).
- Ran `python -m pytest tests/test_api.py -q`, which passed (`15 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a118d57937c832691ac0aa340de7945)