### PR TITLE
docs: document external gate and clean README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ It does **not** improve model weights. It controls release behavior.
 - [Runtime governance visual map](docs/runtime_governance_visual_map.md) — visual-oriented governance architecture reference.
 - [First-run checklist](docs/first_run_checklist.md) — verify the no-key local path.
 - [Evidence map](docs/evidence_map.md) — connect claims to artifacts.
+- [External integration CLI](docs/external_integration.md) — call the three-state release gate from an external generator.
 - [Reverse integration sandbox](docs/reverse_integration_sandbox.md) — controlled intake/evaluation concept.
 - [Sandbox channel adapters](docs/sandbox_channel_adapters.md) — conceptual intake connectors for sandbox evaluation flows.
 - [Deterministic replay architecture](docs/deterministic_replay_architecture.md) — conceptual replay and inspection layer for sandbox evaluation flows.
@@ -39,6 +40,12 @@ New users should start with the no-key path:
 
 The deterministic path does not require provider credentials.
 Provider-backed `/por/complete` may require `XAI_API_KEY` when generating candidate output.
+
+For an external JSON/CLI integration path, see `docs/external_integration.md` and run:
+
+```bash
+python scripts/por_gate_cli.py --input examples/por_gate_input.json
+```
 
 
 ## Installation and dependency setup
@@ -230,8 +237,8 @@ PoR uses:
 - instability score: `I = (drift + (1 - coherence)) / 2`.
 
 Core fixed-threshold release rule:
-- `I <= П„` -> `PROCEED`
-- `I > П„` -> `SILENCE`
+- `I <= threshold` -> `PROCEED`
+- `I > threshold` -> `SILENCE`
 
 ## Architecture split
 ### 1) Core Primitive (thesis-level)
@@ -274,8 +281,8 @@ evidence protocol. Calibrate thresholds before using them with a new model, a ne
 task family, or a new signal source.
 
 The deterministic core rule remains:
-- `I <= П„` -> `PROCEED`
-- `I > П„` -> `SILENCE`
+- `I <= threshold` -> `PROCEED`
+- `I > threshold` -> `SILENCE`
 
 Some integrations may layer a separate `NEEDS_REVIEW` lane. Do not collapse an
 existing tri-state integration into binary behavior unless that integration

--- a/docs/external_integration.md
+++ b/docs/external_integration.md
@@ -1,57 +1,76 @@
-# External PoR gate integration (minimal CLI)
+# External integration CLI
 
-This interface is a **release-control integration point**, not a generation-improvement mechanism.
-It evaluates a candidate answer against the existing PoR gate logic and returns a release decision.
+## Purpose
 
-The first CLI version supports mode `v1` only. v2-family modes require additional external signals and will be added after the external contract is stable.
+Silence-as-Control can be called after an external system generates a candidate output.
+The external generator remains unchanged.
+The gate decides whether the candidate should be released.
 
-## CLI usage
+## Command
 
 ```bash
-python scripts/por_gate_cli.py \
-  --input examples/por_gate_input.json \
-  --output /tmp/por_gate_output.json
+python scripts/por_gate_cli.py --input examples/por_gate_input.json --output outputs/por_gate_decision.json
 ```
 
-Optional overrides:
+## Stdout mode
 
-- `--threshold 0.39` (overrides JSON threshold)
-- `--mode v1` (overrides JSON mode)
+```bash
+python scripts/por_gate_cli.py --input examples/por_gate_input.json
+```
 
-## Required input fields
+## Input fields
 
-Input JSON must include:
+- `prompt`
+- `candidate_answer`
+- optional `candidate_samples`
+- optional `threshold`
+- optional `mode`
+- optional `metadata`
 
-- `prompt` (string)
-- `candidate_answer` (string)
+## Output fields
 
-`candidate_samples` is recommended for drift estimation; if missing or empty, the CLI safely falls back to `[candidate_answer]`.
-
-## Optional metadata
-
-`metadata` is optional and audit-facing. Common fields include:
-
-- `model`
-- `source`
-- generation settings like `temperature`, `top_p`, `top_k`
-
-Only `model` and `source` are forwarded into the output audit block by this minimal interface.
+- `decision`
+- `released_output`
+- `silence`
+- `needs_review`
+- `threshold`
+- `mode`
+- `signals.drift`
+- `signals.coherence`
+- `signals.instability`
+- `signals.review_flags`
+- `audit.reason`
+- `audit.core_decision`
+- `audit.policy_decision`
+- `audit.model`
+- `audit.source`
 
 ## Decision semantics
 
-- `PROCEED`: candidate is releasable under the configured threshold.
-- `SILENCE`: candidate is withheld by release control.
+- `PROCEED`:
+  Candidate is released.
+- `NEEDS_REVIEW`:
+  Candidate is stable enough at the PoR core layer, but release-policy flags require review.
+- `SILENCE`:
+  Candidate exceeded instability threshold and is not released.
 
-Output includes:
+## Architecture boundary
 
-- `decision`
-- `released_output` (string for `PROCEED`, `null` for `SILENCE`)
-- `silence` boolean
-- `signals` (`drift`, `coherence`, `instability`)
-- `audit` metadata
+- PoR core primitive:
+  `PROCEED` / `SILENCE`
+- Release policy layer:
+  `PROCEED` / `NEEDS_REVIEW` / `SILENCE`
 
-## Threshold and scope
+## Claims boundary
 
-Thresholds are **scoped configuration values** and should be calibrated per model/dataset/pipeline/mode.
+- This is not a new model.
+- This is not a training method.
+- This is not a universal truth detector.
+- This does not guarantee safety.
+- It is a scoped post-generation release-control interface.
 
-This interface does **not** make universal safety claims.
+## Relation to por-copilot-bridge
+
+`por-copilot-bridge` is an applied bridge for coding-agent outputs.
+It is compatible by state/schema and architecture.
+It is not a direct dependency of silence-as-control.

--- a/tests/test_por_gate_cli.py
+++ b/tests/test_por_gate_cli.py
@@ -99,8 +99,6 @@ def test_invalid_candidate_samples_fails_cleanly(tmp_path):
     assert "candidate_samples" in res.stderr
 
 
-
-
 def test_non_string_candidate_samples_items_fail_cleanly(tmp_path):
     path = tmp_path / "input.json"
     payload = {"prompt": "p", "candidate_answer": "a", "candidate_samples": ["ok", 7]}


### PR DESCRIPTION
### Motivation
- Make the new external JSON/CLI integration path discoverable and readable so downstream integrators can call the three-state release gate. 
- Remove a broken threshold symbol that causes rendering/encoding confusion and clarify README pointers to the external CLI. 
- Small style cleanup in tests to remove excessive blank lines while preserving test semantics.

### Description
- Added `docs/external_integration.md` that documents the external CLI purpose, commands, input/output schema, decision semantics, architecture and claims boundaries, and relation to `por-copilot-bridge`.
- Updated `README.md` to add a link in the Fast orientation, add a Start-here pointer with the example CLI invocation, and replaced all occurrences of the broken symbol with `threshold` in the core-rule sections.
- Tidied `tests/test_por_gate_cli.py` by removing excessive blank lines before `test_non_string_candidate_samples_items_fail_cleanly` without changing test behavior. 
- Files changed: `docs/external_integration.md`, `README.md`, and `tests/test_por_gate_cli.py`; no runtime logic, benchmark artifacts, provider calls, or #238 implementation were introduced.

### Testing
- Ran `python -m pytest tests/test_por_gate_cli.py -q` and received `11 passed`.
- Ran `python -m pytest tests/test_release_policy.py -q` and received `4 passed`.
- Ran `python -m pytest tests/test_api.py -q` and received `15 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11d7d5f2388326baabed86dfa3c101)