### PR TITLE
Docs: add release-risk benchmark index and clarify benchmark reports/metrics

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - `provider_configuration.md` — no-key vs provider-backed runtime configuration.
 - `threshold_regime_contract.md` — scoped threshold interpretation contract for SimpleQA/Ollama evidence.
 - `evidence_map.md` — claim-to-artifact navigation for core/runtime/benchmark surfaces.
+- `release_risk_benchmark_index.md` — recommended entry point for v1/v2/v3 release-risk benchmark evidence, artifact lineage, commands, and interpretation boundaries.
 - `release_risk_benchmark_report.md` — first deterministic local release-risk benchmark run report.
 - `release_risk_v2_benchmark_report.md` — first local fixture-replay run report for release-risk benchmark v2.
 - `release_risk_v3_benchmark_report.md` — first local fixture-generation/replay run report for release-risk benchmark v3.

--- a/docs/evidence_map.md
+++ b/docs/evidence_map.md
@@ -73,9 +73,12 @@ Treat these directories as the primary source for PR #131 / #132 run summaries.
 
 
 
-## Deterministic release-risk benchmark
+## Release-risk v1 deterministic benchmark
 
-The release-risk benchmark is a local deterministic release-control behavior check. It compares baseline release-by-default against SaC-style routing on 50 handcrafted release-risk cases. It is not a live model-output benchmark and not a production safety guarantee.
+Scope:
+
+- Local deterministic release-control behavior check over 50 handcrafted release-risk cases.
+- Baseline release-by-default versus SaC-style routing (`PROCEED` / `NEEDS_REVIEW` / `SILENCE`).
 
 Artifacts:
 
@@ -97,25 +100,23 @@ Recorded local run:
 
 Interpretation boundary:
 
-This shows deterministic release-routing behavior on the included dataset. It does not evaluate live model generation quality.
+- Deterministic local release-routing evidence over included handcrafted cases.
+- Not live provider/model generation evidence.
+- Not production safety evidence.
 
 Validation:
-
-Run:
 
 ```bash
 python -m pytest tests/test_release_risk_benchmark.py -q
 python -m pytest tests/test_api.py -q
 ```
 
-Expected:
-
-- 1 passed for release-risk benchmark test.
-- 15 passed for API tests.
-
 ## Release-risk v2 fixture replay benchmark
 
-The release-risk v2 fixture replay benchmark evaluates release-routing behavior over candidate outputs using local deterministic fixtures. It compares baseline release-by-default against SaC-style routing on 50 fixture candidate outputs. It is not live provider/model generation evidence and not a production safety guarantee.
+Scope:
+
+- Local deterministic fixture candidate-output replay over 50 prompts/candidates.
+- Baseline release-by-default versus SaC-style routing.
 
 Artifacts:
 
@@ -142,11 +143,11 @@ Recorded local run:
 
 Interpretation boundary:
 
-This shows fixture replay release-routing behavior over local candidate outputs. It does not evaluate live model generation quality.
+- Deterministic fixture replay release-routing evidence.
+- Not live provider/model generation evidence.
+- Not production safety evidence.
 
 Validation:
-
-Run:
 
 ```bash
 python -m pytest tests/test_release_risk_v2_benchmark.py -q
@@ -154,15 +155,13 @@ python -m pytest tests/test_release_risk_benchmark.py -q
 python -m pytest tests/test_api.py -q
 ```
 
-Expected:
-
-- 1 passed for v2 benchmark test.
-- 1 passed for v1 benchmark test.
-- 15 passed for API tests.
-
 ## Release-risk v3 fixture generation/replay benchmark
 
-The release-risk v3 fixture generation/replay benchmark validates generated-candidate schema handling, fixture generation, and replay routing over locally generated fixture candidates. It compares baseline release-by-default against SaC-style routing. It is not live provider/model generation evidence and not a production safety guarantee.
+Scope:
+
+- Generated-candidate schema validation.
+- Fixture generation path and replay routing validation.
+- Provider/local mode separation at interface level, while using fixture evidence.
 
 Artifacts:
 
@@ -181,7 +180,11 @@ Artifacts:
 Recorded local run:
 
 - total_cases: 50
+- baseline_released: 50
 - baseline_unsafe_released: 25
+- sac_proceed: 9
+- sac_needs_review: 22
+- sac_silence: 19
 - sac_unsafe_released: 0
 - unsafe_release_reduction_percent: 100.0
 - safe_proceed_rate: 90.0
@@ -189,15 +192,18 @@ Recorded local run:
 - generation_mode: fixture
 - provider: null
 - model: fixture-generated-candidates-v1
+- num_generation_failures: 0
+- num_empty_candidates: 0
 - num_replayed_candidates: 50
 
 Interpretation boundary:
 
-This validates deterministic fixture generation/replay routing behavior over locally generated fixture candidates. It does not evaluate live provider/model generation quality.
+- Deterministic fixture generation/replay release-routing evidence.
+- Not live provider/model generation evidence.
+- No API keys required for fixture mode.
+- Not production safety evidence.
 
 Validation:
-
-Run:
 
 ```bash
 python -m pytest tests/test_release_risk_v3_benchmark.py -q
@@ -205,13 +211,6 @@ python -m pytest tests/test_release_risk_v2_benchmark.py -q
 python -m pytest tests/test_release_risk_benchmark.py -q
 python -m pytest tests/test_api.py -q
 ```
-
-Expected:
-
-- v3 benchmark test: 1 passed
-- v2 benchmark test: 1 passed
-- v1 benchmark test: 1 passed
-- API tests: 15 passed
 
 ## LangChain/OpenAI action-risk Run 06 progression
 

--- a/docs/release_risk_benchmark_index.md
+++ b/docs/release_risk_benchmark_index.md
@@ -1,0 +1,217 @@
+# Release-Risk Benchmark Index
+
+## Purpose
+
+This page is the recommended entry point for the release-risk benchmark evidence chain across v1, v2, and v3.
+
+Core thesis:
+
+**generation capability != release authority**
+
+These benchmarks measure release-control behavior, not model intelligence.
+
+- Baseline route: `candidate -> RELEASE`
+- SaC-style route: `candidate -> release gate -> PROCEED / NEEDS_REVIEW / SILENCE`
+
+For project identity and framing, see project memory/tracking surfaces in `docs/evidence_map.md`, `docs/roadmap_2026.md`, and issue tracking referenced there.
+
+## Benchmark progression
+
+- **v1** -> deterministic handcrafted release-risk routing
+- **v2** -> fixture candidate-output replay
+- **v3** -> fixture generation/replay scaffold
+- **v4** -> future provider/local generated-candidate capture + replay (**not yet implemented**)
+
+## v1: deterministic release-risk benchmark
+
+**Scope**
+
+- Deterministic local evidence over handcrafted release-risk cases.
+- Baseline release-by-default versus SaC-style routing behavior.
+
+**Main artifacts**
+
+- `benchmarks/release_risk/README.md`
+- `benchmarks/release_risk/run_release_risk.py`
+- `benchmarks/release_risk/data/release_risk_50.jsonl`
+- `benchmarks/release_risk/results/release_risk_summary.json`
+- `benchmarks/release_risk/results/release_risk_summary.csv`
+- `tests/test_release_risk_benchmark.py`
+
+**Report**
+
+- `docs/release_risk_benchmark_report.md`
+
+**Commands**
+
+```bash
+python benchmarks/release_risk/run_release_risk.py
+python -m pytest tests/test_release_risk_benchmark.py -q
+```
+
+**Interpretation boundary**
+
+- Deterministic local benchmark evidence only.
+- Not live model-output generation evidence.
+- Not production safety evidence.
+
+## v2: fixture candidate-output replay benchmark
+
+**Scope**
+
+- Release-routing behavior over fixture candidate outputs.
+- Baseline release-by-default versus SaC-style routing behavior.
+
+**Main artifacts**
+
+- `benchmarks/release_risk_v2/README.md`
+- `benchmarks/release_risk_v2/run_release_risk_v2.py`
+- `benchmarks/release_risk_v2/data/release_risk_prompts_50.jsonl`
+- `benchmarks/release_risk_v2/candidates/fixture_candidates_50.jsonl`
+- `benchmarks/release_risk_v2/results/release_risk_v2_summary.json`
+- `benchmarks/release_risk_v2/results/release_risk_v2_summary.csv`
+- `benchmarks/release_risk_v2/results/release_risk_v2_replay.jsonl`
+- `tests/test_release_risk_v2_benchmark.py`
+
+**Report**
+
+- `docs/release_risk_v2_benchmark_report.md`
+
+**Commands**
+
+```bash
+python benchmarks/release_risk_v2/run_release_risk_v2.py --mode fixture
+python -m pytest tests/test_release_risk_v2_benchmark.py -q
+```
+
+**Interpretation boundary**
+
+- Deterministic fixture replay evidence only.
+- Not live provider/model generation evidence.
+- Not production safety evidence.
+
+## v3: fixture generation/replay scaffold
+
+**Scope**
+
+- Validates generated-candidate schema.
+- Validates fixture generation path.
+- Validates replay routing surface.
+- Validates provider/local mode separation in benchmark interfaces.
+
+**Main artifacts**
+
+- `benchmarks/release_risk_v3/README.md`
+- `benchmarks/release_risk_v3/generate_candidates_v3.py`
+- `benchmarks/release_risk_v3/run_release_risk_v3.py`
+- `benchmarks/release_risk_v3/data/release_risk_prompts_50.jsonl`
+- `benchmarks/release_risk_v3/candidates/fixture_generated_candidates_50.jsonl`
+- `benchmarks/release_risk_v3/candidates/generated_candidates_fixture.jsonl`
+- `benchmarks/release_risk_v3/results/release_risk_v3_summary.json`
+- `benchmarks/release_risk_v3/results/release_risk_v3_summary.csv`
+- `benchmarks/release_risk_v3/results/release_risk_v3_replay.jsonl`
+- `tests/test_release_risk_v3_benchmark.py`
+
+**Report**
+
+- `docs/release_risk_v3_benchmark_report.md`
+
+**Current recorded summary (from committed artifact)**
+
+- total_cases: 50
+- baseline_released: 50
+- baseline_unsafe_released: 25
+- sac_proceed: 9
+- sac_needs_review: 22
+- sac_silence: 19
+- sac_unsafe_released: 0
+- unsafe_release_reduction_percent: 100.0
+- safe_proceed_rate: 90.0
+- candidate_source: fixture
+- generation_mode: fixture
+- provider: null
+- model: fixture-generated-candidates-v1
+- num_generation_failures: 0
+- num_empty_candidates: 0
+- num_replayed_candidates: 50
+
+**Commands**
+
+```bash
+python benchmarks/release_risk_v3/generate_candidates_v3.py --mode fixture
+python benchmarks/release_risk_v3/run_release_risk_v3.py --mode fixture
+python -m pytest tests/test_release_risk_v3_benchmark.py -q
+```
+
+**Interpretation boundary**
+
+- Deterministic fixture generation/replay evidence only.
+- This is not live provider/model generation evidence.
+- Provider/local generation capture remains future work.
+- No API keys are required for fixture mode.
+- Not production safety evidence.
+
+## Artifact lineage
+
+- `#224 -> #225 -> #226`: v1 deterministic benchmark
+- `#227 -> #228 -> #229 -> #230`: v2 fixture replay benchmark
+- `#231 -> #232 -> #233 -> #234 -> #235`: v3 fixture generation/replay benchmark
+
+## Common interpretation boundaries
+
+These benchmarks do **not** claim:
+
+- production safety;
+- exploit prevention;
+- universal AI safety;
+- alignment solution;
+- model correctness;
+- model improvement;
+- hallucination elimination;
+- live provider/model generation evidence for v1/v2/v3;
+- threshold generalization across all models/tasks.
+
+Supported interpretation:
+
+- baseline releases candidates by default;
+- SaC-style routing changes release behavior;
+- unsafe candidate releases are reduced in these scoped deterministic/fixture benchmark settings;
+- generation remains separate from release authority.
+
+## Reproduction commands
+
+**v1**
+
+```bash
+python benchmarks/release_risk/run_release_risk.py
+python -m pytest tests/test_release_risk_benchmark.py -q
+```
+
+**v2**
+
+```bash
+python benchmarks/release_risk_v2/run_release_risk_v2.py --mode fixture
+python -m pytest tests/test_release_risk_v2_benchmark.py -q
+```
+
+**v3**
+
+```bash
+python benchmarks/release_risk_v3/generate_candidates_v3.py --mode fixture
+python benchmarks/release_risk_v3/run_release_risk_v3.py --mode fixture
+python -m pytest tests/test_release_risk_v3_benchmark.py -q
+```
+
+**Shared**
+
+```bash
+python -m pytest tests/test_api.py -q
+```
+
+## Next step
+
+The next benchmark step is **v4 provider/local generated-candidate capture + replay**.
+
+Do not start v4 until v1/v2/v3 benchmark navigation and evidence architecture are coherent.
+
+v4 should remain optional-provider, fixture-fallback, secret-safe, and conservative in claims.

--- a/docs/release_risk_v3_benchmark_report.md
+++ b/docs/release_risk_v3_benchmark_report.md
@@ -42,8 +42,8 @@ total_cases: 50
 baseline_released: 50
 baseline_unsafe_released: 25
 sac_proceed: 9
-sac_needs_review: 18
-sac_silence: 23
+sac_needs_review: 22
+sac_silence: 19
 sac_unsafe_released: 0
 unsafe_release_reduction_percent: 100.0
 safe_proceed_rate: 90.0
@@ -62,8 +62,8 @@ num_replayed_candidates: 50
 | baseline_released | 50 |
 | baseline_unsafe_released | 25 |
 | sac_proceed | 9 |
-| sac_needs_review | 18 |
-| sac_silence | 23 |
+| sac_needs_review | 22 |
+| sac_silence | 19 |
 | sac_unsafe_released | 0 |
 | unsafe_release_reduction_percent | 100.0 |
 | safe_proceed_rate | 90.0 |


### PR DESCRIPTION
### Motivation

- Provide a single recommended entry point that consolidates v1/v2/v3 release-risk benchmark guidance and reproduction commands. 
- Clarify interpretation boundaries so readers understand these are deterministic/fixture release-routing checks and not live model safety guarantees. 
- Fix and align reported v3 metrics in the report to match committed artifact summaries.

### Description

- Add `docs/release_risk_benchmark_index.md` as a canonical index describing scope, artifacts, commands, and interpretation boundaries for v1, v2, and v3 benchmarks. 
- Update `docs/README.md` to link to the new `release_risk_benchmark_index.md` entry. 
- Revise `docs/evidence_map.md` to rename and restructure the release-risk sections with clearer scope, artifacts, interpretation boundaries, and validation commands. 
- Correct summary metrics in `docs/release_risk_v3_benchmark_report.md` by adjusting `sac_needs_review` from 18 to 22 and `sac_silence` from 23 to 19 and update the tabular and textual report outputs accordingly.

### Testing

- Ran `pytest tests/test_release_risk_v3_benchmark.py` and it passed (1 passed). 
- Ran `pytest tests/test_release_risk_v2_benchmark.py` and it passed (1 passed). 
- Ran `pytest tests/test_release_risk_benchmark.py` and it passed (1 passed). 
- Ran `pytest tests/test_api.py` and it passed (15 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11c5032334832687d8ade9870bf765)