### PR TITLE
Add landing runtime trace panel

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -574,6 +574,49 @@ def root() -> HTMLResponse:
       color: #e8eef5;
       overflow-wrap: anywhere;
     }
+    .runtime-trace {
+      margin-top: 0.75rem;
+      padding: 0.75rem;
+      border: 1px solid #203247;
+      border-radius: 0.7rem;
+      background: linear-gradient(180deg, #0b1119 0%, #08101a 100%);
+      box-shadow: inset 0 1px 0 rgba(159, 208, 255, 0.05);
+    }
+    .runtime-trace h3 {
+      margin: 0 0 0.55rem;
+      color: #c6d2df;
+      font-size: 0.95rem;
+      font-weight: 900;
+    }
+    .trace-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+      gap: 0.45rem;
+    }
+    .trace-row {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 0.75rem;
+      border: 1px solid #1c2a3a;
+      border-radius: 0.5rem;
+      padding: 0.45rem 0.55rem;
+      background: #090e15;
+    }
+    .trace-label {
+      color: #8fa4ba;
+      font-size: 0.72rem;
+      font-weight: 800;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .trace-value {
+      color: #dcecff;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+      font-size: 0.82rem;
+      overflow-wrap: anywhere;
+      text-align: right;
+    }
     .release-output {
       margin-top: 0.75rem;
       padding-top: 0.75rem;
@@ -732,6 +775,70 @@ def root() -> HTMLResponse:
       return item;
     }
 
+    const REVIEW_MARGIN = 0.03;
+
+    function numericTraceValue(value) {
+      if (value === undefined || value === null || Number.isNaN(Number(value))) return "—";
+      return Number(value).toFixed(4);
+    }
+
+    function traceRow(label, value) {
+      const row = document.createElement("div");
+      row.className = "trace-row";
+
+      const labelElement = document.createElement("span");
+      labelElement.className = "trace-label";
+      labelElement.textContent = label;
+
+      const valueElement = document.createElement("span");
+      valueElement.className = "trace-value";
+      valueElement.textContent = formatValue(value);
+
+      row.append(labelElement, valueElement);
+      return row;
+    }
+
+    function decisionBand(decision, policyOverride) {
+      if (policyOverride) return "policy override → SILENCE";
+      if (decision === "PROCEED") return "below review band";
+      if (decision === "NEEDS_REVIEW") return "bounded review band";
+      if (decision === "SILENCE") return "above review band";
+      return "—";
+    }
+
+    function renderRuntimeTrace(data) {
+      const threshold = Number(data.threshold);
+      const lowerBound = Number.isNaN(threshold) ? null : Math.max(threshold - REVIEW_MARGIN, 0.0);
+      const upperBound = Number.isNaN(threshold) ? null : Math.min(threshold + REVIEW_MARGIN, 1.0);
+      const notes = Array.isArray(data.notes) ? data.notes : [];
+      const policyOverride = notes.includes("forced_silence_invalid_json");
+      const releaseAuthorized = data.decision === "PROCEED";
+      const silenceActive = data.decision === "SILENCE";
+
+      const panel = document.createElement("div");
+      panel.className = "runtime-trace";
+
+      const title = document.createElement("h3");
+      title.textContent = "Runtime trace";
+
+      const grid = document.createElement("div");
+      grid.className = "trace-grid";
+      grid.append(
+        traceRow("instability score", numericTraceValue(data.instability_score)),
+        traceRow("threshold", numericTraceValue(data.threshold)),
+        traceRow("review margin", REVIEW_MARGIN.toFixed(2)),
+        traceRow("lower bound", numericTraceValue(lowerBound)),
+        traceRow("upper bound", numericTraceValue(upperBound)),
+        traceRow("decision band", decisionBand(data.decision, policyOverride)),
+        traceRow("release_authorized", String(releaseAuthorized)),
+        traceRow("silence_active", String(silenceActive)),
+        traceRow("policy_override", String(policyOverride)),
+      );
+
+      panel.append(title, grid);
+      return panel;
+    }
+
     function renderSummary(data) {
       summary.replaceChildren();
 
@@ -762,7 +869,7 @@ def root() -> HTMLResponse:
         metric("Instability score", data.instability_score),
       );
 
-      summary.append(header, grid);
+      summary.append(header, grid, renderRuntimeTrace(data));
 
       if (data.release_output) {
         const release = document.createElement("div");

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -400,6 +400,10 @@ def test_api_root_endpoint():
     assert "Unsafe example" in response.text
     assert "Decision" in response.text
     assert "Coherence" in response.text
+    assert "Runtime trace" in response.text
+    assert "release_authorized" in response.text
+    assert "silence_active" in response.text
+    assert "policy_override" in response.text
     assert "Raw JSON" in response.text
 
 


### PR DESCRIPTION
### Motivation
- Surface a concise runtime explanation layer in the landing PoR demo so operators can inspect key runtime values derived from an existing `/por/evaluate` response without changing runtime behavior. 
- Keep changes UI-only: do not modify release semantics, scoring logic, or the API response schema.

### Description
- Added a compact dark-styled "Runtime trace" panel to the landing page that displays instability score, threshold, review margin (`0.03`), clipped lower/upper bounds, decision band, `release_authorized`, `silence_active`, and `policy_override` (derived from `forced_silence_invalid_json` in `notes`).
- Implemented the panel entirely client-side in the landing HTML: new CSS for `.runtime-trace` and helper JS (`REVIEW_MARGIN`, `numericTraceValue`, `traceRow`, `decisionBand`, `renderRuntimeTrace`) and appended its DOM after the decision metrics and before release output/raw JSON.
- Did not change runtime helpers, scoring logic, API signatures, or server-side semantics; UI uses the existing `EvaluateResponse` fields returned by `/por/evaluate`.
- Files changed: `api/main.py` (landing HTML/CSS/JS insertion) and `tests/test_api.py` (updated root endpoint test to assert presence of trace labels).

### Testing
- Ran the focused landing test: `python -m pytest tests/test_api.py::test_api_root_endpoint -q` and it passed.
- Ran the module tests: `python -m pytest tests/test_api.py -q` and the suite passed (`17 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ee8cfd504832699862e7256c86fd1)