### PR TITLE
docs: restore markdown structure

### DIFF
--- a/docs/runtime_evidence_linkage.md
+++ b/docs/runtime_evidence_linkage.md
@@ -1,120 +1,70 @@
-***# Runtime Evidence Linkage***
-
-
-
-***This document links runtime and replay artifacts to the project evidence layer.***
-
-
-
-***The goal is to keep runtime evidence separate from broad claims.***
-
-
-
-***## Evidence chain***
-
-
-
-***runtime claim***
-
-***→ runtime artifact***
-
-***→ replay or benchmark output***
-
-***→ evidence map entry***
-
-***→ chronology entry***
-
-
-
-***## Current linkage targets***
-
-
-
-***### Release-control behavior***
-
-
-
-***PoR gate***
-
-***→ PROCEED / NEEDS\_REVIEW / SILENCE***
-
-***→ replay outputs***
-
-***→ docs/evidence\_map.md***
-
-
-
-***### Deterministic replay***
-
-
-
-***candidate capture***
-
-***→ fixture replay***
-
-***→ stable decision trace***
-
-***→ evidence map***
-
-
-
-***### Release-risk examples***
-
-
-
-***unsafe or ambiguous candidate***
-
-***→ gate decision***
-
-***→ replayable result***
-
-***→ release-risk evidence***
-
-
-
-***### Local runtime***
-
-
-
-***candidate generation***
-
-***→ local gate***
-
-***→ runtime log***
-
-***→ replay log***
-
-***→ evidence map***
-
-
-
-***## Evidence rules***
-
-
-
-***- Prefer replayable artifacts.***
-
-***- Prefer small curated outputs over raw logs.***
-
-***- Do not store private archives here.***
-
-***- Do not claim complete validation from partial evidence.***
-
-***- Keep runtime behavior separate from model quality claims.***
-
-
-
-***## Pending links***
-
-
-
-***- release-risk v4 replay outputs***
-
-***- local runtime logs***
-
-***- hosted deployment traces***
-
-***- curated Twitter/X chronology references***
-
-***- issue #202 / #203 progress anchors***
-
+# Runtime Evidence Linkage
+
+This document links runtime and replay artifacts to the project evidence layer.
+
+The goal is to keep runtime evidence separate from broad claims.
+
+## Evidence chain
+
+```text
+runtime claim
+→ runtime artifact
+→ replay or benchmark output
+→ evidence map entry
+→ chronology entry
+```
+
+## Current linkage targets
+
+### Release-control behavior
+
+```text
+PoR gate
+→ PROCEED / NEEDS_REVIEW / SILENCE
+→ replay outputs
+→ docs/evidence_map.md
+```
+
+### Deterministic replay
+
+```text
+candidate capture
+→ fixture replay
+→ stable decision trace
+→ evidence map
+```
+
+### Release-risk examples
+
+```text
+unsafe or ambiguous candidate
+→ gate decision
+→ replayable result
+→ release-risk evidence
+```
+
+### Local runtime
+
+```text
+candidate generation
+→ local gate
+→ runtime log
+→ replay log
+→ evidence map
+```
+
+## Evidence rules
+
+- Prefer replayable artifacts.
+- Prefer small curated outputs over raw logs.
+- Do not store private archives here.
+- Do not claim complete validation from partial evidence.
+- Keep runtime behavior separate from model quality claims.
+
+## Pending links
+
+- release-risk v4 replay outputs
+- local runtime logs
+- hosted deployment traces
+- curated Twitter/X chronology references
+- issue #202 / #203 progress anchors

--- a/docs/twitter_archive_summary.md
+++ b/docs/twitter_archive_summary.md
@@ -1,278 +1,150 @@
-***# Twitter/X Archive Summary***
+# Twitter/X Archive Summary
 
+## Purpose
 
+This document summarizes recurring runtime-governance themes observed across the Twitter/X archive.
 
-***## Purpose***
+The archive is treated as:
 
+- chronology evidence
+- terminology evolution
+- continuity trace
+- conceptual stabilization evidence
 
+not as proof of correctness.
 
-***This document summarizes recurring runtime-governance themes observed across the Twitter/X archive.***
+The goal is to preserve a compact evolution summary without importing the raw archive into the repository.
 
+---
 
+## Archive scope
 
-***The archive is treated as:***
+Approximate archive scale:
 
-***- chronology evidence***
+- ~2700+ public posts
+- 2025 → 2026 continuity window
+- evolving runtime-governance terminology
+- architecture and release-control discussions
 
-***- terminology evolution***
+---
 
-***- continuity trace***
+## Observed evolution pattern
 
-***- conceptual stabilization evidence***
+The archive shows a gradual transition:
 
+```text
+continuity
+→ control
+→ release
+→ replay
+→ runtime governance
+```
 
+rather than abrupt concept switching.
 
-***not as proof of correctness.***
+---
 
+## Early recurring themes
 
+### 2025 — continuity and resonance phase
 
-***The goal is to preserve a compact evolution summary without importing the raw archive into the repository.***
+Observed patterns:
 
+- continuity
+- memory
+- orchestration
+- persistence
+- boundaries
 
+Status:
 
-***---***
+early intuition phase
 
+---
 
+### 2025 Q4 — authority separation phase
 
-***## Archive scope***
+Observed patterns:
 
+- control
+- release
+- execution
+- validation
+- permission
 
+Status:
 
-***Approximate archive scale:***
+pre-runtime-governance crystallization
 
+---
 
+### 2026 — operational runtime phase
 
-***- \~2700+ public posts***
+Observed patterns:
 
-***- 2025 → 2026 continuity window***
+- PoR
+- release-control
+- replay
+- runtime boundaries
+- governance
+- evidence linkage
 
-***- evolving runtime-governance terminology***
+Status:
 
-***- architecture and release-control discussions***
+runtime-governance crystallization
 
+---
 
+## Terminology stabilization
 
-***---***
+Recurring terminology includes:
 
+- control
+- release
+- runtime
+- architecture
+- memory
+- governance
+- replay
+- evidence
 
+The archive suggests terminology stabilization over time rather than isolated experimentation.
 
-***## Observed evolution pattern***
+---
 
+## Relationship to repository evolution
 
+The Twitter/X archive and repository evolution together form:
 
-***The archive shows a gradual transition:***
+```text
+concept intuition
+→ terminology stabilization
+→ issue architecture
+→ replay systems
+→ runtime evidence
+→ operational governance framing
+```
 
+---
 
+## Boundary rules
 
-***continuity***
+- The archive is not treated as proof of correctness.
+- Public posts are treated as chronology evidence only.
+- Curated summaries are preferred over raw archive uploads.
+- Private or unrelated material should remain outside the repository.
+- Runtime evidence should remain separate from public discourse.
 
-***→ control***
+---
 
-***→ release***
+## Non-goals
 
-***→ replay***
+This archive summary does not claim:
 
-***→ runtime governance***
+- AGI
+- sentience
+- consciousness
+- universal AI safety
+- complete validation of the architecture
 
-
-
-***rather than abrupt concept switching.***
-
-
-
-***---***
-
-
-
-***## Early recurring themes***
-
-
-
-***### 2025 — continuity and resonance phase***
-
-
-
-***Observed patterns:***
-
-***- continuity***
-
-***- memory***
-
-***- orchestration***
-
-***- persistence***
-
-***- boundaries***
-
-
-
-***Status:***
-
-***early intuition phase***
-
-
-
-***---***
-
-
-
-***### 2025 Q4 — authority separation phase***
-
-
-
-***Observed patterns:***
-
-***- control***
-
-***- release***
-
-***- execution***
-
-***- validation***
-
-***- permission***
-
-
-
-***Status:***
-
-***pre-runtime-governance crystallization***
-
-
-
-***---***
-
-
-
-***### 2026 — operational runtime phase***
-
-
-
-***Observed patterns:***
-
-***- PoR***
-
-***- release-control***
-
-***- replay***
-
-***- runtime boundaries***
-
-***- governance***
-
-***- evidence linkage***
-
-
-
-***Status:***
-
-***runtime-governance crystallization***
-
-
-
-***---***
-
-
-
-***## Terminology stabilization***
-
-
-
-***Recurring terminology includes:***
-
-
-
-***- control***
-
-***- release***
-
-***- runtime***
-
-***- architecture***
-
-***- memory***
-
-***- governance***
-
-***- replay***
-
-***- evidence***
-
-
-
-***The archive suggests terminology stabilization over time rather than isolated experimentation.***
-
-
-
-***---***
-
-
-
-***## Relationship to repository evolution***
-
-
-
-***The Twitter/X archive and repository evolution together form:***
-
-
-
-***concept intuition***
-
-***→ terminology stabilization***
-
-***→ issue architecture***
-
-***→ replay systems***
-
-***→ runtime evidence***
-
-***→ operational governance framing***
-
-
-
-***---***
-
-
-
-***## Boundary rules***
-
-
-
-***- The archive is not treated as proof of correctness.***
-
-***- Public posts are treated as chronology evidence only.***
-
-***- Curated summaries are preferred over raw archive uploads.***
-
-***- Private or unrelated material should remain outside the repository.***
-
-***- Runtime evidence should remain separate from public discourse.***
-
-
-
-***---***
-
-
-
-***## Non-goals***
-
-
-
-***This archive summary does not claim:***
-
-
-
-***- AGI***
-
-***- sentience***
-
-***- consciousness***
-
-***- universal AI safety***
-
-***- complete validation of the architecture***
-
-
-
-***It documents the observable evolution of runtime-governance terminology and operational framing over time.***
-
+It documents the observable evolution of runtime-governance terminology and operational framing over time.


### PR DESCRIPTION
### Motivation

- Fix accidental triple-emphasis wrappers (`***...***`) that broke GitHub Markdown rendering, anchors, outlines, and list/horizontal-rule rendering in documentation.
- Target the affected docs to restore navigation and readability without changing content or project scope: `docs/runtime_evidence_linkage.md` and `docs/twitter_archive_summary.md`, and resolve the `docs/evidence_graph.md` conflict by keeping the current main version.

### Description

- Removed outer `***` wrappers and restored normal Markdown headings, lists, paragraphs, horizontal rules, and fenced code blocks in `docs/runtime_evidence_linkage.md` and `docs/twitter_archive_summary.md` while preserving original content and meaning.
- Accepted the current main version for `docs/evidence_graph.md` to resolve the merge conflict and keep its correct relationship section referencing `docs/evidence_map.md`.
- No code, architecture, or data changes were made and no new claims or external archives were added.
- Commit message: `docs: restore markdown structure`.

### Testing

- Ran `rg -n '^\*\*\*|\*\*\*$|<<<<<<<|=======|>>>>>>>' docs/runtime_evidence_linkage.md docs/twitter_archive_summary.md docs/evidence_graph.md; test $? -eq 1` and it passed, confirming no remaining triple-emphasis or conflict markers.
- Executed a Python check to assert there are no conflict markers and no remaining `***#` wrapped headings, and it passed.
- Ran `git diff --check` to validate whitespace/merge issues and then committed the changes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1be82bf6188326aa41a7c852e09426)