### PR TITLE
Use repository-local pytest basetemp on Windows and document fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ logs/
 .DS_Store
 .env
 runtime_logs/
+.pytest_tmp_runs/
+.pytest_tmp_run/

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,37 @@
+"""Pytest configuration for repository-local test infrastructure."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import uuid
+from pathlib import Path
+
+
+def _unique_basetemp(temp_root: Path) -> Path:
+    """Return a unique per-run pytest basetemp path below ``temp_root``."""
+
+    return temp_root / f"run-{os.getpid()}-{uuid.uuid4().hex}"
+
+
+def _windows_basetemp() -> Path:
+    """Choose the Windows pytest basetemp path, falling back outside the repo."""
+
+    repo_temp_root = Path(__file__).resolve().parent / ".pytest_tmp_runs"
+
+    try:
+        repo_temp_root.mkdir(parents=True, exist_ok=True)
+        return _unique_basetemp(repo_temp_root)
+    except OSError:
+        fallback_root = Path(tempfile.gettempdir()) / "silence-as-control-pytest"
+        fallback_root.mkdir(parents=True, exist_ok=True)
+        return _unique_basetemp(fallback_root)
+
+
+def pytest_configure(config):  # noqa: ANN001
+    """Use an isolated Windows pytest temp directory unless one was requested."""
+
+    if os.name != "nt" or config.option.basetemp:
+        return
+
+    config.option.basetemp = str(_windows_basetemp())

--- a/docs/direct_reproduction_guide.md
+++ b/docs/direct_reproduction_guide.md
@@ -36,6 +36,12 @@ Assumptions:
 
 Windows note: if pytest temp-folder permissions or file locks cause failures, use a unique `--basetemp` path (shown below).
 
+Repository-local fallback command:
+
+```bash
+python -m pytest --basetemp=.pytest_tmp_runs/manual
+```
+
 ## 3. Fresh checkout setup
 
 Windows PowerShell:


### PR DESCRIPTION
### Motivation

- Prevent pytest failures on Windows caused by temp-folder permission or file-lock issues by selecting an isolated per-run basetemp inside the repository when possible.
- Provide an explicit, documented fallback command for reproducing tests using a repo-local basetemp.

### Description

- Add `conftest.py` that sets `config.option.basetemp` to a unique per-run directory under `.pytest_tmp_runs` on Windows and falls back to a system temp directory when repo writes fail.
- Add `.pytest_tmp_runs/` and `.pytest_tmp_run/` to `.gitignore` so ephemeral pytest directories are not committed.
- Update `docs/direct_reproduction_guide.md` with a repository-local fallback command example: `python -m pytest --basetemp=.pytest_tmp_runs/manual`.

### Testing

- Ran the test invocation `python -m pytest --basetemp=.pytest_tmp_runs/manual` locally to verify pytest picks up the repo-local basetemp and test runs start as expected, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bfc4911888326bc81f761d04ba457)