### PR TITLE
docs: add Windows pytest basetemp troubleshooting and PowerShell snippet

### DIFF
--- a/docs/direct_reproduction_guide.md
+++ b/docs/direct_reproduction_guide.md
@@ -34,13 +34,11 @@ Assumptions:
 - Works on Windows PowerShell, macOS, or Linux shell.
 - Provider keys are not required for this reproduction path.
 
-Windows note: if pytest temp-folder permissions or file locks cause failures, use a unique `--basetemp` path (shown below).
-
-Repository-local fallback command:
+Windows note: if pytest fails before repository code runs with `PermissionError` in `...\pytest-of-User`, treat it as an environment-level pytest temp-directory issue. Use a unique `--basetemp` path:
 
 ```powershell
-New-Item -ItemType Directory .pytest_tmp_runs -Force
-python -m pytest --basetemp=.pytest_tmp_runs/manual
+$bt = Join-Path $env:TEMP ("pytest-sac-" + (Get-Date -Format "yyyyMMdd-HHmmss"))
+python -m pytest -q --basetemp="$bt"
 ```
 
 ## 3. Fresh checkout setup

--- a/docs/first_run_checklist.md
+++ b/docs/first_run_checklist.md
@@ -31,6 +31,15 @@ Expected:
 
     passed
 
+Windows troubleshooting note:
+
+If pytest fails with `PermissionError` in `C:\Users\User\AppData\Local\Temp\pytest-of-User`, this is an environment-level pytest temp-directory issue, not a repository failure. Use a unique `--basetemp` path:
+
+```powershell
+$bt = Join-Path $env:TEMP ("pytest-sac-" + (Get-Date -Format "yyyyMMdd-HHmmss"))
+python -m pytest -q --basetemp="$bt"
+```
+
 ## 3. Run canonical runtime demo
 
 Run:


### PR DESCRIPTION
### Motivation
- Clarify and standardize guidance for Windows users encountering `PermissionError` from pytest temp directories so failures are attributed to environment issues rather than repository code.
- Provide an explicit, reproducible PowerShell command for creating a unique pytest `--basetemp` path to avoid file-lock and permission issues on Windows.

### Description
- Updated `docs/direct_reproduction_guide.md` to replace the previous fallback note with a clearer Windows troubleshooting explanation and a PowerShell snippet that sets `--basetemp` using a timestamped directory in `$env:TEMP` and runs `python -m pytest -q --basetemp="$bt"`.
- Added an analogous troubleshooting note and the same PowerShell `--basetemp` snippet to `docs/first_run_checklist.md` so both guides show the recommended workaround.
- Adjusted surrounding explanatory text to indicate these failures are environment-level pytest temp-directory issues rather than repository test failures.

### Testing
- No code changes were made, so no automated unit tests were modified or required for this PR.
- Documentation build or linting was not run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21bc1442748326a7ee27ddc0f08fc1)