### PR TITLE
docs: add pilot outreach examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ It does **not** improve model weights. It controls release behavior.
 
 - [Pilot evaluation packet](docs/pilot_evaluation_packet.md) — bounded protocol for evaluating release-control behavior in a pilot.
 - [Pilot evaluation template](docs/pilot_evaluation_template.md) — copyable table/log shape for first pilot evaluations.
+- [Pilot outreach examples](docs/pilot_outreach_examples.md) — short bounded messages for release-control audit and pilot conversations.
 - [Evidence map](docs/evidence_map.md) — connect claims to artifacts.
 
 ### Architecture

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - [External reviewer packet](external_reviewer_packet.md) — 5-10 minute technical overview for reviewers and builders.
 - [Pilot evaluation packet](pilot_evaluation_packet.md) — bounded protocol for evaluating release-control behavior in a pilot.
 - [Pilot evaluation template](pilot_evaluation_template.md) — copyable table/log shape for first pilot evaluations.
+- [Pilot outreach examples](pilot_outreach_examples.md) — conservative outreach examples for bounded audit and pilot conversations.
 - [Builder integration guide](builder_integration_guide.md) — where to place the release gate in an app, agent, RAG, or coding workflow.
 - [Integration decision policy examples](integration_decision_policy_examples.md) — examples for handling PROCEED / NEEDS_REVIEW / SILENCE after the release gate.
 - `langchain_openai_action_risk_benchmark.md` — LangChain/OpenAI action-risk benchmark framing and Run 06 hardened v4 progression.

--- a/docs/pilot_outreach_examples.md
+++ b/docs/pilot_outreach_examples.md
@@ -1,0 +1,122 @@
+# Pilot outreach examples
+
+This page is for lightweight, bounded pilot/audit conversations.
+
+- It is not a mass outreach script.
+- It is not a pricing page.
+- It is not a production-readiness claim.
+- It should help a reader understand what to send first and what evidence links to include.
+
+## Core offer
+
+First offer: **AI workflow release-control audit**.
+
+This audit stays narrow and conservative:
+
+- It looks for places where generated output becomes release/action.
+- The goal is to identify where a release gate could be inserted.
+- The deliverable is a bounded review and a recommended pilot design.
+- The audit evaluates release behavior, not model intelligence.
+
+## What to send first
+
+Recommended link order:
+
+1. [README](../README.md)
+2. [docs/release_control_services.md](release_control_services.md)
+3. [docs/pilot_evaluation_packet.md](pilot_evaluation_packet.md)
+4. [docs/builder_integration_guide.md](builder_integration_guide.md)
+5. [docs/direct_reproduction_guide.md](direct_reproduction_guide.md)
+6. [docs/evidence_map.md](evidence_map.md)
+
+Show the no-key reproduction path before any provider-backed claims.
+
+## Outreach example: technical builder
+
+Hi — I am working on Silence-as-Control, a release-control layer for LLM/agent outputs.
+
+It separates candidate generation from release authority.
+
+I am looking for 1-2 bounded pilot conversations with teams building agents, RAG systems, or coding assistants.
+
+The first step is a small workflow audit: where does generated output become user-visible output or action?
+
+No production-safety claims; the goal is scoped release-behavior evaluation.
+
+## Outreach example: founder/operator
+
+Many LLM workflows still release generated output by default.
+
+This can create accepted-wrong-output and review-routing risk.
+
+Silence-as-Control adds a small release decision layer: PROCEED / NEEDS_REVIEW / SILENCE.
+
+I can review one workflow and propose a bounded pilot.
+
+## Outreach example: researcher/reviewer
+
+v0.7 has a deterministic no-key capture-to-replay evidence path.
+
+The project is not claiming universal safety.
+
+The focus is release behavior under a runtime gate.
+
+Feedback on evidence boundaries and pilot design is welcome.
+
+## What not to say
+
+Avoid phrases like:
+
+- “solves hallucinations”
+- “guarantees correctness”
+- “production-safe AI”
+- “AGI runtime”
+- “fully autonomous safety layer”
+- “universal threshold”
+- “model improvement”
+- “replacement for human review”
+
+## Better phrases
+
+Prefer phrases like:
+
+- “release-control audit”
+- “bounded pilot”
+- “runtime release gate”
+- “candidate/release separation”
+- “accepted-output risk review”
+- “review-routing layer”
+- “deterministic no-key reviewer path”
+- “scoped release-behavior evaluation”
+
+## Minimal pilot ask
+
+Suggested ask:
+
+“Can we review one workflow where an LLM or agent produces output that becomes user-visible, code-visible, or action-visible?”
+
+Minimal pilot shape:
+
+- 25-50 examples for qualitative review.
+- 100-300 examples for early quantitative review.
+- Measure PROCEED / NEEDS_REVIEW / SILENCE.
+- Preserve candidate, decision, review flag, and outcome note.
+
+## Boundaries
+
+- Not a production safety guarantee.
+- Not model training.
+- Not model improvement.
+- Not hallucination elimination.
+- Not a replacement for human review.
+- Provider/local generated-candidate capture remains optional future work.
+- Thresholds must be calibrated per task/model/signal regime.
+
+## Suggested follow-up reading
+
+- [release_control_services.md](release_control_services.md)
+- [pilot_evaluation_packet.md](pilot_evaluation_packet.md)
+- [pilot_evaluation_template.md](pilot_evaluation_template.md)
+- [builder_integration_guide.md](builder_integration_guide.md)
+- [direct_reproduction_guide.md](direct_reproduction_guide.md)
+- [evidence_map.md](evidence_map.md)


### PR DESCRIPTION
### Motivation

- Provide a short, conservative outreach page to start bounded pilot/audit conversations about runtime release-control without expanding the project toward product hype or new code.  
- Preserve the core v0.7 thesis that generation is a candidate and release is a separate runtime decision, and avoid making safety/AGI/production claims.  
- Surface a clear, minimal evidence-first path for collaborators so they can show a no-key reproduction path before any provider-backed claims.

### Description

- Add `docs/pilot_outreach_examples.md` containing a compact framing, a conservative "AI workflow release-control audit" offer, a recommended link order to share first, audience-specific outreach templates (technical builder, founder/operator, researcher/reviewer), "what not to say" and safer phrasing, a minimal pilot ask and shape, and conservative boundaries.  
- Link the new page from the README pilot section by updating `README.md` and from the docs index by updating `docs/README.md`.  
- This is a documentation-only change with no modifications to runtime, benchmark, or provider-backed code or committed generated artifacts.

### Testing

- Ran `git diff --check` with no issues reported.  
- Ran `python -m pytest tests/test_por_gate_cli.py tests/test_release_policy.py tests/test_api.py -q` and received `30 passed` indicating existing tests continue to pass.  
- No runtime behavior, benchmark runs, or provider calls were added or changed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14995edda48326ada8e6627529d6f7)