### PR TITLE
docs: stabilize v0.7 evidence navigation

### DIFF
--- a/docs/evidence_map.md
+++ b/docs/evidence_map.md
@@ -214,6 +214,36 @@ python -m pytest tests/test_release_risk_benchmark.py -q
 python -m pytest tests/test_api.py -q
 ```
 
+
+## Release-risk v4 deterministic capture/replay evidence
+
+Scope:
+
+- Deterministic no-key fixture capture and replay.
+
+Artifacts:
+
+- `benchmarks/release_risk_v4_capture_candidates.py`
+- `benchmarks/release_risk_v4_fixture_replay.py`
+- `docs/release_risk_v4_capture_to_replay.md`
+- `docs/release_risk_benchmark_index.md`
+- `tests/test_release_risk_v4_capture_candidates.py`
+- `tests/test_release_risk_v4_fixture_replay.py`
+
+Proof signals:
+
+- `generation_mode`: `fixture_capture`
+- `model`: `fixture-v4-capture-synthetic-1`
+- `provider`: `None`
+
+Interpretation boundaries:
+
+- Deterministic fixture capture/replay evidence only.
+- No API keys required.
+- Not provider-backed evidence.
+- Not production safety evidence.
+- Optional provider/local capture remains future work.
+
 ## LangChain/OpenAI action-risk Run 06 progression
 
 Run 06 action-risk evidence is an integration/deployment validation surface for release control, not a primitive-core result and not a universal AI safety claim. The strongest supported claim is: same model, same dataset, same threshold, no PoR core change; release-layer hardening changed the review/release profile.

--- a/docs/project_crystallization_status.md
+++ b/docs/project_crystallization_status.md
@@ -42,6 +42,10 @@ The project is currently converting long-running conceptual, repository, and pub
   - links runtime/replay artifacts into the evidence layer
   - preserves conservative evidence boundaries
 
+- v0.7 deterministic no-key capture/replay evidence path
+  - links candidate capture, fixture replay, replay summaries, and evidence navigation
+  - keeps provider-backed replay artifacts marked as pending/future
+
 ## Stable primitives
 
 ```text
@@ -78,6 +82,8 @@ evidence map scaffold: done
 curated archive evidence summary: scaffolded
 provenance/evidence graph layer: scaffolded
 runtime/replay evidence linkage: linked
+deterministic v0.7 no-key capture/replay evidence path: linked
+provider-backed replay artifacts: pending/future
 memory-admission prototype: pending
 future hosted/runtime traces: pending
 ```

--- a/docs/project_navigation.md
+++ b/docs/project_navigation.md
@@ -22,6 +22,10 @@ docs/
   ├─ evidence_graph.md               ← compact claim topology
   ├─ chronology.md                   ← project evolution timeline
   ├─ runtime_evidence_linkage.md     ← runtime/replay evidence links
+  ├─ release_risk_benchmark_index.md ← release-risk benchmark lineage
+  ├─ release_risk_v4_capture_to_replay.md ← v4 no-key capture/replay path
+  ├─ external_reviewer_packet.md     ← external technical review packet
+  ├─ builder_integration_guide.md    ← app/agent/workflow integration guide
   ├─ runtime_observability.md        ← telemetry verification
   ├─ provider_configuration.md       ← API/provider setup
   ├─ release_control_services.md     ← pilot/integration interest
@@ -41,6 +45,10 @@ issues/
 | Understand the architecture split | [Architecture](architecture.md) |
 | Understand agentic release-control | [Agentic release-control](agentic_release_control.md) |
 | Check claims and artifacts | [Evidence map](evidence_map.md) |
+| Follow release-risk benchmark lineage | [Release-risk benchmark index](release_risk_benchmark_index.md) |
+| Reproduce the v4 no-key capture/replay path | [Release-risk v4 capture-to-replay](release_risk_v4_capture_to_replay.md) |
+| Review as an external technical reader | [External reviewer packet](external_reviewer_packet.md) |
+| Integrate the release gate into an app/agent/workflow | [Builder integration guide](builder_integration_guide.md) |
 | Follow project chronology | [Project chronology](chronology.md) |
 | Inspect runtime telemetry | [Runtime observability](runtime_observability.md) |
 | Configure provider-backed completion | [Provider configuration](provider_configuration.md) |

--- a/docs/runtime_evidence_linkage.md
+++ b/docs/runtime_evidence_linkage.md
@@ -34,6 +34,8 @@ candidate capture
 → evidence map
 ```
 
+The v4 capture-to-replay flow is the current deterministic no-key reviewer path. Provider/local capture remains optional future work; runtime behavior should stay separate from model quality claims.
+
 ### Release-risk examples
 
 ```text


### PR DESCRIPTION
### Motivation

- Improve documentation navigation and cohesion so external reviewers and builders can find the stable v0.7 deterministic no-key v4 capture→replay evidence path without changing runtime or benchmark behavior. 
- Keep changes conservative, docs-only, and explicitly separated from runtime/benchmark/test/artifact logic or new claims.

### Description

- Add concise navigation entries to `docs/project_navigation.md` for the release-risk benchmark lineage, the v4 no-key capture/replay path, an external reviewer packet, and the builder integration guide. 
- Add a compact `Release-risk v4 deterministic capture/replay evidence` section to `docs/evidence_map.md` that lists scope, artifacts, proof signals, and conservative interpretation boundaries. 
- Add a short clarifying note to `docs/runtime_evidence_linkage.md` stating that the v4 capture-to-replay flow is the current deterministic no-key reviewer path and that provider/local capture remain optional future work. 
- Mark the deterministic v0.7 no-key capture/replay evidence path as linked in `docs/project_crystallization_status.md` while keeping provider-backed replay artifacts pending/future. 
- Files changed: `docs/project_navigation.md`, `docs/evidence_map.md`, `docs/runtime_evidence_linkage.md`, `docs/project_crystallization_status.md` and no runtime/benchmark/test/artifact/metric changes were made. 

### Testing

- Ran `git diff --check` and confirmed no whitespace/diff issues. 
- Ran the test suite with `python -m pytest -q --basetemp="/tmp/pytest-sac-nav-XXXXXXXX"`, which completed successfully with `257 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21cccaa77c8326bbad0f5533f20561)