### PR TITLE
Set repo-local pytest basetemp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,4 @@ where = ["src"]
 [tool.pytest.ini_options]
 pythonpath = ["src", "."]
 testpaths = ["tests"]
+addopts = "--basetemp=.pytest_tmp_runs"


### PR DESCRIPTION
### Motivation
- Avoid first-run Windows `tmp_path` PermissionError by making `python -m pytest` use a repo-local temp directory so developer runs are zero-friction.

### Description
- Add `addopts = "--basetemp=.pytest_tmp_runs"` under `[tool.pytest.ini_options]` in `pyproject.toml` so pytest uses the existing ignored `.pytest_tmp_runs/` directory instead of the system temp root.

### Testing
- Ran `python -m pytest` which completed with `257 passed, 1 warning` and ran `git diff --check` with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a213472130483268172e15fadffecf8)