### PR TITLE
docs: add crystallization/provenance links and evidence graph topology to documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - `provider_configuration.md` — no-key vs provider-backed runtime configuration.
 - `threshold_regime_contract.md` — scoped threshold interpretation contract for SimpleQA/Ollama evidence.
 - `evidence_map.md` — claim-to-artifact navigation for core/runtime/benchmark surfaces.
+- `evidence_graph.md` — compact claim-to-artifact topology companion.
 - `release_risk_benchmark_index.md` — recommended entry point for v1/v2/v3 release-risk benchmark evidence, artifact lineage, commands, and interpretation boundaries.
 - `release_risk_benchmark_report.md` — first deterministic local release-risk benchmark run report.
 - `release_risk_v2_benchmark_report.md` — first local fixture-replay run report for release-risk benchmark v2.
@@ -43,5 +44,14 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - [Review lane architecture](review_lane_architecture.md) — conceptual governance routing layer for sandbox evaluation flows.
 - [Connector sandbox boundary](connector_sandbox_boundary.md) — conceptual governance boundary for external communication surfaces.
 - `applied_bridges.md` — bounded notes on compatible applied bridges such as `por-copilot-bridge`.
+
+## Crystallization / provenance index
+
+- [Project chronology](chronology.md)
+- [Core primitives](core_primitives.md)
+- [Evidence graph](evidence_graph.md)
+- [Project crystallization status](project_crystallization_status.md)
+- [Runtime evidence linkage](runtime_evidence_linkage.md)
+- [Twitter/X archive summary](twitter_archive_summary.md)
 
 For paper/preprint context, see `../paper/README.md`.

--- a/docs/evidence_map.md
+++ b/docs/evidence_map.md
@@ -48,11 +48,13 @@ Interpretation boundaries:
 
 ## Benchmark / evaluation files
 
-- `eval_simpleqa_ollama.py`
-- `benchmark/eval_100_milestone.py`
-- `benchmark/eval_100_messy.py`
+- `benchmarks/simpleqa/run_simpleqa_por.py`
+- `benchmarks/simpleqa/README.md`
+- `data/simpleqa_clean_100.jsonl`
+- `data/simpleqa_messy_100.jsonl`
+- `reports/simpleqa_ollama_calibration_summary.md`
 
-These files produce evaluation outputs used for threshold-behavior inspection.
+These tracked benchmark and dataset files support threshold-behavior inspection. For the compact claim-to-artifact topology, see `docs/evidence_graph.md`.
 
 ## Demo evidence note
 

--- a/docs/project_crystallization_status.md
+++ b/docs/project_crystallization_status.md
@@ -34,6 +34,14 @@ The project is currently converting long-running conceptual, repository, and pub
   - maps claims to artifacts and evidence gaps
   - prevents unsupported claim expansion
 
+- `docs/twitter_archive_summary.md`
+  - provides a curated archive/provenance summary
+  - keeps archive continuity separate from correctness claims
+
+- `docs/runtime_evidence_linkage.md`
+  - links runtime/replay artifacts into the evidence layer
+  - preserves conservative evidence boundaries
+
 ## Stable primitives
 
 ```text
@@ -45,9 +53,9 @@ syntax != operational correctness
 
 ## Near-term next steps
 
-- Add curated Twitter/X archive evidence summary.
-- Link runtime/replay artifacts to the evidence map.
-- Add release-risk examples where they support operational claims.
+- Extend the curated Twitter/X archive evidence summary only with sanitized, compact references.
+- Maintain runtime/replay artifact links as evidence surfaces evolve.
+- Add future release-risk examples only where they support operational claims.
 - Define a small memory-admission prototype direction.
 - Keep issue #202 and issue #203 aligned with crystallization progress.
 
@@ -67,7 +75,9 @@ chronology scaffold: done
 navigation link: done
 core primitives: done
 evidence map scaffold: done
-curated archive evidence: pending
-runtime/replay evidence linkage: pending
+curated archive evidence summary: scaffolded
+provenance/evidence graph layer: scaffolded
+runtime/replay evidence linkage: linked
 memory-admission prototype: pending
+future hosted/runtime traces: pending
 ```

--- a/docs/project_navigation.md
+++ b/docs/project_navigation.md
@@ -19,7 +19,9 @@ docs/
   ├─ architecture.md                 ← core/runtime/experimental split
   ├─ agentic_release_control.md      ← agentic release-control layer
   ├─ evidence_map.md                 ← claims → artifacts
+  ├─ evidence_graph.md               ← compact claim topology
   ├─ chronology.md                   ← project evolution timeline
+  ├─ runtime_evidence_linkage.md     ← runtime/replay evidence links
   ├─ runtime_observability.md        ← telemetry verification
   ├─ provider_configuration.md       ← API/provider setup
   ├─ release_control_services.md     ← pilot/integration interest
@@ -46,6 +48,15 @@ issues/
 | See milestone planning | [Roadmap 2026](roadmap_2026.md) |
 | Recover current project memory | [Issue #202](https://github.com/SemeAIPletinnya/silence-as-control/issues/202) |
 | Track roadmap/progress/dependencies | [Issue #203](https://github.com/SemeAIPletinnya/silence-as-control/issues/203) |
+
+## Crystallization / provenance / evidence topology
+
+- [Project chronology](chronology.md)
+- [Core primitives](core_primitives.md)
+- [Evidence graph](evidence_graph.md)
+- [Project crystallization status](project_crystallization_status.md)
+- [Runtime evidence linkage](runtime_evidence_linkage.md)
+- [Twitter/X archive summary](twitter_archive_summary.md)
 
 ## Boundary rules
 

--- a/docs/runtime_evidence_linkage.md
+++ b/docs/runtime_evidence_linkage.md
@@ -43,6 +43,14 @@ unsafe or ambiguous candidate
 → release-risk evidence
 ```
 
+Linked surfaces:
+
+- `docs/release_risk_benchmark_index.md`
+- `docs/release_risk_v4_capture_to_replay.md`
+- `benchmarks/release_risk_v4_fixture_replay.py`
+- `benchmarks/release_risk_v4/results/release_risk_v4_summary.json`
+- `benchmarks/release_risk_v4/results/release_risk_v4_replay.jsonl`
+
 ### Local runtime
 
 ```text
@@ -52,6 +60,12 @@ candidate generation
 → replay log
 → evidence map
 ```
+
+Linked surfaces:
+
+- `docs/runtime_observability.md`
+- `scripts/runtime_observability_report.py`
+- `tests/test_runtime_observability_report.py`
 
 ## Evidence rules
 
@@ -63,8 +77,6 @@ candidate generation
 
 ## Pending links
 
-- release-risk v4 replay outputs
-- local runtime logs
 - hosted deployment traces
-- curated Twitter/X chronology references
-- issue #202 / #203 progress anchors
+- optional provider-backed replay artifacts
+- future memory-admission prototype evidence


### PR DESCRIPTION
### Motivation

- Surface a compact provenance/evidence topology for the project to link claims to replayable artifacts and curated archives.  
- Make runtime/replay evidence linkages explicit so deterministic replay and release-risk outputs are discoverable.  
- Expose tracked benchmark/dataset artifacts used for SimpleQA/PoR runs alongside the evidence map.

### Description

- Updated `docs/README.md` to include an `evidence_graph.md` reference and a Crystallization / provenance index.  
- Updated `docs/project_navigation.md` to link the `evidence_graph.md` and `runtime_evidence_linkage.md` into the navigation map.  
- Updated `docs/evidence_map.md` to reference the compact claim topology (`docs/evidence_graph.md`) and list tracked SimpleQA benchmark/dataset artifacts such as `benchmarks/simpleqa/run_simpleqa_por.py`, `data/simpleqa_clean_100.jsonl`, and `reports/simpleqa_ollama_calibration_summary.md`.  
- Updated `docs/project_crystallization_status.md` and `docs/runtime_evidence_linkage.md` to mark scaffolding/links for the curated archive, provenance/evidence graph, and runtime/replay artifacts including references to `docs/release_risk_v4_capture_to_replay.md` and `benchmarks/release_risk_v4/results/release_risk_v4_replay.jsonl`.

### Testing

- This change is documentation-only and did not modify executable code, so no automated tests were changed or executed as part of this PR.  
- Existing CI/docs linters (if any) were not invoked by this update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bf3214b1c83268ff39df0f5ba41c5)