### PR TITLE
benchmarks: add custom input support to release-risk v4 replay

### DIFF
--- a/benchmarks/release_risk_v4_fixture_replay.py
+++ b/benchmarks/release_risk_v4_fixture_replay.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import csv
 import json
 from pathlib import Path
@@ -171,9 +172,19 @@ def write_artifacts(
             handle.write(json.dumps(row) + "\n")
 
 
-if __name__ == "__main__":
-    metrics = run()
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Replay release-risk v4 fixture candidates.")
+    parser.add_argument("--input", type=Path, default=FIXTURE_PATH, help="Path to generated-candidate JSONL input.")
+    parser.add_argument("--results-dir", type=Path, default=RESULTS_DIR, help="Directory for replay artifacts.")
+    args = parser.parse_args(argv)
+
+    metrics = run(fixture_path=args.input, results_dir=args.results_dir)
     print("Release-Risk v4 Fixture Replay Summary")
     print("-" * 39)
     for key, value in metrics.items():
         print(f"{key}: {value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_risk_v4_fixture_replay.py
+++ b/tests/test_release_risk_v4_fixture_replay.py
@@ -7,6 +7,7 @@ from benchmarks.release_risk_v4_fixture_replay import (
     SUMMARY_CSV,
     SUMMARY_JSON,
     run,
+    main,
 )
 
 REQUIRED_KEYS = {
@@ -121,3 +122,58 @@ def test_v4_fixture_replay_treats_null_generated_candidate_as_empty(tmp_path: Pa
     assert SUMMARY_JSON.read_bytes() == baseline_artifacts["summary_json"]
     assert SUMMARY_CSV.read_bytes() == baseline_artifacts["summary_csv"]
     assert REPLAY_JSONL.read_bytes() == baseline_artifacts["replay_jsonl"]
+
+
+def test_v4_fixture_replay_main_defaults_to_fixture_path(tmp_path: Path) -> None:
+    results_dir = tmp_path / "default-results"
+    exit_code = main(["--results-dir", str(results_dir)])
+    assert exit_code == 0
+    assert (results_dir / "release_risk_v4_summary.json").exists()
+    summary = json.loads((results_dir / "release_risk_v4_summary.json").read_text(encoding="utf-8"))
+    assert summary["candidate_source"] == "fixture"
+    assert summary["generation_mode"] == "fixture_replay"
+
+
+def test_v4_fixture_replay_main_honors_custom_input_and_results_dir(tmp_path: Path) -> None:
+    tmp_input = tmp_path / "capture.jsonl"
+    tmp_results = tmp_path / "custom-results"
+    tmp_input.write_text(
+        json.dumps(
+            {
+                "prompt_id": "capture-1",
+                "risk": "safe",
+                "category": "other",
+                "prompt": "ping",
+                "generated_candidate": "pong",
+                "candidate_source": "generated",
+                "generation_mode": "fixture_capture",
+                "provider": None,
+                "model": "custom-test-model",
+                "generation_error": None,
+                "expected_behavior": "PROCEED",
+                "metadata": {},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    baseline_summary = SUMMARY_JSON.read_bytes()
+    baseline_csv = SUMMARY_CSV.read_bytes()
+    baseline_replay = REPLAY_JSONL.read_bytes()
+
+    exit_code = main(["--input", str(tmp_input), "--results-dir", str(tmp_results)])
+    assert exit_code == 0
+
+    summary_path = tmp_results / "release_risk_v4_summary.json"
+    replay_path = tmp_results / "release_risk_v4_replay.jsonl"
+    assert summary_path.exists()
+    assert replay_path.exists()
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary["generation_mode"] == "fixture_capture"
+    assert summary["model"] == "custom-test-model"
+
+    assert SUMMARY_JSON.read_bytes() == baseline_summary
+    assert SUMMARY_CSV.read_bytes() == baseline_csv
+    assert REPLAY_JSONL.read_bytes() == baseline_replay


### PR DESCRIPTION
### Motivation
- Allow the v4 fixture replay script to accept a caller-provided generated-candidates JSONL and caller-provided results directory so captured Phase 2B outputs can be replayed and isolated from committed artifacts.

### Description
- Add CLI parsing to `benchmarks/release_risk_v4_fixture_replay.py` using `argparse` and introduce `main(argv: list[str] | None = None)` to accept `--input` and `--results-dir` parameters wired to `run(fixture_path=..., results_dir=...)` while preserving default constants `FIXTURE_PATH` and `RESULTS_DIR`.
- Preserve all existing replay, routing, and release-policy logic and maintain the original summary print format; the `metrics` returned reflect the actual input file used.
- Add tests in `tests/test_release_risk_v4_fixture_replay.py` to validate default behavior, custom `--input` handling, and that writing to a custom `--results-dir` does not overwrite committed default artifacts.
- Files changed: `benchmarks/release_risk_v4_fixture_replay.py` and `tests/test_release_risk_v4_fixture_replay.py`.

### Testing
- Ran capture + replay end-to-end with `python benchmarks/release_risk_v4_capture_candidates.py --mode fixture --output outputs/release_risk_v4_fixture_capture.jsonl` and `python benchmarks/release_risk_v4_fixture_replay.py --input outputs/release_risk_v4_fixture_capture.jsonl --results-dir outputs/release_risk_v4_replay_results`, which produced a summary reflecting `generation_mode: fixture_capture` and the capture `model` values.
- Ran unit tests: `python -m pytest tests/test_release_risk_v4_capture_candidates.py -q`, `python -m pytest tests/test_release_risk_v4_fixture_replay.py -q`, and the broader suite `python -m pytest tests/test_por_gate_cli.py tests/test_release_policy.py tests/test_api.py -q`, and all tests passed.
- Verified that committed summary and replay artifacts under the default `RESULTS_DIR` were not overwritten when using custom `--results-dir` in tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a134b282b108326ae11fb1b7056a13f)