### PR TITLE
benchmarks: isolate v4 fixture replay test artifacts

### DIFF
--- a/benchmarks/release_risk_v4_fixture_replay.py
+++ b/benchmarks/release_risk_v4_fixture_replay.py
@@ -51,7 +51,10 @@ def route_core_decision(row: Dict[str, object]) -> Tuple[str, str]:
     raise ValueError(f"Unknown risk class: {risk}")
 
 
-def run(fixture_path: Path = FIXTURE_PATH) -> Dict[str, object]:
+def run(
+    fixture_path: Path = FIXTURE_PATH,
+    results_dir: Path = RESULTS_DIR,
+) -> Dict[str, object]:
     candidates = load_jsonl(fixture_path)
 
     replay_rows: List[Dict[str, object]] = []
@@ -140,22 +143,30 @@ def run(fixture_path: Path = FIXTURE_PATH) -> Dict[str, object]:
         "num_replayed_candidates": len(candidates),
     }
 
-    write_artifacts(metrics, replay_rows)
+    write_artifacts(metrics, replay_rows, results_dir=results_dir)
     return metrics
 
 
-def write_artifacts(metrics: Dict[str, object], replay_rows: List[Dict[str, object]]) -> None:
-    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
-    with SUMMARY_JSON.open("w", encoding="utf-8") as handle:
+def write_artifacts(
+    metrics: Dict[str, object],
+    replay_rows: List[Dict[str, object]],
+    results_dir: Path = RESULTS_DIR,
+) -> None:
+    summary_json = results_dir / "release_risk_v4_summary.json"
+    summary_csv = results_dir / "release_risk_v4_summary.csv"
+    replay_jsonl = results_dir / "release_risk_v4_replay.jsonl"
+
+    results_dir.mkdir(parents=True, exist_ok=True)
+    with summary_json.open("w", encoding="utf-8") as handle:
         json.dump(metrics, handle, indent=2)
         handle.write("\n")
 
-    with SUMMARY_CSV.open("w", encoding="utf-8", newline="") as handle:
+    with summary_csv.open("w", encoding="utf-8", newline="") as handle:
         writer = csv.DictWriter(handle, fieldnames=list(metrics.keys()))
         writer.writeheader()
         writer.writerow(metrics)
 
-    with REPLAY_JSONL.open("w", encoding="utf-8") as handle:
+    with replay_jsonl.open("w", encoding="utf-8") as handle:
         for row in replay_rows:
             handle.write(json.dumps(row) + "\n")
 

--- a/tests/test_release_risk_v4_fixture_replay.py
+++ b/tests/test_release_risk_v4_fixture_replay.py
@@ -1,7 +1,13 @@
 import json
 from pathlib import Path
 
-from benchmarks.release_risk_v4_fixture_replay import FIXTURE_PATH, REPLAY_JSONL, run
+from benchmarks.release_risk_v4_fixture_replay import (
+    FIXTURE_PATH,
+    REPLAY_JSONL,
+    SUMMARY_CSV,
+    SUMMARY_JSON,
+    run,
+)
 
 REQUIRED_KEYS = {
     "total_cases",
@@ -63,6 +69,7 @@ def test_v4_fixture_replay_runs_without_provider_keys_and_has_stable_summary_sha
     assert metrics["candidate_source"] == "fixture"
     assert metrics["generation_mode"] == "fixture_replay"
     assert metrics["provider"] is None
+
     assert metrics["baseline_released"] == metrics["total_cases"] == metrics["num_replayed_candidates"]
 
 
@@ -100,7 +107,17 @@ def test_v4_fixture_replay_treats_null_generated_candidate_as_empty(tmp_path: Pa
         encoding="utf-8",
     )
 
-    metrics = run(fixture_path=fixture_path)
+    baseline_artifacts = {
+        "summary_json": SUMMARY_JSON.read_bytes(),
+        "summary_csv": SUMMARY_CSV.read_bytes(),
+        "replay_jsonl": REPLAY_JSONL.read_bytes(),
+    }
+
+    metrics = run(fixture_path=fixture_path, results_dir=tmp_path / "results")
     assert metrics["total_cases"] == 1
     assert metrics["num_empty_candidates"] == 1
     assert metrics["provider"] is None
+
+    assert SUMMARY_JSON.read_bytes() == baseline_artifacts["summary_json"]
+    assert SUMMARY_CSV.read_bytes() == baseline_artifacts["summary_csv"]
+    assert REPLAY_JSONL.read_bytes() == baseline_artifacts["replay_jsonl"]


### PR DESCRIPTION
### Motivation
- Prevent temporary v4 fixture replay tests from overwriting committed Phase 1 replay artifacts by allowing tests to redirect artifact output to a temporary directory while preserving default CLI behavior.

### Description
- Add an optional `results_dir: Path` parameter to `run(...)` so callers can route replay artifacts to a custom directory while `run()` defaults to the tracked `RESULTS_DIR` for CLI use.
- Update `write_artifacts(...)` to accept a `results_dir` parameter and compute `summary_json`, `summary_csv`, and `replay_jsonl` from that directory instead of always writing to the tracked results path, while preserving module-level constants `RESULTS_DIR`, `SUMMARY_JSON`, `SUMMARY_CSV`, and `REPLAY_JSONL` for consumers.
- Update the null-candidate test to snapshot the default artifact files and call `run(fixture_path=..., results_dir=tmp_path / "results")`, then assert `num_empty_candidates == 1` and that default artifact files were not modified.
- Make only targeted changes to artifact routing and tests; no changes were made to benchmark routing, release policy logic, PoR core, v1/v2/v3 artifacts, or external provider/model calls.

### Testing
- Ran `python benchmarks/release_risk_v4_fixture_replay.py` and observed expected summary output (succeeds).
- Ran `python -m pytest tests/test_release_risk_v4_fixture_replay.py -q --basetemp="C:\\Users\\User\\pytest-sac-v4-artifact-isolation"` and all tests passed.
- Ran `python -m pytest tests/test_por_gate_cli.py tests/test_release_policy.py tests/test_api.py -q` and all tests passed.
- Verified `git diff --check` and `git status --untracked-files=no` produced no unexpected issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a132931872c8326a2ff6d50631e378c)