### PR TITLE
docs: clarify runtime decision contract (bounded review-band edges & runtime overrides)

### DIFF
--- a/docs/runtime_decision_contract.md
+++ b/docs/runtime_decision_contract.md
@@ -28,24 +28,54 @@ The runtime computes an `instability` score and compares it with a resolved `thr
 
 Current margin: `0.03`.
 
-Decision bands:
+Before comparison, runtime clamps the review-band edges into `[0.0, 1.0]`:
 
 ```text
-instability < threshold - margin
+lower_bound = max(threshold - margin, 0.0)
+upper_bound = min(threshold + margin, 1.0)
+```
+
+Decision bands then use those bounded edges:
+
+```text
+instability < lower_bound
   => PROCEED
 
-threshold - margin <= instability < threshold + margin
+lower_bound <= instability < upper_bound
   => NEEDS_REVIEW
 
-instability >= threshold + margin
+instability >= upper_bound
   => SILENCE
 ```
 
 With the current margin, a threshold of `0.39` yields:
 
+- `lower_bound = 0.36`
+- `upper_bound = 0.42`
 - `instability < 0.36` => `PROCEED`
 - `0.36 <= instability < 0.42` => `NEEDS_REVIEW`
 - `instability >= 0.42` => `SILENCE`
+
+With the current margin, a threshold of `1.0` yields clipped review-band edges:
+
+- `lower_bound = 0.97`
+- `upper_bound = 1.0`
+- `instability < 0.97` => `PROCEED`
+- `0.97 <= instability < 1.0` => `NEEDS_REVIEW`
+- `instability >= 1.0` => `SILENCE`
+
+## Runtime policy overrides
+
+Certain runtime/API policies may override the nominal instability-band result. These policies preserve runtime safety requirements that are stricter than pure instability-band routing.
+
+For example, if the prompt expects JSON and runtime JSON validation fails, `/por/evaluate` forces `SILENCE` even if the instability score falls inside the nominal `PROCEED` or `NEEDS_REVIEW` band.
+
+In that case:
+
+- `release_output` is withheld
+- `silence_token` is returned
+
+This preserves structured-output safety above pure instability-band routing.
 
 ## Black-box compatibility
 


### PR DESCRIPTION
### Motivation

- The existing `docs/runtime_decision_contract.md` described the review-band formula but omitted that review-band edges are clamped into `[0.0, 1.0]` before comparison. 
- The docs also needed to keep the JSON/structured-output override behavior documented alongside the runtime decision contract. 
- This change is documentation-only and does not alter runtime behavior, API schema, or core primitives. 

### Description

- Updated `docs/runtime_decision_contract.md` to show the clamping formula `lower_bound = max(threshold - margin, 0.0)` and `upper_bound = min(threshold + margin, 1.0)`. 
- Rewrote the decision-band comparisons to use `lower_bound` and `upper_bound` and added the clipped example for `threshold = 1.0` with `margin = 0.03`. 
- Added a `Runtime policy overrides` section documenting that certain runtime/API policies (for example, failed JSON validation when JSON is expected) force `SILENCE`, withhold `release_output`, and return `silence_token` even if the instability score would otherwise fall into `PROCEED` or `NEEDS_REVIEW`. 
- The only file modified is `docs/runtime_decision_contract.md` and no runtime code, tests, or schemas were changed. 

### Testing

- Ran a small automated assertion script `python - <<'PY' ... PY` to verify the required text (`lower_bound`/`upper_bound` and runtime override examples) is present, which succeeded. 
- Ran `git diff --check` to ensure there are no leftover diff-check issues, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ee49d743083268f5552014eb967fa)