### PR TITLE
docs: add pilot case log template

### DIFF
--- a/docs/external_reviewer_packet.md
+++ b/docs/external_reviewer_packet.md
@@ -87,6 +87,7 @@ Deterministic paths do not require provider credentials.
 - [docs/runtime_evidence_linkage.md](runtime_evidence_linkage.md)
 - [docs/external_integration.md](external_integration.md)
 - [docs/pilot_evaluation_packet.md](pilot_evaluation_packet.md)
+- [docs/pilot_case_log_template.md](pilot_case_log_template.md)
 - [docs/applied_bridges.md](applied_bridges.md)
 - [README.md](../README.md)
 
@@ -148,7 +149,7 @@ It uses compatible state/schema ideas: `PROCEED` / `NEEDS_REVIEW` / `SILENCE`.
 - Thresholds must be calibrated per task/model/signal regime.
 - `NEEDS_REVIEW` review flags are deterministic and intentionally scoped.
 - Provider-backed generation paths require separate configuration.
-- Real pilots should define their own release policy and failure criteria. For a conservative first-pass evaluation shape, see the [pilot evaluation packet](pilot_evaluation_packet.md).
+- Real pilots should define their own release policy and failure criteria. For a conservative first-pass evaluation shape, see the [pilot evaluation packet](pilot_evaluation_packet.md) and [pilot case log template](pilot_case_log_template.md).
 
 ## 9. Good first pilot use cases
 

--- a/docs/pilot_case_log_template.md
+++ b/docs/pilot_case_log_template.md
@@ -1,0 +1,83 @@
+# Pilot case log template
+
+## 1. Purpose
+
+This template is for bounded pilot logging during a first Silence-as-Control (SaC) evaluation. It helps reviewers compare release-by-default behavior against SaC-style release mediation, where a generated candidate is evaluated before it is allowed to proceed.
+
+The log is not benchmark evidence by itself. It is not production deployment evidence. It is a practical traceability surface for manual review: each candidate, baseline release assumption, SaC decision, review reason, and reviewer interpretation should remain inspectable together.
+
+## 2. When to use this template
+
+Use this template:
+
+- during a first 25–100 case pilot
+- for one narrow workflow or task family
+- before production enforcement
+- when comparing candidate outputs against release-gate decisions
+
+Do not use a first pilot log to make broad production, provider-backed, or universal safety claims.
+
+## 3. Case log table
+
+| case_id | workflow | prompt_or_task | candidate_summary | baseline_release | sac_decision | review_reason | human_label | release_outcome_note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+|  |  |  |  |  |  |  |  |  |
+
+Column meanings:
+
+- `case_id`: stable pilot identifier.
+- `workflow`: narrow pilot workflow or task family.
+- `prompt_or_task`: short task description.
+- `candidate_summary`: compact summary, not necessarily the full raw output.
+- `baseline_release`: whether the candidate would have been released by default.
+- `sac_decision`: `PROCEED` / `NEEDS_REVIEW` / `SILENCE`.
+- `review_reason`: short explanation, trace, or policy note.
+- `human_label`: optional reviewer label such as `acceptable`, `risky`, `wrong`, `unsafe`, or `unclear`.
+- `release_outcome_note`: final reviewer interpretation.
+
+## 4. Decision values
+
+- `PROCEED`: release the candidate.
+- `NEEDS_REVIEW`: do not auto-release; route the candidate for bounded review.
+- `SILENCE`: withhold the candidate.
+
+## 5. Suggested labels
+
+Optional human labels include:
+
+- `acceptable`
+- `review-worthy`
+- `wrong`
+- `unsafe`
+- `unclear`
+- `policy-sensitive`
+- `insufficient-evidence`
+
+## 6. Minimal pilot summary
+
+```text
+Total cases:
+Baseline released:
+SaC PROCEED:
+SaC NEEDS_REVIEW:
+SaC SILENCE:
+False-negative releases found:
+False-positive reviews found:
+Notes:
+```
+
+## 7. Evidence boundary
+
+This log is pilot evidence only for the scoped workflow, candidate set, thresholds, and policy settings. It does not prove model correctness, guarantee safety, or prove universal threshold transfer.
+
+Interpret the log together with the [Pilot evaluation packet](pilot_evaluation_packet.md) and [Evidence map](evidence_map.md), especially when deciding which claims are supported by repository-visible evidence and which claims remain outside the current evidence boundary.
+
+## 8. Relationship to existing docs
+
+Use this template alongside:
+
+- [Pilot evaluation packet](pilot_evaluation_packet.md)
+- [Reviewer console guide](reviewer_console_guide.md)
+- [Evidence map](evidence_map.md)
+- [Runtime evidence linkage](runtime_evidence_linkage.md)
+- [Release-risk benchmark index](release_risk_benchmark_index.md)

--- a/docs/pilot_evaluation_packet.md
+++ b/docs/pilot_evaluation_packet.md
@@ -79,6 +79,8 @@ Collect enough evidence to support a narrow technical review:
 - notes/traces where available
 - comparison to release-by-default
 
+For a practical logging format, see [docs/pilot_case_log_template.md](pilot_case_log_template.md).
+
 Evidence should remain tied to the pilot's workflow, candidate set, thresholds, and policy settings. It should not be generalized into provider-backed, universal-safety, or production-readiness claims without separate evidence.
 
 ## 8. Recommended first pilot size
@@ -97,6 +99,7 @@ The first goal is to understand release-control behavior and reviewer workload o
 
 Use this packet alongside the existing documentation and reviewer surfaces:
 
+- [Pilot case log template](pilot_case_log_template.md)
 - [Reviewer console guide](reviewer_console_guide.md)
 - [Standalone reviewer console](../examples/sac_reviewer_console.html)
 - [Evidence map](evidence_map.md)

--- a/docs/project_navigation.md
+++ b/docs/project_navigation.md
@@ -28,6 +28,7 @@ docs/
   ├─ reviewer_console_guide.md       ← standalone reviewer console usage
   ├─ builder_integration_guide.md    ← app/agent/workflow integration guide
   ├─ pilot_evaluation_packet.md      ← bounded pilot evaluation path
+  ├─ pilot_case_log_template.md       ← bounded pilot case logging
   ├─ runtime_observability.md        ← telemetry verification
   ├─ provider_configuration.md       ← API/provider setup
   ├─ release_control_services.md     ← pilot/integration interest
@@ -53,6 +54,7 @@ issues/
 | Try the standalone reviewer console | [Reviewer console guide](reviewer_console_guide.md) and [../examples/sac_reviewer_console.html](../examples/sac_reviewer_console.html) |
 | Integrate the release gate into an app/agent/workflow | [Builder integration guide](builder_integration_guide.md) |
 | Evaluate a bounded pilot | [Pilot evaluation packet](pilot_evaluation_packet.md) |
+| Log pilot cases | [Pilot case log template](pilot_case_log_template.md) |
 | Follow project chronology | [Project chronology](chronology.md) |
 | Inspect runtime telemetry | [Runtime observability](runtime_observability.md) |
 | Configure provider-backed completion | [Provider configuration](provider_configuration.md) |


### PR DESCRIPTION
### Motivation

- Provide a concise, practical logging template for bounded pilot evaluations (25–100 cases) to improve reviewer traceability when comparing release-by-default behavior against SaC-style release mediation. 
- Surface a reviewer-facing, reproducible trace format that complements the existing pilot packet and reviewer console without asserting production readiness or universal safety.

### Description

- Add `docs/pilot_case_log_template.md` containing the required sections: Purpose, When to use, Case log table (with the specified columns), Decision values, Suggested labels, Minimal pilot summary, Evidence boundary, and Relationship to existing docs. 
- Link the new template from the high-level docs map by updating `docs/project_navigation.md` and add short references to it in `docs/pilot_evaluation_packet.md` and `docs/external_reviewer_packet.md`. 
- Changes are documentation-only and limited to `docs/pilot_case_log_template.md`, `docs/project_navigation.md`, `docs/pilot_evaluation_packet.md`, and `docs/external_reviewer_packet.md`, with no runtime, API, benchmark, test, metric, or example modifications.

### Testing

- Ran `git diff --check` with no reported issues. 
- Ran `python -m pytest -q --basetemp="$bt"` and observed `257 passed, 1 warning`. 
- All automated tests passed and no test files were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2287fdf4d08326b5fef78f1c9ac34f)