### PR TITLE
docs: group README fast orientation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,33 @@ It does **not** improve model weights. It controls release behavior.
 
 ## Fast orientation
 
+### Start
+
 - [Plain-English pitch](docs/plain_english_pitch.md) — understand the idea simply.
 - [External reviewer packet](docs/external_reviewer_packet.md) — 5-10 minute technical overview for reviewers and builders.
-- [Pilot evaluation packet](docs/pilot_evaluation_packet.md) — bounded protocol for evaluating release-control behavior in a pilot.
 - [Project navigation map](docs/project_navigation.md) — choose the right entry point.
-- [Runtime governance stack](docs/runtime_governance_stack.md) — canonical map of sandbox and release-control governance layers.
-- [Governance stack walkthrough](docs/governance_stack_walkthrough.md) — guided architecture walkthrough of governance layers.
-- [Runtime governance visual map](docs/runtime_governance_visual_map.md) — visual-oriented governance architecture reference.
+
+### Reproduce locally
+
 - [First-run checklist](docs/first_run_checklist.md) — verify the no-key local path.
 - [Direct reproduction guide](docs/direct_reproduction_guide.md) — local commands to verify the no-key release-control path.
-- [Evidence map](docs/evidence_map.md) — connect claims to artifacts.
+
+### Integrate
+
 - [External integration CLI](docs/external_integration.md) — call the three-state release gate from an external generator.
 - [Builder integration guide](docs/builder_integration_guide.md) — where to place the release gate in an app, agent, RAG, or coding workflow.
 - [Integration decision policy examples](docs/integration_decision_policy_examples.md) — examples for handling PROCEED / NEEDS_REVIEW / SILENCE after the release gate.
+
+### Evaluate a pilot
+
+- [Pilot evaluation packet](docs/pilot_evaluation_packet.md) — bounded protocol for evaluating release-control behavior in a pilot.
+- [Evidence map](docs/evidence_map.md) — connect claims to artifacts.
+
+### Architecture
+
+- [Runtime governance stack](docs/runtime_governance_stack.md) — canonical map of sandbox and release-control governance layers.
+- [Governance stack walkthrough](docs/governance_stack_walkthrough.md) — guided architecture walkthrough of governance layers.
+- [Runtime governance visual map](docs/runtime_governance_visual_map.md) — visual-oriented governance architecture reference.
 - [Reverse integration sandbox](docs/reverse_integration_sandbox.md) — controlled intake/evaluation concept.
 - [Sandbox channel adapters](docs/sandbox_channel_adapters.md) — conceptual intake connectors for sandbox evaluation flows.
 - [Deterministic replay architecture](docs/deterministic_replay_architecture.md) — conceptual replay and inspection layer for sandbox evaluation flows.


### PR DESCRIPTION
### Motivation
- The README "Fast orientation" section had become a long flat list that made first-click navigation harder for new readers.
- Grouping the links into small, purposeful entry points improves discoverability while keeping the entry surface conservative and evidence-first.

### Description
- Restructured the `README.md` "Fast orientation" section into grouped subsections: `Start`, `Reproduce locally`, `Integrate`, `Evaluate a pilot`, and `Architecture`.
- Preserved all existing documentation links and file paths in `README.md` and did not remove or rename any docs.
- This is a documentation-only, conservative reorganization that does not add claims or change runtime behavior.

### Testing
- Ran `git diff --check` which reported no issues.
- Committed the single-file change to `README.md` with message `docs: group README fast orientation links`.
- No automated unit tests were run because this is a documentation-only change and does not affect code behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11fc2f0c0c8326bae8bfe7a32721b9)