### PR TITLE
Add runtime decision examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ This is a runtime-governance demonstration, not a production-readiness claim.
 See the [runtime decision contract](docs/runtime_decision_contract.md) and
 [API walkthrough](docs/api_walkthrough.md).
 
+### Runtime decision examples
+
+`PROCEED`
+
+![Runtime proceed example](docs/assets/runtime-surface-proceed.png)
+
+`NEEDS_REVIEW`
+
+![Runtime needs review example](docs/assets/runtime-surface-needs-review.png)
+
+`SILENCE` with runtime policy override
+
+![Runtime silence override example](docs/assets/runtime-surface-silence-policy-override.png)
+
 ## Integrator quick path
 
 ```text


### PR DESCRIPTION
### Motivation
- Provide quick visual examples of the runtime tri-state decisions so readers and integrators can immediately see `PROCEED`, `NEEDS_REVIEW`, and `SILENCE` behaviors in the live surface.

### Description
- Inserted a new "Runtime decision examples" section in `README.md` that references the existing screenshot assets `docs/assets/runtime-surface-proceed.png`, `docs/assets/runtime-surface-needs-review.png`, and `docs/assets/runtime-surface-silence-policy-override.png` and did not modify runtime behavior.

### Testing
- Ran `git diff --check` and verified the referenced asset files exist via file-existence checks, and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f401551e083269464ae980a7214f7)