### PR TITLE
Add runtime flow block to FastAPI landing page

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -336,6 +336,7 @@ def root() -> HTMLResponse:
       border-color: #9fd0ff;
       outline: none;
     }
+    .flow,
     .demo {
       border: 1px solid #263544;
       border-radius: 1rem;
@@ -343,14 +344,69 @@ def root() -> HTMLResponse:
       text-align: left;
       background: #101722;
     }
+    .flow {
+      margin-bottom: 1rem;
+    }
+    .flow h2,
     .demo h2 {
       margin: 0 0 0.25rem;
       font-size: 1.15rem;
     }
+    .flow p,
     .demo p {
       margin: 0 0 1rem;
       color: #9fb0c3;
       line-height: 1.5;
+    }
+    .flow-steps {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: stretch;
+      gap: 0.5rem;
+    }
+    .flow-card,
+    .flow-arrow {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .flow-card {
+      min-height: 3rem;
+      flex: 1 1 8rem;
+      border: 1px solid #263544;
+      border-radius: 0.75rem;
+      padding: 0.65rem;
+      background: #0b0f14;
+      color: #e8eef5;
+      font-weight: 800;
+      text-align: center;
+    }
+    .flow-outcomes {
+      flex: 1.4 1 14rem;
+      gap: 0.35rem;
+      flex-wrap: wrap;
+    }
+    .flow-arrow {
+      color: #6b7f94;
+      font-weight: 900;
+    }
+    .outcome {
+      border: 1px solid #314458;
+      border-radius: 999px;
+      padding: 0.3rem 0.5rem;
+      color: #c6d2df;
+      font-size: 0.78rem;
+      letter-spacing: 0.03em;
+    }
+    @media (max-width: 42rem) {
+      .flow-steps {
+        display: grid;
+        grid-template-columns: 1fr;
+      }
+      .flow-arrow {
+        min-height: 1rem;
+        transform: rotate(90deg);
+      }
     }
     label {
       display: block;
@@ -496,6 +552,24 @@ def root() -> HTMLResponse:
       <a href="/health">Health</a>
       <a href="https://github.com/SemeAIPletinnya/silence-as-control">GitHub</a>
     </nav>
+
+    <section class="flow" aria-labelledby="flow-title">
+      <h2 id="flow-title">Runtime flow</h2>
+      <p>Generation proposes a candidate; the runtime evaluates it before release authority is granted.</p>
+      <div class="flow-steps" aria-label="candidate generation to release gate outcomes">
+        <div class="flow-card">candidate generation</div>
+        <div class="flow-arrow" aria-hidden="true">→</div>
+        <div class="flow-card">runtime evaluation</div>
+        <div class="flow-arrow" aria-hidden="true">→</div>
+        <div class="flow-card">release gate</div>
+        <div class="flow-arrow" aria-hidden="true">→</div>
+        <div class="flow-card flow-outcomes" aria-label="release decisions">
+          <span class="outcome">PROCEED</span>
+          <span class="outcome">NEEDS_REVIEW</span>
+          <span class="outcome">SILENCE</span>
+        </div>
+      </div>
+    </section>
 
     <section class="demo" aria-labelledby="demo-title">
       <h2 id="demo-title">Live PoR evaluate demo</h2>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -367,6 +367,11 @@ def test_api_root_endpoint():
     assert "Silence-as-Control" in response.text
     assert "generation != release authority" in response.text
     assert "/por/evaluate" in response.text
+    assert "Runtime flow" in response.text
+    assert "candidate generation" in response.text
+    assert "release gate" in response.text
+    assert "NEEDS_REVIEW" in response.text
+    assert "SILENCE" in response.text
     assert "Evaluate" in response.text
     assert "Decision" in response.text
     assert "Coherence" in response.text


### PR DESCRIPTION
### Motivation
- Make the runtime flow visually clear on the root landing page before the live PoR demo so visitors see the candidate → evaluation → release path. 
- Keep runtime semantics, API endpoints, and existing demo behavior unchanged while not introducing any external JS/CSS dependencies. 

### Description
- Insert a minimal, dark-styled `Runtime flow` section (inline cards and arrows) between the nav and the live demo in `api/main.py` to show: `candidate generation → runtime evaluation → release gate → PROCEED / NEEDS_REVIEW / SILENCE`. 
- Add responsive CSS for `.flow`, `.flow-steps`, `.flow-card`, `.flow-arrow`, and `.outcome` inside the same `api/main.py` HTML to ensure mobile stacking and a minimal infra aesthetic. 
- Update `tests/test_api.py` to assert the root page contains the new flow heading and copy: `Runtime flow`, `candidate generation`, `release gate`, `NEEDS_REVIEW`, and `SILENCE`. 
- Files changed: `api/main.py`, `tests/test_api.py`.

### Testing
- Ran `pytest tests/test_api.py -q` and the updated root tests passed (test suite for that file succeeded). 
- Ran the full test suite with `pytest -q` and all tests passed (254 passed, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ea193654483268ce8b9b90a8a0cba)