### PR TITLE
docs: activate venv before pip install in direct reproduction guide

### DIFF
--- a/docs/direct_reproduction_guide.md
+++ b/docs/direct_reproduction_guide.md
@@ -38,23 +38,24 @@ Windows note: if pytest temp-folder permissions or file locks cause failures, us
 
 ## 3. Fresh checkout setup
 
-```bash
+Windows PowerShell:
+
+```powershell
 python -m venv .venv
+.venv\Scripts\activate
 python -m pip install --upgrade pip
 python -m pip install -r requirements.txt
 python -m pip install -e .
 ```
 
-Windows PowerShell activation hint:
-
-```powershell
-.venv\Scripts\activate
-```
-
-Bash/macOS/Linux activation hint:
+Bash/macOS/Linux:
 
 ```bash
+python -m venv .venv
 source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+python -m pip install -e .
 ```
 
 ## 4. Run the canonical deterministic demo


### PR DESCRIPTION
### Motivation
- Prevent accidental installation of dependencies into the global Python environment by activating the virtual environment immediately after creation and making platform-specific steps explicit.

### Description
- Update `docs/direct_reproduction_guide.md` to split the "Fresh checkout setup" into Windows PowerShell and Bash/macOS/Linux blocks and move the `.venv` activation (`.venv\Scripts\activate` / `source .venv/bin/activate`) directly after `python -m venv .venv`, with no runtime/test/benchmark/provider logic changes.

### Testing
- Ran `git diff --check` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11ea85af1c83269521835fe5e55887)