### PR TITLE
docs: add v0.7 reviewer reproduction path

### DIFF
--- a/docs/external_reviewer_packet.md
+++ b/docs/external_reviewer_packet.md
@@ -60,12 +60,31 @@ Optional output path:
 python scripts/por_gate_cli.py --input examples/por_gate_input.json --output outputs/por_gate_decision.json
 ```
 
+v0.7 no-key capture/replay path:
+
+```bash
+python benchmarks/release_risk_v4_capture_candidates.py --mode fixture --output outputs/release_risk_v4_fixture_capture.jsonl
+python benchmarks/release_risk_v4_fixture_replay.py --input outputs/release_risk_v4_fixture_capture.jsonl --results-dir outputs/release_risk_v4_replay_results
+```
+
+Expected proof signal:
+
+```text
+generation_mode: fixture_capture
+model: fixture-v4-capture-synthetic-1
+provider: None
+```
+
+The v0.7 path is deterministic fixture capture/replay evidence only; optional provider/local capture remains future work.
+
 Deterministic paths do not require provider credentials.
 
 ## 5. What evidence to inspect
 
 - [docs/evidence_map.md](evidence_map.md)
 - [docs/release_risk_benchmark_index.md](release_risk_benchmark_index.md)
+- [docs/release_risk_v4_capture_to_replay.md](release_risk_v4_capture_to_replay.md)
+- [docs/runtime_evidence_linkage.md](runtime_evidence_linkage.md)
 - [docs/external_integration.md](external_integration.md)
 - [docs/applied_bridges.md](applied_bridges.md)
 - [README.md](../README.md)
@@ -155,7 +174,8 @@ Avoid:
 1. [README.md](../README.md)
 2. [docs/plain_english_pitch.md](plain_english_pitch.md)
 3. [docs/external_reviewer_packet.md](external_reviewer_packet.md)
-4. [docs/external_integration.md](external_integration.md)
-5. [docs/evidence_map.md](evidence_map.md)
-6. [docs/release_risk_benchmark_index.md](release_risk_benchmark_index.md)
-7. [docs/applied_bridges.md](applied_bridges.md)
+4. [docs/evidence_map.md](evidence_map.md)
+5. [docs/release_risk_benchmark_index.md](release_risk_benchmark_index.md)
+6. [docs/release_risk_v4_capture_to_replay.md](release_risk_v4_capture_to_replay.md)
+7. [docs/runtime_evidence_linkage.md](runtime_evidence_linkage.md)
+8. [docs/external_integration.md](external_integration.md)


### PR DESCRIPTION
### Motivation
- Add a compact, reproducible v0.7 deterministic no-key fixture capture/replay path to the external reviewer packet so reviewers can reproduce the new release-risk v4 evidence flow.
- Improve reviewer navigation by linking the new capture→replay guidance and runtime-evidence linkage docs from the packet so evidence surfaces are easier to find.

### Description
- Updated `docs/external_reviewer_packet.md` to add a `v0.7 no-key capture/replay path` subsection containing the two reproduction commands for fixture capture and fixture replay. 
- Added a compact expected proof signal block (`generation_mode: fixture_capture`, `model: fixture-v4-capture-synthetic-1`, `provider: None`) and a single-sentence note that the v0.7 path is deterministic fixture-only and that provider/local capture is future work. 
- Added links in the "What evidence to inspect" section to `docs/release_risk_v4_capture_to_replay.md` and `docs/runtime_evidence_linkage.md` and updated the compact "Best reading order" to include those docs. 
- Change is docs-only and does not alter runtime code, tests, benchmarks, artifacts, metrics, or introduce provider-backed or production-safety claims. 

### Testing
- Ran `git diff --check` with no issues reported. 
- Ran the test suite with `python -m pytest -q --basetemp="$bt"` which completed successfully (`257 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21d6dcbfd883268070b1012dccb616)