### PR TITLE
Use repo-local timestamped pytest basetemp and remove pyproject basetemp addopt

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,35 +3,32 @@
 from __future__ import annotations
 
 import os
-import tempfile
-import uuid
+from datetime import UTC, datetime
 from pathlib import Path
 
 
-def _unique_basetemp(temp_root: Path) -> Path:
-    """Return a unique per-run pytest basetemp path below ``temp_root``."""
-
-    return temp_root / f"run-{os.getpid()}-{uuid.uuid4().hex}"
+_REPO_ROOT = Path(__file__).resolve().parent
+_PYTEST_TMP_RUNS = _REPO_ROOT / ".pytest_tmp_runs"
 
 
-def _windows_basetemp() -> Path:
-    """Choose the Windows pytest basetemp path, falling back outside the repo."""
+def _basetemp_was_requested(config) -> bool:  # noqa: ANN001
+    """Return whether pytest already has an explicit basetemp configured."""
 
-    repo_temp_root = Path(__file__).resolve().parent / ".pytest_tmp_runs"
+    return bool(config.option.basetemp)
 
-    try:
-        repo_temp_root.mkdir(parents=True, exist_ok=True)
-        return _unique_basetemp(repo_temp_root)
-    except OSError:
-        fallback_root = Path(tempfile.gettempdir()) / "silence-as-control-pytest"
-        fallback_root.mkdir(parents=True, exist_ok=True)
-        return _unique_basetemp(fallback_root)
+
+def _repo_local_basetemp() -> Path:
+    """Return a unique, repo-local pytest basetemp path for this run."""
+
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+    _PYTEST_TMP_RUNS.mkdir(parents=True, exist_ok=True)
+    return _PYTEST_TMP_RUNS / f"run-{timestamp}-{os.getpid()}"
 
 
 def pytest_configure(config):  # noqa: ANN001
-    """Use an isolated Windows pytest temp directory unless one was requested."""
+    """Use an isolated repo-local pytest basetemp unless one was requested."""
 
-    if os.name != "nt" or config.option.basetemp:
+    if _basetemp_was_requested(config):
         return
 
-    config.option.basetemp = str(_windows_basetemp())
+    config.option.basetemp = str(_repo_local_basetemp())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,4 +27,3 @@ where = ["src"]
 [tool.pytest.ini_options]
 pythonpath = ["src", "."]
 testpaths = ["tests"]
-addopts = "--basetemp=.pytest_tmp_runs"


### PR DESCRIPTION
### Motivation

- Provide a unique, repo-local pytest `basetemp` per run without relying on system temp directories or platform-specific branching.
- Avoid overriding an explicitly requested `basetemp` set by the user or CI configuration.
- Stop forcing a global `--basetemp` through `pyproject.toml` so test runs can opt in or be configured externally.

### Description

- Reworked `conftest.py` to introduce `_PYTEST_TMP_RUNS` and `_repo_local_basetemp()` that returns a timestamped run directory under the repository for `basetemp` instead of using `tempfile` and `uuid`.
- Added `_basetemp_was_requested(config)` to detect when pytest already has an explicit `basetemp` and early-return from `pytest_configure()` in that case.
- Simplified logic by removing the previous Windows-specific branch and replaced it with a repo-local default; updated `pytest_configure()` to set `config.option.basetemp` to the repo-local path when not requested.
- Removed the `addopts = "--basetemp=.pytest_tmp_runs"` setting from `pyproject.toml` so `basetemp` is no longer forced globally.

### Testing

- Ran the test suite with `pytest` after the changes and all tests completed successfully with no failures.
- Verified that `pytest_configure()` does not override an explicitly provided `--basetemp` option during test invocation.
- Confirmed that the repo-local directory `./.pytest_tmp_runs` is created and timestamped run directories are produced for test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2141cc53c48326b2879caa03f00d6f)