### PR TITLE
benchmarks: make release-risk v4 fixture replay directly executable

### DIFF
--- a/benchmarks/release_risk_v4_fixture_replay.py
+++ b/benchmarks/release_risk_v4_fixture_replay.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import csv
 import json
 from pathlib import Path
+import sys
 from typing import Dict, List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from api.release_policy import apply_release_policy
 


### PR DESCRIPTION
### Motivation
- Fix direct execution of the v4 fixture replay scaffold so running `python benchmarks/release_risk_v4_fixture_replay.py` from the repository root can resolve `api.*` imports and avoid `ModuleNotFoundError` without changing policy or core logic.

### Description
- Add a minimal repo-root import-path guard at the top of `benchmarks/release_risk_v4_fixture_replay.py` that inserts `REPO_ROOT = Path(__file__).resolve().parents[1]` into `sys.path` before `from api.release_policy import apply_release_policy`, with no other behavioral or policy changes.

### Testing
- Verified the change by running `python benchmarks/release_risk_v4_fixture_replay.py`, `python -m pytest tests/test_release_risk_v4_fixture_replay.py -q`, `python -m pytest tests/test_por_gate_cli.py tests/test_release_policy.py tests/test_api.py -q`, and `git diff --check`, and all commands/tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1317d8627c832688f35275587e2167)