### PR TITLE
docs: document Windows pytest basetemp fallback

### DIFF
--- a/docs/direct_reproduction_guide.md
+++ b/docs/direct_reproduction_guide.md
@@ -34,13 +34,11 @@ Assumptions:
 - Works on Windows PowerShell, macOS, or Linux shell.
 - Provider keys are not required for this reproduction path.
 
-Windows note: if pytest temp-folder permissions or file locks cause failures, use a unique `--basetemp` path (shown below).
-
-Repository-local fallback command:
+Windows note: if pytest fails before repository code runs with `PermissionError` in `...\pytest-of-User`, treat it as an environment-level pytest temp-directory issue. Use a unique `--basetemp` path:
 
 ```powershell
-New-Item -ItemType Directory .pytest_tmp_runs -Force
-python -m pytest --basetemp=.pytest_tmp_runs/manual
+$bt = "C:\Users\User\pytest-sac-" + (Get-Date -Format "yyyyMMdd-HHmmss")
+python -m pytest -q --basetemp="$bt"
 ```
 
 ## 3. Fresh checkout setup

--- a/docs/first_run_checklist.md
+++ b/docs/first_run_checklist.md
@@ -31,6 +31,15 @@ Expected:
 
     passed
 
+Windows troubleshooting note:
+
+If pytest fails with `PermissionError` in `C:\Users\User\AppData\Local\Temp\pytest-of-User`, this is an environment-level pytest temp-directory issue, not a repository failure. Use a unique `--basetemp` path:
+
+```powershell
+$bt = "C:\Users\User\pytest-sac-" + (Get-Date -Format "yyyyMMdd-HHmmss")
+python -m pytest -q --basetemp="$bt"
+```
+
 ## 3. Run canonical runtime demo
 
 Run:


### PR DESCRIPTION
### Motivation

- On Windows, pytest can fail before repository code runs when the default pytest temp root is locked or has broken permissions, producing `PermissionError` pointing at `...\pytest-of-User`.
- The intent is to clarify this is an environment-level pytest temp-directory issue and provide a minimal, conservative PowerShell fallback that runs tests with a unique `--basetemp`.
- If pytest fails with `PermissionError` in `...\pytest-of-User`, use a unique `--basetemp`.

### Description

- Add a short Windows troubleshooting note to `docs/direct_reproduction_guide.md` that explains the `PermissionError` is an environment-level pytest temp-root issue and shows a PowerShell fallback using a unique `--basetemp`.
- Insert the same concise troubleshooting note into `docs/first_run_checklist.md` so first-run readers see the guidance in the checklist.
- This is a docs-only change; no runtime code, tests, pytest configuration, conftest, benchmark logic, or artifacts were modified.

### Testing

- Ran `git diff --check` to validate the edits and there were no whitespace or diff errors.
- No automated runtime tests were run because this is a documentation-only change; manual validation can be done with `python -m pytest -q --basetemp="$bt"` as shown in the docs.
- The change is minimal and low-risk since it only updates two markdown files (`docs/direct_reproduction_guide.md` and `docs/first_run_checklist.md`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21bc1442748326a7ee27ddc0f08fc1)