### PR TITLE
Ignore pytest temp folders and add Windows basetemp fallback to docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ logs/
 .DS_Store
 .env
 runtime_logs/
+.pytest_tmp_runs/
+.pytest_tmp_run/

--- a/docs/direct_reproduction_guide.md
+++ b/docs/direct_reproduction_guide.md
@@ -36,6 +36,13 @@ Assumptions:
 
 Windows note: if pytest temp-folder permissions or file locks cause failures, use a unique `--basetemp` path (shown below).
 
+Repository-local fallback command:
+
+```powershell
+New-Item -ItemType Directory .pytest_tmp_runs -Force
+python -m pytest --basetemp=.pytest_tmp_runs/manual
+```
+
 ## 3. Fresh checkout setup
 
 Windows PowerShell:


### PR DESCRIPTION
### Motivation
- Prevent accidental check-ins of temporary pytest run folders and provide a repository-local Windows fallback for running pytest with `--basetemp` to avoid permission or file-lock issues.

### Description
- Add `.pytest_tmp_runs/` and `.pytest_tmp_run/` to `.gitignore` and update `docs/direct_reproduction_guide.md` with a PowerShell fallback that creates `.pytest_tmp_runs` and runs `python -m pytest --basetemp=.pytest_tmp_runs/manual`.

### Testing
- No automated tests were run for this documentation and `.gitignore` change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bfc4911888326bc81f761d04ba457)