### PR TITLE
Add Windows-safe pytest basetemp plugin and enable it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ logs/
 .DS_Store
 .env
 runtime_logs/
+
+.pytest_tmp_runs/
+.pytest_tmp_run/

--- a/_pytest_windows_tmp.py
+++ b/_pytest_windows_tmp.py
@@ -1,0 +1,47 @@
+"""Pytest temp-directory hardening for Windows test runs.
+
+This plugin keeps pytest's tmp_path basetemp out of shared, reusable temp
+roots on Windows. It is test infrastructure only; it does not affect runtime
+code, replay artifacts, or benchmark semantics.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+
+
+def _has_basetemp(args: list[str]) -> bool:
+    """Return True when the user already supplied a pytest basetemp option."""
+    return any(arg == "--basetemp" or arg.startswith("--basetemp=") for arg in args)
+
+
+def _run_basetemp(root: Path) -> Path:
+    """Return a unique per-run basetemp path below *root*."""
+    run_id = f"run-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    return root / run_id
+
+
+def _windows_tmp_root(repo_root: Path) -> Path:
+    """Prefer a repo-local temp root, then fall back to a user temp subdir."""
+    repo_tmp_root = repo_root / ".pytest_tmp_runs"
+    try:
+        repo_tmp_root.mkdir(exist_ok=True)
+        return repo_tmp_root
+    except OSError:
+        fallback_root = Path(tempfile.gettempdir()) / "silence-as-control-pytest"
+        fallback_root.mkdir(exist_ok=True)
+        return fallback_root
+
+
+def pytest_load_initial_conftests(early_config, parser, args: list[str]) -> None:
+    """Set a unique Windows basetemp unless the caller chose one explicitly."""
+    if sys.platform != "win32" or _has_basetemp(args):
+        return
+
+    repo_root = Path(str(getattr(early_config, "rootpath", Path.cwd())))
+    basetemp = _run_basetemp(_windows_tmp_root(repo_root))
+    args.append(f"--basetemp={basetemp}")

--- a/docs/direct_reproduction_guide.md
+++ b/docs/direct_reproduction_guide.md
@@ -149,7 +149,7 @@ The current path is scoped to stable, no-key verification.
 
 ## 10. Troubleshooting
 
-- If pytest temp permissions fail on Windows, run pytest with a unique `--basetemp` path.
+- On Windows, the test suite automatically uses a unique per-run pytest temp root to avoid shared temp-directory cleanup races. If Python 3.14 / pytest 8.3.5 still reports temp cleanup permissions, run `python -m pytest --basetemp=.pytest_tmp_runs/manual`.
 - If provider-backed `/por/complete` fails, check provider configuration; it is not required for this guide.
 - If an output path does not exist, the CLI should create parent directories for `--output`.
 - If imports fail, run `python -m pip install -e .`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,5 +25,6 @@ package-dir = {"" = "src"}
 where = ["src"]
 
 [tool.pytest.ini_options]
+addopts = ["-p", "_pytest_windows_tmp"]
 pythonpath = ["src", "."]
 testpaths = ["tests"]


### PR DESCRIPTION
### Motivation

- Prevent flaky test runs on Windows caused by shared temporary directories and cleanup permission races by ensuring pytest uses a unique per-run `--basetemp` on Windows.

### Description

- Add `_pytest_windows_tmp.py` pytest plugin that sets a unique repo-local or fallback temp root and appends a per-run `--basetemp=<path>` when running on Windows and no `--basetemp` was provided.
- Register the plugin by adding `addopts = ["-p", "_pytest_windows_tmp"]` to `[tool.pytest.ini_options]` in `pyproject.toml` so the plugin is loaded automatically for test runs.
- Update `.gitignore` to exclude the repository temp directories `.pytest_tmp_runs/` and `.pytest_tmp_run/` created by the plugin.
- Update documentation in `docs/direct_reproduction_guide.md` to explain the automatic per-run pytest temp root on Windows and provide a manual `--basetemp` example.

### Testing

- Ran the test suite with `python -m pytest` in a non-Windows CI-like environment where the plugin is a no-op, and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bf95355088326b582578c569b9a86)