### PR TITLE
docs: add release-risk v4 capture-to-replay guide

### DIFF
--- a/docs/release_risk_benchmark_index.md
+++ b/docs/release_risk_benchmark_index.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This page is the recommended entry point for the release-risk benchmark evidence chain across v1, v2, and v3.
+This page is the recommended entry point for the release-risk benchmark evidence chain across v1, v2, v3, and v4.
 
 Core thesis:
 
@@ -20,7 +20,7 @@ For project identity and framing, see project memory/tracking surfaces in `docs/
 - **v1** -> deterministic handcrafted release-risk routing
 - **v2** -> fixture candidate-output replay
 - **v3** -> fixture generation/replay scaffold
-- **v4** -> future provider/local generated-candidate capture + replay (**not yet implemented**)
+- **v4** -> deterministic no-key capture + replay foundation with future optional provider/local capture
 
 ## v1: deterministic release-risk benchmark
 
@@ -151,11 +151,53 @@ python -m pytest tests/test_release_risk_v3_benchmark.py -q
 - No API keys are required for fixture mode.
 - Not production safety evidence.
 
+## v4: deterministic no-key capture + replay foundation
+
+**Scope**
+
+- Deterministic no-key generated-candidate capture.
+- Replay over caller-provided generated-candidate JSONL.
+- Caller-controlled replay artifact isolation via `--results-dir`.
+- Validation of the capture-to-replay evidence path.
+
+**Main artifacts**
+
+- `benchmarks/release_risk_v4_capture_candidates.py`
+- `benchmarks/release_risk_v4_fixture_replay.py`
+- `docs/release_risk_v4_capture_to_replay.md`
+- `docs/release_risk_v4_provider_capture_plan.md`
+- `tests/test_release_risk_v4_capture_candidates.py`
+- `tests/test_release_risk_v4_fixture_replay.py`
+
+**Commands**
+
+```bash
+python benchmarks/release_risk_v4_capture_candidates.py --mode fixture --output outputs/release_risk_v4_fixture_capture.jsonl
+python benchmarks/release_risk_v4_fixture_replay.py --input outputs/release_risk_v4_fixture_capture.jsonl --results-dir outputs/release_risk_v4_replay_results
+```
+
+**Expected proof signal**
+
+```text
+generation_mode: fixture_capture
+model: fixture-v4-capture-synthetic-1
+```
+
+**Interpretation boundary**
+
+- Deterministic fixture capture/replay evidence only.
+- No provider/OpenAI calls are required.
+- No API keys are required.
+- This is not provider-backed evidence.
+- This is not production safety evidence.
+- Optional provider/local capture remains future work.
+
 ## Artifact lineage
 
 - `#224 -> #225 -> #226`: v1 deterministic benchmark
 - `#227 -> #228 -> #229 -> #230`: v2 fixture replay benchmark
 - `#231 -> #232 -> #233 -> #234 -> #235`: v3 fixture generation/replay benchmark
+- `#253 -> #254 -> #255 -> #256 -> #258 -> #260 -> #261`: v4 no-key capture/replay foundation
 
 ## Common interpretation boundaries
 
@@ -202,6 +244,15 @@ python benchmarks/release_risk_v3/run_release_risk_v3.py --mode fixture
 python -m pytest tests/test_release_risk_v3_benchmark.py -q
 ```
 
+**v4**
+
+```bash
+python benchmarks/release_risk_v4_capture_candidates.py --mode fixture --output outputs/release_risk_v4_fixture_capture.jsonl
+python benchmarks/release_risk_v4_fixture_replay.py --input outputs/release_risk_v4_fixture_capture.jsonl --results-dir outputs/release_risk_v4_replay_results
+python -m pytest tests/test_release_risk_v4_capture_candidates.py -q
+python -m pytest tests/test_release_risk_v4_fixture_replay.py -q
+```
+
 **Shared**
 
 ```bash
@@ -210,11 +261,9 @@ python -m pytest tests/test_api.py -q
 
 ## Next step
 
-The next benchmark step is **v4 provider/local generated-candidate capture + replay**.
+The next v4 step is optional provider/local generated-candidate capture as a separate opt-in evidence track.
 
-Planning reference (design-only, no evidence addition):
+Planning reference:
 - `docs/release_risk_v4_provider_capture_plan.md`
 
-Do not start v4 until v1/v2/v3 benchmark navigation and evidence architecture are coherent.
-
-v4 should remain optional-provider, fixture-fallback, secret-safe, and conservative in claims.
+The deterministic no-key replay path should remain the default reproducibility lane for external reviewers.

--- a/docs/release_risk_v4_capture_to_replay.md
+++ b/docs/release_risk_v4_capture_to_replay.md
@@ -1,0 +1,171 @@
+# Release-risk v4 capture-to-replay guide
+
+## Purpose
+
+This guide documents the deterministic, no-key release-risk v4 capture-to-replay path.
+
+It shows how to create a generated-candidate JSONL with the v4 capture CLI, replay that JSONL through the v4 release-risk replay script, and verify the expected proof signals without provider access or API keys.
+
+Core framing:
+
+```text
+generation capability != release authority
+```
+
+The v4 no-key path keeps candidate creation and release evaluation separate:
+
+```text
+fixture capture -> generated-candidate JSONL -> replay -> summary + replay artifacts
+```
+
+## What this path proves
+
+This path proves that the repository has a reproducible, no-key evidence lane for release-risk v4:
+
+- a caller can generate replay-compatible candidate records with fixture capture;
+- replay can consume a caller-provided `--input` JSONL;
+- replay can write artifacts to a caller-provided `--results-dir`;
+- replay preserves the captured `generation_mode` and `model` metadata in the summary;
+- fixture capture and replay can run without OpenAI, provider calls, local model calls, or API keys.
+
+## What this path does not prove
+
+This path does **not** claim:
+
+- provider-backed evidence;
+- local-model evidence;
+- live generation quality;
+- production safety;
+- exploit prevention;
+- universal AI safety;
+- model correctness;
+- model improvement;
+- hallucination elimination;
+- threshold generalization across all models or tasks.
+
+It is deterministic fixture evidence for the capture-to-replay mechanics and release-routing surface.
+
+## No-key fixture capture
+
+From the repository root, run:
+
+```bash
+python benchmarks/release_risk_v4_capture_candidates.py --mode fixture --output outputs/release_risk_v4_fixture_capture.jsonl
+```
+
+This writes a small generated-candidate JSONL to:
+
+```text
+outputs/release_risk_v4_fixture_capture.jsonl
+```
+
+The fixture capture mode is intentionally bounded:
+
+- it does not call OpenAI;
+- it does not call a local model;
+- it does not require `OPENAI_API_KEY`;
+- it does not read secrets;
+- it does not modify committed benchmark artifacts.
+
+The capture records include replay-required fields such as:
+
+- `prompt_id`
+- `risk`
+- `category`
+- `prompt`
+- `generated_candidate`
+- `candidate_source`
+- `generation_mode`
+- `provider`
+- `model`
+- `generation_error`
+- `expected_behavior`
+- `metadata`
+
+## Replay captured candidates
+
+Replay the captured fixture JSONL into an isolated results directory:
+
+```bash
+python benchmarks/release_risk_v4_fixture_replay.py --input outputs/release_risk_v4_fixture_capture.jsonl --results-dir outputs/release_risk_v4_replay_results
+```
+
+This keeps generated outputs separate from committed default artifacts and makes the run easier to inspect.
+
+The replay stage evaluates the candidate outputs through the existing release policy path and writes summary/replay artifacts under the selected results directory.
+
+## Expected proof signal
+
+A successful no-key capture-to-replay run should report summary metadata that reflects the captured fixture candidates, including:
+
+```text
+generation_mode: fixture_capture
+model: fixture-v4-capture-synthetic-1
+```
+
+This signal matters because it shows that replay is consuming the caller-provided capture artifact instead of silently using the default committed fixture.
+
+## Suggested verification commands
+
+Run the focused tests for the v4 capture and replay lane:
+
+```bash
+python -m pytest tests/test_release_risk_v4_capture_candidates.py -q
+python -m pytest tests/test_release_risk_v4_fixture_replay.py -q
+```
+
+A broader focused smoke set can also be used:
+
+```bash
+python -m pytest tests/test_por_gate_cli.py tests/test_release_policy.py tests/test_api.py -q
+```
+
+These tests should not require provider credentials.
+
+## Output artifacts
+
+For the example commands above, the generated files live under `outputs/`, not under committed benchmark result directories:
+
+```text
+outputs/release_risk_v4_fixture_capture.jsonl
+outputs/release_risk_v4_replay_results/
+```
+
+This is intentional. The guide is meant to demonstrate a caller-controlled evidence path without overwriting committed artifacts.
+
+## Windows troubleshooting
+
+If temporary test paths or existing output directories cause issues on Windows, prefer caller-controlled locations:
+
+```bash
+python benchmarks/release_risk_v4_capture_candidates.py --mode fixture --output outputs/release_risk_v4_fixture_capture.jsonl
+python benchmarks/release_risk_v4_fixture_replay.py --input outputs/release_risk_v4_fixture_capture.jsonl --results-dir outputs/release_risk_v4_replay_results
+```
+
+For pytest temp-directory isolation on Windows, use an explicit base temp directory when needed:
+
+```bash
+python -m pytest tests/test_release_risk_v4_fixture_replay.py -q --basetemp="C:\\Users\\User\\pytest-sac-v4-artifact-isolation"
+```
+
+If a run appears to use stale artifacts, delete the caller-controlled `outputs/release_risk_v4_replay_results/` directory and run the two commands again.
+
+## Relationship to provider capture
+
+This guide documents the implemented no-key fixture capture-to-replay path.
+
+Provider/local capture remains separate and opt-in. See:
+
+- `docs/release_risk_v4_provider_capture_plan.md`
+
+Do not treat fixture capture as provider-backed evidence. The fixture path is the deterministic reproducibility lane for reviewers who want to inspect the capture/replay mechanics without secrets or network calls.
+
+## Suggested reading order
+
+1. `docs/release_risk_benchmark_index.md`
+2. `docs/release_risk_v4_capture_to_replay.md`
+3. `docs/release_risk_v4_provider_capture_plan.md`
+4. `benchmarks/release_risk_v4_capture_candidates.py`
+5. `benchmarks/release_risk_v4_fixture_replay.py`
+6. `tests/test_release_risk_v4_capture_candidates.py`
+7. `tests/test_release_risk_v4_fixture_replay.py`


### PR DESCRIPTION
## Motivation
- Document the implemented deterministic no-key release-risk v4 capture-to-replay path so external reviewers can reproduce the evidence flow without provider access or API keys.
- Align the benchmark index with the current v4 state after the fixture replay scaffold, capture CLI scaffold, and replay input/results-dir support landed.

## Description
- Add `docs/release_risk_v4_capture_to_replay.md` documenting the v4 no-key capture -> replay workflow, expected proof signals, boundaries/non-claims, troubleshooting guidance, and suggested reading order.
- Update `docs/release_risk_benchmark_index.md` to reflect the current v4 state as a deterministic no-key capture/replay foundation instead of a future-only placeholder.
- Add v4 commands, expected proof signals (`generation_mode: fixture_capture`, `model: fixture-v4-capture-synthetic-1`), artifact lineage, and conservative interpretation boundaries.
- Preserve the current scope constraints: no runtime logic changes, no PoR core changes, no provider evidence claims, no API-key requirements, and no production-safety claims.

## Testing
- Documentation-only change.
- No runtime logic or benchmark behavior was modified.
- The documented commands and proof signals are derived from the merged v4 fixture replay and capture PR chain (#253, #254, #255, #256, #258, #260, #261).
