### PR TITLE
docs: add Integrator quick path to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,28 @@ This is a runtime-governance demonstration, not a production-readiness claim.
 See the [runtime decision contract](docs/runtime_decision_contract.md) and
 [API walkthrough](docs/api_walkthrough.md).
 
+## Integrator quick path
+
+```text
+external generator / agent / app
+→ candidate output
+→ POST /por/evaluate
+→ runtime decision
+→ downstream policy
+```
+
+An external system generates a candidate output, then SaC evaluates that
+candidate before release. By default, downstream policy should treat only
+`PROCEED` as release-authorized. Route `NEEDS_REVIEW` to human or policy
+review. Treat `SILENCE` as a decision to withhold the candidate and use a
+fallback, clarification, or escalation path.
+
+The API is black-box compatible: integrators can evaluate candidate outputs
+without access to model logits or logprobs. See the
+[runtime decision contract](docs/runtime_decision_contract.md),
+[API walkthrough](docs/api_walkthrough.md), and
+[builder integration guide](docs/builder_integration_guide.md).
+
 ## Fast orientation
 
 ### Start


### PR DESCRIPTION
### Motivation
- Make it immediately clear how an external generator, agent, app, or API wrapper should route candidate outputs through the three-state PoR runtime before release. 
- Surface conservative, actionable handling for the runtime decisions (`PROCEED`, `NEEDS_REVIEW`, `SILENCE`) so integrators can implement downstream policy. 
- Emphasize black-box compatibility so integrators know logits/logprobs are not required and link to the detailed contract and integration docs.

### Description
- Inserted a new `## Integrator quick path` section into `README.md` immediately after the `Live runtime surface` section that shows the flow: `external generator / agent / app` → candidate → `POST /por/evaluate` → runtime decision → downstream policy. 
- Clearly state default downstream handling: treat `PROCEED` as release-authorized, route `NEEDS_REVIEW` to human/policy review, and treat `SILENCE` as withholding the candidate in favor of fallback/clarification/escalation. 
- Note the API is black-box compatible and add direct links to `docs/runtime_decision_contract.md`, `docs/api_walkthrough.md`, and `docs/builder_integration_guide.md`. 
- This is a docs-only change; no code or runtime behavior was modified (file changed: `README.md`).

### Testing
- Ran `git diff --check` to validate there are no trailing whitespace or diff-check issues and it passed. 
- Verified the new section was inserted in `README.md` between `Live runtime surface` and `Fast orientation`. 
- No automated unit or integration tests were required because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f2d39b3e08326867be6b9a428a0d1)