### PR TITLE
docs: reconcile evidence graph with evidence map

### DIFF
--- a/docs/evidence_graph.md
+++ b/docs/evidence_graph.md
@@ -5,6 +5,21 @@ This document maps project claims to the smallest available artifacts that suppo
 The goal is not to collect every possible reference.
 The goal is to keep the project evidence layer inspectable, minimal, and reproducible.
 
+## Relationship to evidence_map.md
+
+`docs/evidence_map.md` is the broader evidence orientation document.
+
+This file is a compact companion graph for tracing:
+
+```text
+claim
+→ artifact
+→ status
+→ evidence gap
+```
+
+It should not replace the evidence map or duplicate large evidence explanations.
+
 ## Evidence model
 
 Each entry should follow this shape:


### PR DESCRIPTION
## Summary

Clarifies the relationship between `docs/evidence_graph.md` and `docs/evidence_map.md`.

Adds:
- compact companion framing
- claim → artifact → status explanation
- explicit non-duplication boundary

## Purpose

Resolve evidence-layer ambiguity without introducing raw archives or expanding the repository evidence surface.

This keeps:
- `evidence_map.md` as the broader orientation layer
- `evidence_graph.md` as the compact claim topology layer
