### PR TITLE
docs: add pilot evaluation packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It does **not** improve model weights. It controls release behavior.
 
 - [Plain-English pitch](docs/plain_english_pitch.md) — understand the idea simply.
 - [External reviewer packet](docs/external_reviewer_packet.md) — 5-10 minute technical overview for reviewers and builders.
+- [Pilot evaluation packet](docs/pilot_evaluation_packet.md) — bounded protocol for evaluating release-control behavior in a pilot.
 - [Project navigation map](docs/project_navigation.md) — choose the right entry point.
 - [Runtime governance stack](docs/runtime_governance_stack.md) — canonical map of sandbox and release-control governance layers.
 - [Governance stack walkthrough](docs/governance_stack_walkthrough.md) — guided architecture walkthrough of governance layers.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - `release_risk_v3_benchmark_report.md` — first local fixture-generation/replay run report for release-risk benchmark v3.
 - [Plain-English pitch](plain_english_pitch.md) — a simple explanation of Silence-as-Control for first-time readers.
 - [External reviewer packet](external_reviewer_packet.md) — 5-10 minute technical overview for reviewers and builders.
+- [Pilot evaluation packet](pilot_evaluation_packet.md) — bounded protocol for evaluating release-control behavior in a pilot.
 - [Builder integration guide](builder_integration_guide.md) — where to place the release gate in an app, agent, RAG, or coding workflow.
 - `langchain_openai_action_risk_benchmark.md` — LangChain/OpenAI action-risk benchmark framing and Run 06 hardened v4 progression.
 - `action_risk_1000_dataset.md` — Run 06 1000-case synthetic dataset scope and schema.

--- a/docs/pilot_evaluation_packet.md
+++ b/docs/pilot_evaluation_packet.md
@@ -1,0 +1,127 @@
+# Pilot evaluation packet
+
+**Pilot thesis:** Generation creates a candidate. Release is a separate runtime decision. A pilot evaluates release behavior, not model intelligence.
+
+This packet is for bounded evaluation of Silence-as-Control (SaC) / Proof-of-Resonance (PoR) release behavior. It is intentionally conservative and evidence-first.
+
+Core framing:
+- Generation creates a candidate.
+- Release is a separate runtime decision.
+- Same model. Different decision.
+- Either correct, or silent.
+
+## Who this pilot is for
+
+Suitable pilot scopes:
+- coding-agent output review
+- config/deployment recommendations
+- internal RAG/copilot answers
+- workflow/action candidates
+- agent plans before execution
+
+Not suitable for first pilots:
+- autonomous medical/legal/financial decisioning
+- high-stakes production release without human review
+- broad claims of hallucination elimination
+- production safety claims without deployment evidence
+
+## Minimal pilot flow
+
+```text
+existing generator
+-> candidate output
+-> SaC / PoR release gate
+-> PROCEED / NEEDS_REVIEW / SILENCE
+-> evaluator logs decision and outcome
+```
+
+## What to measure
+
+Track pilot-level metrics (not only anecdotal examples):
+- total candidates
+- accepted outputs
+- accepted wrong / unsafe outputs
+- NEEDS_REVIEW rate
+- SILENCE rate
+- false accept examples
+- false silence examples
+- reviewer burden
+- task categories where the gate helps
+- task categories where the gate hurts
+
+## Data/evidence to preserve
+
+For each evaluated case, preserve a compact audit record with:
+- prompt/task
+- candidate output
+- candidate samples if available
+- model/source
+- threshold/mode
+- decision
+- core_decision
+- policy_decision
+- review_flags
+- evaluator/human label if available
+- notes on whether release would have been harmful, wrong, low-confidence, or merely policy-sensitive
+
+## Suggested pilot sizes
+
+Practical starting points (not universal requirements):
+- 25-50 tasks for first qualitative review
+- 100-300 tasks for early quantitative review
+- 1000+ only after taxonomy, labels, and review rules are stable
+
+These ranges are meant to reduce over-claiming and encourage stable evaluation design before scaling volume.
+
+## Success criteria examples
+
+Treat success as scoped release-behavior improvement, for example:
+- fewer unsafe accepted outputs than baseline release-by-default
+- useful separation between PROCEED / NEEDS_REVIEW / SILENCE
+- actionable audit trail
+- clearer review routing
+- identifiable task categories where the gate is useful
+
+## Failure criteria examples
+
+A pilot should be treated as unsuccessful or inconclusive when you observe:
+- too many false accepts
+- too many false silences
+- unclear reviewer burden
+- weak task taxonomy
+- missing labels/evidence
+- threshold not calibrated for the pilot context
+- NEEDS_REVIEW becoming a dumping ground without clear review policy
+
+## Suggested evaluation table
+
+Use a lightweight table template for consistent case logging:
+
+| task_id | task_type | model/source | candidate_summary | gate_decision | review_flags | evaluator_label | release_outcome_note |
+|---|---|---|---|---|---|---|---|
+| T-001 |  |  |  | PROCEED / NEEDS_REVIEW / SILENCE |  |  |  |
+| T-002 |  |  |  | PROCEED / NEEDS_REVIEW / SILENCE |  |  |  |
+
+## Boundaries / non-claims
+
+This packet is explicitly:
+- not a production safety guarantee
+- not model training
+- not a universal hallucination detector
+- not proof of correctness
+- not a replacement for human review in high-risk workflows
+- not implementation of #238
+
+Additional boundary condition:
+- thresholds are scoped and must be calibrated per task/model/signal regime
+
+## Suggested reading order
+
+1. [Repository README](../README.md)
+2. [External reviewer packet](external_reviewer_packet.md)
+3. [Direct reproduction guide](direct_reproduction_guide.md)
+4. [Builder integration guide](builder_integration_guide.md)
+5. [External integration CLI](external_integration.md)
+6. [Evidence map](evidence_map.md)
+7. [Release-control services](release_control_services.md)
+8. [Release-risk benchmark index](release_risk_benchmark_index.md)


### PR DESCRIPTION
### Motivation
- Provide a concise, conservative, evidence-first pilot packet (issue #245) to help external evaluators test Silence-as-Control / PoR release behavior in a bounded pilot without over-claiming production safety.
- Bridge the gap between builder/reviewer understanding and full pilot evaluation by focusing on release decisions (not model intelligence) and practical audit/metrics guidance.

### Description
- Added `docs/pilot_evaluation_packet.md` containing the required pilot thesis, suitable/not-suitable scopes, minimal flow, pilot metrics, audit fields, conservative pilot sizes, success/failure criteria, an evaluation table template, boundaries/non-claims, and a suggested reading order.
- Updated `README.md` Fast orientation to include a link to the new Pilot evaluation packet and updated `docs/README.md` docs index to reference the new packet.
- Changes are documentation-only and preserve the core thesis: generation produces a candidate and release is a separate runtime decision (same model, different decision; either correct, or silent).
- No runtime logic, test, benchmark, provider, pricing, or production-safety claim changes were made and this does not implement issue #238.

### Testing
- Ran `git diff --check` (passed) and committed the documentation changes to the current branch.
- The focused pytest smoke set `python -m pytest tests/test_por_gate_cli.py tests/test_release_policy.py tests/test_api.py -q` was not run because this is a docs-only change (command is available if maintainers wish to run it).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11f16d38308326be16d3814a2ec8e0)