### PR TITLE
Add runtime decision contract docs for /por/evaluate

### DIFF
--- a/docs/api_walkthrough.md
+++ b/docs/api_walkthrough.md
@@ -60,7 +60,8 @@ Representative response shape:
 
 Notes:
 - Exact numeric values and notes depend on the input text.
-- If decision becomes `SILENCE`, output fields are gated and a silence token is returned.
+- Runtime decisions use tri-state mediation: `PROCEED`, `NEEDS_REVIEW`, or `SILENCE`.
+- For the full `/por/evaluate` runtime decision contract, including review-band semantics, see [Runtime Decision Contract](runtime_decision_contract.md).
 
 ## Mental model
 

--- a/docs/runtime_decision_contract.md
+++ b/docs/runtime_decision_contract.md
@@ -1,0 +1,52 @@
+# Runtime Decision Contract for `/por/evaluate`
+
+This page documents the applied runtime/API decision contract for reviewers and integrators using `POST /por/evaluate`.
+
+It describes release mediation at the runtime boundary. It does not redefine the PoR primitive core and does not change runtime behavior.
+
+## Layer boundary
+
+- **Generation is not release authority.** A generated candidate is only a candidate. The runtime gate decides whether that candidate may be released, held for review, or withheld as silence.
+- **The core primitive remains binary.** The primitive core computes instability from drift/coherence signals and compares that score to a threshold as a release-control primitive.
+- **The runtime/API layer uses tri-state mediation.** The API wraps the binary primitive with a bounded review band around the threshold so borderline candidates are routed to review instead of being auto-released or hard-silenced.
+
+## Runtime outcomes
+
+`POST /por/evaluate` returns one of three runtime decisions:
+
+| Decision | Runtime contract |
+| --- | --- |
+| `PROCEED` | `release_output` is returned. The candidate passed the runtime release gate. |
+| `NEEDS_REVIEW` | `release_output` is withheld for review. The candidate is inside the bounded review band. |
+| `SILENCE` | `release_output` is withheld and `silence_token` is returned. The candidate is outside the allowed release/review region. |
+
+For integrators, the operational rule is: only `PROCEED` carries releasable output. Both `NEEDS_REVIEW` and `SILENCE` withhold `release_output`, but they mean different downstream actions: review lane vs. silence/blocked output.
+
+## Review band formula
+
+The runtime computes an `instability` score and compares it with a resolved `threshold` using the current bounded review margin.
+
+Current margin: `0.03`.
+
+Decision bands:
+
+```text
+instability < threshold - margin
+  => PROCEED
+
+threshold - margin <= instability < threshold + margin
+  => NEEDS_REVIEW
+
+instability >= threshold + margin
+  => SILENCE
+```
+
+With the current margin, a threshold of `0.39` yields:
+
+- `instability < 0.36` => `PROCEED`
+- `0.36 <= instability < 0.42` => `NEEDS_REVIEW`
+- `instability >= 0.42` => `SILENCE`
+
+## Black-box compatibility
+
+This contract is black-box compatible. It does not require model internals, logits, or logprobs. Integrations may supply generated text from any candidate source, then use the runtime gate to decide whether output is released, routed to review, or withheld as silence.


### PR DESCRIPTION
### Motivation
- Provide a concise, reviewer-facing contract that documents tri-state runtime mediation for `POST /por/evaluate` and clarifies the boundary between generation and release authority.
- Make the runtime review-band semantics explicit for integrators so downstream systems know when `release_output` is releasable vs. withheld.

### Description
- Add `docs/runtime_decision_contract.md` describing that generation != release authority, that the core primitive remains binary, and that the runtime/API layer applies tri-state mediation (PROCEED / NEEDS_REVIEW / SILENCE).
- Document the runtime review-band formula and current margin (`0.03`), the operational meaning of `PROCEED` / `NEEDS_REVIEW` / `SILENCE`, and that the contract is black-box compatible (no logits/logprobs required).
- Link the new contract from `docs/api_walkthrough.md` so reviewers and integrators can find the full decision contract.
- No runtime behavior or tests were modified; this PR only adds documentation and a single walkthrough link.

### Testing
- Ran `python -m pytest tests/test_api.py tests/test_por_runtime.py`, with all tests passing (`30 passed, 0 failed`).
- No behavioral tests were changed and the runtime codebase was not modified by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1edd024a4c8326be60806546b3cc11)