### PR TITLE
docs: add reviewer console usage guide

### DIFF
--- a/docs/external_reviewer_packet.md
+++ b/docs/external_reviewer_packet.md
@@ -91,6 +91,7 @@ Deterministic paths do not require provider credentials.
 
 Reviewer/demo surface, not evidence:
 
+- [docs/reviewer_console_guide.md](reviewer_console_guide.md) — usage guide for inspecting the standalone reviewer console without treating it as reproducible benchmark/replay evidence.
 - [examples/sac_reviewer_console.html](../examples/sac_reviewer_console.html) — standalone browser reviewer console for local visual/offline inspection of the release gate. Live API mode defaults to same-origin `/por/evaluate`; full remote URLs require CORS-enabled API access.
 
 Evidence is scoped to specific tasks, thresholds, datasets, and signal regimes.

--- a/docs/project_navigation.md
+++ b/docs/project_navigation.md
@@ -25,6 +25,7 @@ docs/
   ├─ release_risk_benchmark_index.md ← release-risk benchmark lineage
   ├─ release_risk_v4_capture_to_replay.md ← v4 no-key capture/replay path
   ├─ external_reviewer_packet.md     ← external technical review packet
+  ├─ reviewer_console_guide.md       ← standalone reviewer console usage
   ├─ builder_integration_guide.md    ← app/agent/workflow integration guide
   ├─ runtime_observability.md        ← telemetry verification
   ├─ provider_configuration.md       ← API/provider setup
@@ -48,7 +49,7 @@ issues/
 | Follow release-risk benchmark lineage | [Release-risk benchmark index](release_risk_benchmark_index.md) |
 | Reproduce the v4 no-key capture/replay path | [Release-risk v4 capture-to-replay](release_risk_v4_capture_to_replay.md) |
 | Review as an external technical reader | [External reviewer packet](external_reviewer_packet.md) |
-| Try the standalone reviewer console | [../examples/sac_reviewer_console.html](../examples/sac_reviewer_console.html) |
+| Try the standalone reviewer console | [Reviewer console guide](reviewer_console_guide.md) and [../examples/sac_reviewer_console.html](../examples/sac_reviewer_console.html) |
 | Integrate the release gate into an app/agent/workflow | [Builder integration guide](builder_integration_guide.md) |
 | Follow project chronology | [Project chronology](chronology.md) |
 | Inspect runtime telemetry | [Runtime observability](runtime_observability.md) |

--- a/docs/reviewer_console_guide.md
+++ b/docs/reviewer_console_guide.md
@@ -1,0 +1,64 @@
+# Reviewer console usage guide
+
+## 1. Purpose
+
+The standalone reviewer console is a browser-based visual inspection surface for the Silence-as-Control release gate.
+
+It demonstrates the release-gate flow:
+
+```text
+candidate generation → runtime evaluation → release gate → PROCEED / NEEDS_REVIEW / SILENCE
+```
+
+Use it to inspect how a candidate, threshold, mode selection, and result display fit together in the reviewer-facing flow.
+
+Do not treat the console as benchmark evidence or production safety evidence. It is a demo/reviewer surface, not a reproducible evaluation artifact.
+
+## 2. How to open it
+
+Open [`examples/sac_reviewer_console.html`](../examples/sac_reviewer_console.html) in a browser for local visual/offline inspection.
+
+Local demo mode is the default. No provider key is required for local inspection.
+
+## 3. Local demo mode
+
+Local demo mode uses approximate deterministic demo logic in the browser. It is useful for visual inspection of the form, presets, release-gate states, and result layout.
+
+Local demo mode is not Python runtime parity. It is not benchmark evidence, and it is not a substitute for the repository replay or benchmark paths.
+
+## 4. Live API mode
+
+Live API mode is the canonical runtime/API path when the console is served from an allowed origin.
+
+The default endpoint is `/por/evaluate`. This works when the reviewer console is served from the same origin as the API.
+
+Full remote URLs require CORS-enabled API access. Live API mode may fail in `file://` or static-host scenarios because browser CORS policy can block requests to the API.
+
+## 5. Adaptive threshold fields
+
+`use_adaptive_threshold` requires recent drift/coherence metrics to exercise adaptive behavior.
+
+The `recent_drifts` and `recent_coherences` inputs are optional comma-separated fields. Leaving them blank is closer to the default/fixed threshold path.
+
+The reviewer-entered threshold is sent as the adaptive base when adaptive thresholding is enabled.
+
+## 6. Reading the result
+
+`PROCEED` means the released output is shown.
+
+`NEEDS_REVIEW` means the output is routed for bounded review instead of being released automatically.
+
+`SILENCE` means the output is blocked.
+
+In Live API mode, the review band is server-side policy. In Local demo mode, the review band is the threshold plus or minus the reviewer-entered review margin.
+
+## 7. Evidence boundary
+
+Use the reviewer console for visual inspection only. Use the benchmark and replay documentation for reproducible evidence:
+
+- [Evidence map](evidence_map.md)
+- [Release-risk v4 capture-to-replay](release_risk_v4_capture_to_replay.md)
+- [Runtime evidence linkage](runtime_evidence_linkage.md)
+- [Release-risk benchmark index](release_risk_benchmark_index.md)
+
+The reviewer console can help external reviewers understand the release-gate interaction, but reproducible evidence belongs to the replay, benchmark, and evidence-linkage paths above.


### PR DESCRIPTION
### Motivation
- Provide a concise, reviewer-facing guide that frames the standalone HTML reviewer console as a visual/demo inspection surface rather than reproducible benchmark or production-safety evidence.
- Surface how to open and use the console (Local demo vs Live API), explain adaptive threshold inputs, how to read results, and point reviewers to the canonical evidence/replay docs.

### Description
- Add `docs/reviewer_console_guide.md` with sections for Purpose, How to open it, Local demo mode, Live API mode, Adaptive threshold fields, Reading the result, and Evidence boundary.
- Link the new guide from `docs/project_navigation.md` and add a pointer in `docs/external_reviewer_packet.md` under the reviewer/demo surface so external reviewers find the guide alongside the standalone HTML console.
- Changes are docs-only and do not modify runtime code, API behavior, benchmarks, tests, or the example HTML itself.

### Testing
- Ran `git diff --check` which reported no whitespace or diff-check issues.
- Ran the test suite with `python -m pytest -q --basetemp="$bt"` which completed successfully with `257 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22790340a8832692ae78fb3cad893f)