### PR TITLE
Add FastAPI root landing endpoint

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -269,6 +269,18 @@ def resolve_experimental_short_regen_flag(req: CompleteRequest) -> bool:
     return req.enable_short_regen
 
 
+@app.get("/")
+def root() -> dict[str, str]:
+    """Minimal deployment landing endpoint for root URL checks."""
+    return {
+        "project": "Silence-as-Control",
+        "status": "running",
+        "thesis": "generation != release authority",
+        "docs": "/docs",
+        "health": "/health",
+    }
+
+
 @app.get("/health")
 def health() -> dict[str, str]:
     """Health endpoint for API runtime checks."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -359,6 +359,19 @@ def test_api_complete_returns_500_on_internal_failure(monkeypatch):
     assert response.json()["detail"] == "por_complete_failed"
 
 
+def test_api_root_endpoint():
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "project": "Silence-as-Control",
+        "status": "running",
+        "thesis": "generation != release authority",
+        "docs": "/docs",
+        "health": "/health",
+    }
+
+
 def test_api_health_endpoint():
     response = client.get("/health")
 


### PR DESCRIPTION
### Motivation
- Provide a minimal `GET /` landing endpoint so deployed FastAPI environments (e.g., VibeNest) return a friendly deployment UX JSON instead of `{"detail":"Not Found"}`.

### Description
- Add a `@app.get("/")` handler in `api/main.py` that returns the required payload (`project`, `status`, `thesis`, `docs`, `health`).
- Add `test_api_root_endpoint` to `tests/test_api.py` to assert the root payload is returned as expected.
- Change is intentionally minimal and scoped; it does not modify PoR gate logic, replay semantics, benchmark behavior, or evidence outputs.

### Testing
- Ran `pytest tests/test_api.py -q` which executed the API test suite; result: `16 passed, 1 warning` (the warning is from `fastapi.testclient`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e870828648326941e5d0a80358c6f)