### PR TITLE
Update ambiguous preset copy to 'near-threshold instability'

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -637,7 +637,7 @@ def root() -> HTMLResponse:
           </button>
           <button class="preset-button preset-ambiguous" type="button" data-preset="ambiguous">
             Ambiguous example
-            <span>Expected intent: borderline / review</span>
+            <span>Expected intent: near-threshold instability</span>
           </button>
           <button class="preset-button preset-unsafe" type="button" data-preset="unsafe">
             Unsafe example


### PR DESCRIPTION
### Motivation
- Avoid implying a review outcome not emitted by the live `/por/evaluate` path by changing the Ambiguous preset language to more accurate demo wording.

### Description
- Replace the Ambiguous preset copy in `api/main.py` to read `Expected intent: near-threshold instability` and keep the change strictly scoped to landing/demo copy without touching `/por/evaluate` behavior or PoR gate logic.

### Testing
- Ran `pytest tests/test_api.py::test_api_root_endpoint` which passed, and verified formatting/consistency with `git diff --check` (no issues).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ed76ccf8083269100986d61f5070d)