### PR TITLE
Add runtime NEEDS_REVIEW decision band

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import Any, Mapping, TypedDict
+from typing import Any, Literal, Mapping, TypedDict
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
@@ -24,13 +24,15 @@ from silence_as_control.types import DecisionResult
 from api.core_primitive import (
     CORE_FIXED_THRESHOLD,
     compute_instability_score,
-    fixed_threshold_release_decision,
 )
 from api.experimental_recovery import (
     get_experimental_margin,
     maybe_short_regen,
 )
 from api.por_runtime import (
+    RUNTIME_REVIEW_MARGIN,
+    RuntimeDecision,
+    bounded_runtime_release_decision,
     compute_adaptive_threshold,
     estimate_coherence,
     estimate_drift,
@@ -93,12 +95,15 @@ class EvaluateRequest(BaseModel):
     recent_coherences: list[float] = Field(default_factory=list)
 
 
+RuntimeResponseDecision = Literal["PROCEED", "NEEDS_REVIEW", "SILENCE"]
+
+
 class EvaluateResponse(BaseModel):
     drift: float
     coherence: float
     instability_score: float
     threshold: float
-    decision: str
+    decision: RuntimeResponseDecision
     release_output: str | None = None
     silence_token: str | None = None
     notes: list[str]
@@ -126,7 +131,7 @@ class CompleteResponse(BaseModel):
     coherence: float
     instability_score: float
     threshold: float
-    decision: str
+    decision: RuntimeResponseDecision
     release_output: str | None = None
     silence_token: str | None = None
     notes: list[str]
@@ -150,7 +155,7 @@ class RuntimeScore(TypedDict):
     coherence: float
     instability_score: float
     threshold: float
-    decision: str
+    decision: RuntimeDecision
     release_output: str | None
     silence_token: str | None
     notes: list[str]
@@ -220,15 +225,18 @@ def score_candidate_runtime(
     threshold: float,
     candidate_samples: list[str] | None = None,
 ) -> RuntimeScore:
-    """[RUNTIME] Score one candidate and apply the core release decision."""
+    """[RUNTIME] Score one candidate and apply the runtime release decision."""
     samples = candidate_samples or [candidate]
     drift, drift_notes = estimate_drift(samples)
     coherence, coherence_notes = estimate_coherence(prompt, candidate)
     instability = compute_instability_score(drift=drift, coherence=coherence)
     json_check = check_json_validity(prompt, candidate)
 
-    decision = fixed_threshold_release_decision(instability, threshold)
+    decision = bounded_runtime_release_decision(instability, threshold)
     notes = drift_notes + coherence_notes + json_check["notes"]
+
+    if decision == "NEEDS_REVIEW":
+        notes.append(f"runtime_review_band:margin={RUNTIME_REVIEW_MARGIN:.2f}")
 
     if json_check["expects_json"] and json_check["is_valid_json"] is False:
         decision = "SILENCE"

--- a/api/por_runtime.py
+++ b/api/por_runtime.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
+from typing import Literal
 
 from silence_as_control.config import (
     ADAPTIVE_THRESHOLD_ALPHA_DEFAULT,
@@ -39,6 +40,8 @@ MAX_EMBEDDING_CHARS_ENV_VAR = "MAX_EMBEDDING_CHARS"
 DEFAULT_MAX_EMBEDDING_CHARS = MAX_EMBEDDING_CHARS_DEFAULT
 EmbeddingFn = Callable[[str], list[float]]
 CUSTOM_EMBEDDING_FN: EmbeddingFn | None = None
+RuntimeDecision = Literal["PROCEED", "NEEDS_REVIEW", "SILENCE"]
+RUNTIME_REVIEW_MARGIN = 0.03
 
 
 @dataclass(frozen=True)
@@ -52,6 +55,30 @@ class AdaptiveThresholdConfig:
 
 def _clip(value: float, low: float = 0.0, high: float = 1.0) -> float:
     return max(low, min(value, high))
+
+
+def bounded_runtime_release_decision(
+    instability_score: float,
+    threshold: float,
+    review_margin: float = RUNTIME_REVIEW_MARGIN,
+) -> RuntimeDecision:
+    """[RUNTIME] Return a three-lane release decision around a threshold.
+
+    The core primitive remains binary. Runtime scoring uses this bounded, fixed
+    review band so borderline instability is held for human or downstream
+    review instead of being released or hard-silenced.
+    """
+    normalized_instability = _clip(instability_score)
+    normalized_threshold = _clip(threshold)
+    normalized_margin = max(0.0, review_margin)
+    lower_bound = _clip(round(normalized_threshold - normalized_margin, 10))
+    upper_bound = _clip(round(normalized_threshold + normalized_margin, 10))
+
+    if normalized_instability < lower_bound:
+        return "PROCEED"
+    if normalized_instability < upper_bound:
+        return "NEEDS_REVIEW"
+    return "SILENCE"
 
 
 def _stable_token_index(token: str, dim: int) -> int:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -105,6 +105,27 @@ def test_api_evaluate_stays_fixed_when_adaptive_disabled():
     assert payload["threshold"] == 0.39
 
 
+def test_api_evaluate_can_return_needs_review_in_runtime_review_band():
+    response = client.post(
+        "/por/evaluate",
+        json={
+            "prompt": "Summarize the incident risk in one sentence.",
+            "candidate": (
+                "The situation might be stable, but details are incomplete and "
+                "the release risk remains uncertain."
+            ),
+            "threshold": 0.36,
+            "use_adaptive_threshold": False,
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["decision"] == "NEEDS_REVIEW"
+    assert "release_output" not in payload
+    assert "silence_token" not in payload
+    assert any("runtime_review_band" in note for note in payload["notes"])
+
+
 def test_api_evaluate_can_silence_on_low_coherence_runtime_signal():
     response = client.post(
         "/por/evaluate",

--- a/tests/test_integration_api.py
+++ b/tests/test_integration_api.py
@@ -23,7 +23,7 @@ def test_integration_por_evaluate_deterministic_payload():
     assert response.status_code == 200
     payload = response.json()
     assert payload["threshold"] == 0.39
-    assert payload["decision"] in {"PROCEED", "SILENCE"}
+    assert payload["decision"] in {"PROCEED", "NEEDS_REVIEW", "SILENCE"}
     assert 0.0 <= payload["instability_score"] <= 1.0
 
 

--- a/tests/test_por_runtime.py
+++ b/tests/test_por_runtime.py
@@ -115,3 +115,15 @@ def test_core_release_decision_exact_threshold_equality_proceeds():
 
     assert fixed_threshold_release_decision(0.42, 0.42) == "PROCEED"
     assert fixed_threshold_release_decision(0.4200001, 0.42) == "SILENCE"
+
+
+def test_runtime_bounded_release_decision_uses_fixed_review_band():
+    assert por_runtime.bounded_runtime_release_decision(0.35, 0.39) == "PROCEED"
+    assert por_runtime.bounded_runtime_release_decision(0.39, 0.39) == "NEEDS_REVIEW"
+    assert por_runtime.bounded_runtime_release_decision(0.42, 0.39) == "SILENCE"
+
+
+def test_runtime_bounded_release_decision_clips_band_edges():
+    assert por_runtime.bounded_runtime_release_decision(0.0, 0.01) == "NEEDS_REVIEW"
+    assert por_runtime.bounded_runtime_release_decision(0.99, 1.0) == "NEEDS_REVIEW"
+    assert por_runtime.bounded_runtime_release_decision(1.0, 1.0) == "SILENCE"


### PR DESCRIPTION
### Motivation
- Provide a deterministic, runtime-visible intermediate decision for borderline instability so near-threshold candidates can be routed to human/review lanes instead of being automatically released or hard-silenced. 
- Preserve the paper-core PoR primitive as a binary gate while adding a simple runtime scaffold that is auditable and deterministic. 

### Description
- Introduced a bounded runtime review band with a fixed margin (`RUNTIME_REVIEW_MARGIN = 0.03`) and implemented `bounded_runtime_release_decision` in `api/por_runtime.py`, which returns `PROCEED` if `instability < threshold - margin`, `NEEDS_REVIEW` if `threshold - margin <= instability < threshold + margin`, and `SILENCE` otherwise. 
- Switched the runtime scorer to use the bounded runtime decision in `api/main.py` by calling `bounded_runtime_release_decision` and appended a `runtime_review_band:margin=` note when `NEEDS_REVIEW` is emitted, while preserving the core `compute_instability_score` semantics. 
- Updated response typing to explicitly include the runtime decisions (`PROCEED | NEEDS_REVIEW | SILENCE`) and ensured `NEEDS_REVIEW` does not expose `release_output` or `silence_token`. 
- Added tests that cover the review-band semantics and updated integration expectations: `tests/test_por_runtime.py`, `tests/test_api.py`, and `tests/test_integration_api.py` (no benchmark datasets changed). 

### Testing
- Ran the full automated test suite with `pytest -q`; result: `257 passed`, 1 unrelated Starlette/httpx deprecation warning. 
- New/updated unit tests covering the review-band behavior passed, including the bounded decision edge cases and a live `/por/evaluate` case that returns `NEEDS_REVIEW`.
- No provider-specific logic or benchmark data were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ed8db5be48326b31ea9984727ad55)