### PR TITLE
benchmarks: treat null v4 fixture candidates as empty output

### DIFF
--- a/benchmarks/release_risk_v4_fixture_replay.py
+++ b/benchmarks/release_risk_v4_fixture_replay.py
@@ -68,7 +68,8 @@ def run(fixture_path: Path = FIXTURE_PATH) -> Dict[str, object]:
     safe_proceeded = 0
 
     for row in candidates:
-        candidate = str(row.get("generated_candidate", ""))
+        raw_candidate = row.get("generated_candidate")
+        candidate = raw_candidate if isinstance(raw_candidate, str) else ""
         if not candidate.strip():
             num_empty_candidates += 1
 

--- a/tests/test_release_risk_v4_fixture_replay.py
+++ b/tests/test_release_risk_v4_fixture_replay.py
@@ -75,3 +75,32 @@ def test_v4_replay_artifact_contains_decisions_and_metadata() -> None:
     assert "sac_decision" in first
     assert "review_flags" in first
     assert "metadata" in first
+
+
+def test_v4_fixture_replay_treats_null_generated_candidate_as_empty(tmp_path: Path) -> None:
+    fixture_path = tmp_path / "fixture.jsonl"
+    fixture_path.write_text(
+        json.dumps(
+            {
+                "prompt_id": "null-candidate",
+                "risk": "safe",
+                "category": "other",
+                "prompt": "say hello",
+                "generated_candidate": None,
+                "candidate_source": "fixture",
+                "generation_mode": "fixture_replay",
+                "provider": None,
+                "model": None,
+                "generation_error": None,
+                "expected_behavior": "PROCEED",
+                "metadata": {},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    metrics = run(fixture_path=fixture_path)
+    assert metrics["total_cases"] == 1
+    assert metrics["num_empty_candidates"] == 1
+    assert metrics["provider"] is None


### PR DESCRIPTION
### Motivation
- Fix a bug where `generated_candidate: null` in v4 fixture JSONL became the literal string "None", causing undercounted empty candidates and incorrect replay/evaluation metrics.

### Description
- Normalize `generated_candidate` explicitly in `benchmarks/release_risk_v4_fixture_replay.py` using `raw_candidate = row.get("generated_candidate")` and `candidate = raw_candidate if isinstance(raw_candidate, str) else ""` so non-string values become an empty string.
- Preserve existing artifact fields and core/ policy behavior and avoid adding any provider/OpenAI/local calls or API-key usage.
- Add a deterministic test `tests/test_release_risk_v4_fixture_replay.py::test_v4_fixture_replay_treats_null_generated_candidate_as_empty` that writes a temporary JSONL row with `generated_candidate: null` and asserts it is counted as an empty candidate and that replay runs without provider keys.

### Testing
- Ran `python benchmarks/release_risk_v4_fixture_replay.py` which produced the summary and completed successfully.
- Ran `python -m pytest tests/test_release_risk_v4_fixture_replay.py -q` and `python -m pytest tests/test_por_gate_cli.py tests/test_release_policy.py tests/test_api.py -q`, and all tests passed.
- Ran `git diff --check` and fixed transient artifact changes by restoring result files; the committed changes are limited to the benchmark and test files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1322d7a28c8326badf4ae8a4cf5956)