### PR TITLE
Update README runtime surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,37 @@ It does **not** improve model weights. It controls release behavior.
 
 **Same model. Different decision.**
 
+## Live runtime surface
+
+Silence-as-Control now includes a live FastAPI runtime surface for `/por/evaluate`.
+The demo shows the core thesis in executable form: generation creates a candidate;
+runtime evaluation decides release authority.
+
+```text
+candidate generation
+→ runtime evaluation
+→ release gate
+→ PROCEED / NEEDS_REVIEW / SILENCE
+```
+
+The core primitive remains binary. The runtime/API layer adds a bounded review
+band around the threshold and exposes tri-state runtime mediation:
+
+- `PROCEED`: release output is returned.
+- `NEEDS_REVIEW`: release output is withheld for review.
+- `SILENCE`: release output is withheld and a silence token is returned.
+
+The live landing page surfaces the runtime flow, preset scenarios, a decision
+badge, metrics, runtime trace, and raw JSON evidence. Runtime trace observability
+includes instability score, threshold, review margin, lower/upper review-band
+bounds, decision band, release authorization state, silence state, and policy
+override visibility.
+
+This is a runtime-governance demonstration, not a production-readiness claim.
+
+See the [runtime decision contract](docs/runtime_decision_contract.md) and
+[API walkthrough](docs/api_walkthrough.md).
+
 ## Fast orientation
 
 ### Start


### PR DESCRIPTION
### Motivation
- Make the README first-click accurate for the current live runtime demo and surface for `/por/evaluate`. 
- Reflect that generation is separate from release authority and that the runtime/API layer exposes a bounded tri-state mediation around the core threshold. 
- Surface runtime observability fields and link to the formal runtime decision contract and API walkthrough while avoiding production-readiness claims.

### Description
- Add a focused `Live runtime surface` section near the top of `README.md` describing the runtime flow: generation → runtime evaluation → release gate → `PROCEED` / `NEEDS_REVIEW` / `SILENCE`.
- Clarify that the core primitive remains binary while the runtime/API layer adds a bounded review band and tri-state mediation.
- Document the live landing-page observability (decision badge, metrics, runtime trace, raw JSON evidence) and list runtime trace fields (instability score, threshold, review margin, lower/upper review-band bounds, decision band, release authorization, silence state, and policy override visibility).
- Link to `docs/runtime_decision_contract.md` and `docs/api_walkthrough.md` and retain existing README framing and evidence/replay boundaries.

### Testing
- Ran `python -m pytest tests/test_api.py tests/test_integration_api.py tests/test_por_runtime.py -q --basetemp=.pytest_tmp_runs/manual` and all tests passed (`33 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f1df730048326a691425985ce1bfe)