### PR TITLE
docs: add funding and donation links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+custom:
+  - "https://tronscan.org/#/address/TJmrrUrpsRpG3u9H4FE9oVyCRPYQYEpG27"

--- a/DONATIONS.md
+++ b/DONATIONS.md
@@ -1,0 +1,24 @@
+# Support Silence-as-Control
+
+Silence-as-Control is an independent open-source research and infrastructure project focused on release-control for LLM systems.
+
+If this work is useful to you, you can support continued development, documentation, evaluation, and integration work.
+
+## Crypto support
+
+Network: TRON / TRC20  
+Asset: USDT-compatible TRC20 wallet  
+Address:
+
+TJmrrUrpsRpG3u9H4FE9oVyCRPYQYEpG27
+
+Explorer:
+
+https://tronscan.org/#/address/TJmrrUrpsRpG3u9H4FE9oVyCRPYQYEpG27
+
+## Notes
+
+- Double-check the network before sending.
+- Only send assets compatible with the TRON / TRC20 address.
+- Donations support independent development and maintenance of the project.
+- Donations do not create a support contract, service-level agreement, or investment relationship.

--- a/README.md
+++ b/README.md
@@ -407,6 +407,18 @@ For pilot or integration interest, see `docs/release_control_services.md`.
 - **Runtime extensions**: practical deployment helpers, optional deployment scaffolding.
 - **Experimental features**: MAYBE_SHORT_REGEN, optional and non-core.
 
+## Support
+
+Silence-as-Control is an independent open-source research and infrastructure project.
+
+If this work is useful to you, you can support continued development here:
+
+- [Support / donations](DONATIONS.md)
+
+TRC20 / USDT-compatible address:
+
+`TJmrrUrpsRpG3u9H4FE9oVyCRPYQYEpG27`
+
 ## Contributing
 
 Contributions should preserve the architecture split: primitive core, runtime


### PR DESCRIPTION
### Motivation
- Provide a minimal, discoverable open-source funding surface so users can support continued development while keeping all funding details and guidance in documentation rather than runtime code.
- Ensure GitHub funding uses a URL (Tronscan) per platform requirements while exposing the raw TRC20 wallet address in a copy/paste-friendly `DONATIONS.md`.

### Description
- Add `.github/FUNDING.yml` with a custom Tronscan funding URL: `https://tronscan.org/#/address/TJmrrUrpsRpG3u9H4FE9oVyCRPYQYEpG27`.
- Add `DONATIONS.md` containing the TRON / TRC20 USDT-compatible wallet address `TJmrrUrpsRpG3u9H4FE9oVyCRPYQYEpG27`, explorer link, and concise donation notes.
- Update `README.md` to include a new `## Support` section linking to `DONATIONS.md` and showing the wallet address for visibility.
- All changes are documentation/configuration-only and do not modify runtime logic, tests, benchmarks, provider code, pricing, or support/investment language.

### Testing
- Ran `git diff --check` to verify no whitespace or diff issues and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12eabddfb88326a6e88c624b0c5688)