### PR TITLE
docs: add project crystallization status

### DIFF
--- a/docs/project_crystallization_status.md
+++ b/docs/project_crystallization_status.md
@@ -1,0 +1,73 @@
+# Project Crystallization Status
+
+This document tracks the current crystallization phase of the Silence-as-Control / PoR runtime-governance project.
+
+The goal of this phase is to reduce conceptual sprawl and preserve the smallest stable architecture:
+
+```text
+generation != release authority
+```
+
+## Current phase
+
+```text
+crystallization
+```
+
+The project is currently converting long-running conceptual, repository, and public-discourse evolution into compact runtime-governance documentation.
+
+## Completed in this phase
+
+- `docs/chronology.md`
+  - establishes a project chronology scaffold
+  - keeps provenance separate from evidence claims
+
+- `docs/project_navigation.md`
+  - links the chronology into the documentation map
+  - preserves entry-point clarity
+
+- `docs/core_primitives.md`
+  - defines the smallest stable primitives
+  - anchors authority-separation language
+
+- `docs/evidence_graph.md`
+  - maps claims to artifacts and evidence gaps
+  - prevents unsupported claim expansion
+
+## Stable primitives
+
+```text
+generation != release authority
+capability != execution authority
+memory != persistence authority
+syntax != operational correctness
+```
+
+## Near-term next steps
+
+- Add curated Twitter/X archive evidence summary.
+- Link runtime/replay artifacts to the evidence graph.
+- Add release-risk examples where they support operational claims.
+- Define a small memory-admission prototype direction.
+- Keep issue #202 and issue #203 aligned with crystallization progress.
+
+## Boundary rules
+
+- Do not upload raw private archives into the repository.
+- Do not expand this phase into a full manifesto.
+- Do not claim AGI, sentience, consciousness, or universal AI safety.
+- Prefer small documentation PRs.
+- Mark evidence gaps explicitly.
+- Keep artifacts ahead of claims.
+
+## Current status
+
+```text
+chronology scaffold: done
+navigation link: done
+core primitives: done
+evidence graph scaffold: done
+curated archive evidence: pending
+runtime/replay evidence linkage: pending
+memory-admission prototype: pending
+```

--- a/docs/project_crystallization_status.md
+++ b/docs/project_crystallization_status.md
@@ -30,7 +30,7 @@ The project is currently converting long-running conceptual, repository, and pub
   - defines the smallest stable primitives
   - anchors authority-separation language
 
-- `docs/evidence_graph.md`
+- `docs/evidence_map.md`
   - maps claims to artifacts and evidence gaps
   - prevents unsupported claim expansion
 
@@ -46,7 +46,7 @@ syntax != operational correctness
 ## Near-term next steps
 
 - Add curated Twitter/X archive evidence summary.
-- Link runtime/replay artifacts to the evidence graph.
+- Link runtime/replay artifacts to the evidence map.
 - Add release-risk examples where they support operational claims.
 - Define a small memory-admission prototype direction.
 - Keep issue #202 and issue #203 aligned with crystallization progress.
@@ -66,7 +66,7 @@ syntax != operational correctness
 chronology scaffold: done
 navigation link: done
 core primitives: done
-evidence graph scaffold: done
+evidence map scaffold: done
 curated archive evidence: pending
 runtime/replay evidence linkage: pending
 memory-admission prototype: pending


### PR DESCRIPTION
## Summary

Adds a compact `project_crystallization_status.md` checkpoint document.

Focus:
- current crystallization phase
- completed documentation primitives
- stable runtime-governance boundaries
- next operational steps
- anti-overclaim rules

## Purpose

This PR establishes a lightweight checkpoint layer for:
- chronology
- navigation
- core primitives
- evidence graph
- future runtime evidence linkage

without expanding project scope.