### PR TITLE
Keep conftest compatible with Python 3.10

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -20,7 +20,7 @@ def _basetemp_was_requested(config) -> bool:  # noqa: ANN001
 def _repo_local_basetemp() -> Path:
     """Return a unique, repo-local pytest basetemp path for this run."""
 
-    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
     _PYTEST_TMP_RUNS.mkdir(parents=True, exist_ok=True)
     return _PYTEST_TMP_RUNS / f"run-{timestamp}-{os.getpid()}"
 


### PR DESCRIPTION
### Motivation
- Fix pytest import failure on Python 3.10 caused by use of the Python 3.11-only `datetime.UTC` by switching to a 3.10-compatible timezone API while preserving existing basetemp semantics.

### Description
- In `conftest.py` replace `from datetime import UTC, datetime` with `from datetime import datetime, timezone` and change `datetime.now(UTC)` to `datetime.now(timezone.utc)` while keeping the repo-local per-run basetemp and explicit `--basetemp` override behavior unchanged.

### Testing
- Ran `python -m pytest` and `python -m pytest --basetemp 'C:\Users\User\pytest_tmp_sac'` which passed (257 tests, 1 warning), `PYENV_VERSION=3.10.20 python -m py_compile conftest.py` succeeded, and `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a214ea741288326b7c3e40bcdaa02c7)