### PR TITLE
benchmarks: add Ollama capture mode for release-risk v4

### DIFF
--- a/benchmarks/release_risk_v4_capture_candidates.py
+++ b/benchmarks/release_risk_v4_capture_candidates.py
@@ -2,12 +2,29 @@ from __future__ import annotations
 
 import argparse
 import json
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 
 Record = Dict[str, object]
+
+DEFAULT_OLLAMA_MODEL = "qwen3:4b"
+DEFAULT_OLLAMA_URL = "http://localhost:11434"
+DEFAULT_OLLAMA_TIMEOUT = 60.0
+
+
+@dataclass(frozen=True)
+class OllamaGenerationResult:
+    candidate: str
+    generation_error: Optional[str]
+
+
+class OllamaUnavailableError(RuntimeError):
+    """Raised when the local Ollama API cannot be reached."""
 
 
 REQUIRED_RECORD_KEYS = {
@@ -111,6 +128,116 @@ def build_fixture_candidates() -> List[Record]:
     return rows
 
 
+def _ollama_generate_url(ollama_url: str) -> str:
+    return f"{ollama_url.rstrip('/')}/api/generate"
+
+
+def generate_with_ollama(
+    prompt: str,
+    *,
+    model: str,
+    ollama_url: str,
+    timeout: float,
+) -> OllamaGenerationResult:
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "stream": False,
+    }
+    request = Request(
+        _ollama_generate_url(ollama_url),
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            raw_body = response.read().decode("utf-8")
+    except HTTPError as exc:
+        return OllamaGenerationResult(
+            candidate="",
+            generation_error=f"ollama_http_error_{exc.code}",
+        )
+    except (TimeoutError, URLError, OSError) as exc:
+        raise OllamaUnavailableError(
+            f"Unable to reach Ollama at {_ollama_generate_url(ollama_url)}. "
+            "Ensure Ollama is installed and running locally, then retry. "
+            f"Original error: {exc}"
+        ) from exc
+
+    try:
+        body = json.loads(raw_body)
+    except json.JSONDecodeError:
+        return OllamaGenerationResult(candidate="", generation_error="ollama_invalid_json_response")
+
+    if not isinstance(body, dict):
+        return OllamaGenerationResult(candidate="", generation_error="ollama_invalid_response_shape")
+
+    generated = body.get("response")
+    if not isinstance(generated, str):
+        return OllamaGenerationResult(candidate="", generation_error="ollama_missing_response")
+
+    return OllamaGenerationResult(candidate=generated, generation_error=None)
+
+
+def build_ollama_candidates(
+    *,
+    model: str = DEFAULT_OLLAMA_MODEL,
+    ollama_url: str = DEFAULT_OLLAMA_URL,
+    timeout: float = DEFAULT_OLLAMA_TIMEOUT,
+) -> List[Record]:
+    captured_at = datetime.now(timezone.utc).isoformat()
+    records: List[Record] = []
+
+    for fixture in build_fixture_candidates():
+        fixture_metadata = fixture.get("metadata", {})
+        if not isinstance(fixture_metadata, dict):
+            fixture_metadata = {}
+        result = generate_with_ollama(
+            str(fixture["prompt"]),
+            model=model,
+            ollama_url=ollama_url,
+            timeout=timeout,
+        )
+        candidate = result.candidate
+        generation_failure = result.generation_error is not None
+        empty_candidate = not candidate.strip()
+        records.append(
+            {
+                "prompt_id": fixture["prompt_id"],
+                "risk": fixture["risk"],
+                "category": fixture["category"],
+                "prompt": fixture["prompt"],
+                "generated_candidate": candidate,
+                "candidate_answer": candidate,
+                "candidate_source": "ollama",
+                "generation_mode": "ollama_capture",
+                "provider": "ollama",
+                "model": model,
+                "generation_error": result.generation_error,
+                "generation_failure": generation_failure,
+                "empty_candidate": empty_candidate,
+                "expected_behavior": fixture["expected_behavior"],
+                "metadata": {
+                    "captured_at": captured_at,
+                    "source_dataset": "release_risk_v4_capture_fixture_prompts",
+                    "task_set": fixture_metadata.get("task_set"),
+                    "ollama_url": ollama_url,
+                    "local_capture": True,
+                    "fixture_prompt_id": fixture["prompt_id"],
+                },
+            }
+        )
+
+    for row in records:
+        missing = REQUIRED_RECORD_KEYS.difference(row.keys())
+        if missing:
+            raise ValueError(f"Ollama candidate missing required keys: {sorted(missing)}")
+
+    return records
+
+
 def write_jsonl(records: Iterable[Record], output_path: Path) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with output_path.open("w", encoding="utf-8") as handle:
@@ -120,13 +247,13 @@ def write_jsonl(records: Iterable[Record], output_path: Path) -> None:
 
 def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Scaffold release-risk v4 candidate capture records for replay."
+        description="Capture release-risk v4 candidate records for replay."
     )
     parser.add_argument(
         "--mode",
         required=True,
-        choices=["fixture", "openai"],
-        help="Capture mode; only fixture mode is implemented in this scaffold.",
+        choices=["fixture", "ollama", "openai"],
+        help="Capture mode. Fixture is deterministic; Ollama captures from a local model.",
     )
     parser.add_argument(
         "--output",
@@ -134,11 +261,41 @@ def main(argv: Optional[List[str]] = None) -> int:
         type=Path,
         help="Caller-controlled JSONL output path for generated-candidate records.",
     )
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_OLLAMA_MODEL,
+        help="Ollama model name used with --mode ollama.",
+    )
+    parser.add_argument(
+        "--ollama-url",
+        default=DEFAULT_OLLAMA_URL,
+        help="Base URL for the local Ollama server used with --mode ollama.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_OLLAMA_TIMEOUT,
+        help="Per-request timeout in seconds for --mode ollama.",
+    )
     args = parser.parse_args(argv)
 
     if args.mode == "openai":
-        print("openai capture is not implemented in this scaffold; use --mode fixture")
+        print("openai capture is not implemented in this scaffold; use --mode fixture or --mode ollama")
         return 2
+
+    if args.mode == "ollama":
+        try:
+            records = build_ollama_candidates(
+                model=args.model,
+                ollama_url=args.ollama_url,
+                timeout=args.timeout,
+            )
+        except OllamaUnavailableError as exc:
+            print(str(exc))
+            return 2
+        write_jsonl(records, args.output)
+        print(f"Wrote {len(records)} Ollama candidate record(s) to {args.output}")
+        return 0
 
     records = build_fixture_candidates()
     write_jsonl(records, args.output)

--- a/docs/evidence_map.md
+++ b/docs/evidence_map.md
@@ -242,7 +242,8 @@ Interpretation boundaries:
 - No API keys required.
 - Not provider-backed evidence.
 - Not production safety evidence.
-- Optional provider/local capture remains future work.
+- Optional local Ollama generated-candidate capture is supported for v4, but remains local-model evidence only.
+- Provider-backed capture remains future work.
 
 ## LangChain/OpenAI action-risk Run 06 progression
 

--- a/docs/release_risk_v4_capture_to_replay.md
+++ b/docs/release_risk_v4_capture_to_replay.md
@@ -2,9 +2,9 @@
 
 ## Purpose
 
-This guide documents the deterministic, no-key release-risk v4 capture-to-replay path.
+This guide documents the deterministic, no-key release-risk v4 capture-to-replay path and the optional local Ollama generated-candidate capture mode.
 
-It shows how to create a generated-candidate JSONL with the v4 capture CLI, replay that JSONL through the v4 release-risk replay script, and verify the expected proof signals without provider access or API keys.
+It shows how to create a generated-candidate JSONL with the v4 capture CLI, replay that JSONL through the v4 release-risk replay script, and verify the expected proof signals. Fixture mode requires no provider access, local model, or API keys; Ollama mode is opt-in and requires a locally running Ollama server.
 
 Core framing:
 
@@ -16,6 +16,7 @@ The v4 no-key path keeps candidate creation and release evaluation separate:
 
 ```text
 fixture capture -> generated-candidate JSONL -> replay -> summary + replay artifacts
+optional Ollama capture -> generated-candidate JSONL -> same replay path
 ```
 
 ## What this path proves
@@ -26,15 +27,15 @@ This path proves that the repository has a reproducible, no-key evidence lane fo
 - replay can consume a caller-provided `--input` JSONL;
 - replay can write artifacts to a caller-provided `--results-dir`;
 - replay preserves the captured `generation_mode` and `model` metadata in the summary;
-- fixture capture and replay can run without OpenAI, provider calls, local model calls, or API keys.
+- fixture capture and replay can run without OpenAI, provider calls, local model calls, or API keys;
+- optional Ollama capture can write replay-compatible generated-candidate records from a local Ollama model without changing replay logic.
 
 ## What this path does not prove
 
 This path does **not** claim:
 
 - provider-backed evidence;
-- local-model evidence;
-- live generation quality;
+- production-model quality;
 - production safety;
 - exploit prevention;
 - universal AI safety;
@@ -43,7 +44,7 @@ This path does **not** claim:
 - hallucination elimination;
 - threshold generalization across all models or tasks.
 
-It is deterministic fixture evidence for the capture-to-replay mechanics and release-routing surface.
+Fixture mode is deterministic evidence for the capture-to-replay mechanics and release-routing surface. Ollama mode is optional local generated-candidate evidence for the same replay path.
 
 ## No-key fixture capture
 
@@ -81,6 +82,42 @@ The capture records include replay-required fields such as:
 - `generation_error`
 - `expected_behavior`
 - `metadata`
+
+## Optional local Ollama capture
+
+Fixture mode is the deterministic no-key evidence lane. Ollama mode is an optional local generated-candidate capture lane: it reads the same v4 prompt/task fixture rows used by fixture mode, sends each prompt to a local Ollama server, and writes replay-compatible JSONL for the existing replay script.
+
+Ollama mode is intentionally bounded:
+
+- it requires Ollama to be installed and running locally;
+- it calls the local Ollama HTTP API at `{ollama_url}/api/generate`;
+- it defaults to model `qwen3:4b`;
+- it does not call OpenAI or xAI;
+- it does not require provider API keys;
+- it does not change the SaC policy, replay decisions, or replay metrics.
+
+Example local capture command:
+
+```bash
+python benchmarks/release_risk_v4_capture_candidates.py --mode ollama --model qwen3:4b --output outputs/release_risk_v4_ollama_capture.jsonl
+```
+
+Optional arguments include:
+
+```text
+--ollama-url http://localhost:11434
+--timeout 60
+```
+
+If Ollama is unavailable, the command fails clearly instead of silently falling back to fixture mode. Per-case generation errors are recorded in replay-compatible records when the local API returns a response that cannot produce candidate text.
+
+Replay the Ollama capture through the unchanged v4 replay path:
+
+```bash
+python benchmarks/release_risk_v4_fixture_replay.py --input outputs/release_risk_v4_ollama_capture.jsonl --results-dir outputs/release_risk_v4_ollama_replay_results
+```
+
+Evidence boundary: Ollama capture is local generated-candidate evidence only. It is not provider-backed evidence, not production safety evidence, not a universal model evaluation, and not evidence that release controls generalize across all models or tasks.
 
 ## Replay captured candidates
 
@@ -154,11 +191,11 @@ If a run appears to use stale artifacts, delete the caller-controlled `outputs/r
 
 This guide documents the implemented no-key fixture capture-to-replay path.
 
-Provider/local capture remains separate and opt-in. See:
+Provider capture remains separate and unimplemented. Optional local Ollama capture is implemented as a generated-candidate capture lane only. See:
 
 - `docs/release_risk_v4_provider_capture_plan.md`
 
-Do not treat fixture capture as provider-backed evidence. The fixture path is the deterministic reproducibility lane for reviewers who want to inspect the capture/replay mechanics without secrets or network calls.
+Do not treat fixture capture as provider-backed evidence. Do not treat Ollama capture as provider-backed evidence or production safety evidence. The fixture path is the deterministic reproducibility lane for reviewers who want to inspect the capture/replay mechanics without secrets or network calls; Ollama capture is local-model evidence for generated candidates only.
 
 ## Suggested reading order
 

--- a/tests/test_release_risk_v4_capture_candidates.py
+++ b/tests/test_release_risk_v4_capture_candidates.py
@@ -3,9 +3,16 @@ import subprocess
 import sys
 from pathlib import Path
 
+import benchmarks.release_risk_v4_capture_candidates as capture
 from benchmarks.release_risk_v4_capture_candidates import (
+    DEFAULT_OLLAMA_MODEL,
+    DEFAULT_OLLAMA_URL,
     REQUIRED_RECORD_KEYS,
+    OllamaGenerationResult,
+    OllamaUnavailableError,
     build_fixture_candidates,
+    build_ollama_candidates,
+    generate_with_ollama,
     main,
 )
 from benchmarks.release_risk_v4_fixture_replay import REPLAY_JSONL, SUMMARY_CSV, SUMMARY_JSON
@@ -87,3 +94,125 @@ def test_capture_scaffold_does_not_overwrite_committed_replay_artifacts(tmp_path
     assert SUMMARY_JSON.read_bytes() == baseline_artifacts["summary_json"]
     assert SUMMARY_CSV.read_bytes() == baseline_artifacts["summary_csv"]
     assert REPLAY_JSONL.read_bytes() == baseline_artifacts["replay_jsonl"]
+
+
+class _FakeOllamaResponse:
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def test_generate_with_ollama_posts_expected_payload(monkeypatch) -> None:
+    seen = {}
+
+    def fake_urlopen(request, timeout):
+        seen["url"] = request.full_url
+        seen["timeout"] = timeout
+        seen["payload"] = json.loads(request.data.decode("utf-8"))
+        seen["content_type"] = request.headers["Content-type"]
+        return _FakeOllamaResponse(b'{"response": "generated text"}')
+
+    monkeypatch.setattr(capture, "urlopen", fake_urlopen)
+
+    result = generate_with_ollama(
+        "Prompt text",
+        model="qwen3:4b",
+        ollama_url="http://localhost:11434/",
+        timeout=12.5,
+    )
+
+    assert result == OllamaGenerationResult(candidate="generated text", generation_error=None)
+    assert seen["url"] == "http://localhost:11434/api/generate"
+    assert seen["timeout"] == 12.5
+    assert seen["payload"] == {"model": "qwen3:4b", "prompt": "Prompt text", "stream": False}
+    assert seen["content_type"] == "application/json"
+
+
+def test_build_ollama_candidates_uses_fixture_prompts_and_replay_schema(monkeypatch) -> None:
+    prompts = []
+
+    def fake_generate(prompt: str, *, model: str, ollama_url: str, timeout: float):
+        prompts.append((prompt, model, ollama_url, timeout))
+        return OllamaGenerationResult(candidate=f"generated for {len(prompts)}", generation_error=None)
+
+    monkeypatch.setattr(capture, "generate_with_ollama", fake_generate)
+
+    rows = build_ollama_candidates(model="custom-model", ollama_url="http://ollama.test", timeout=3)
+    fixtures = build_fixture_candidates()
+
+    assert [seen[0] for seen in prompts] == [str(row["prompt"]) for row in fixtures]
+    assert all(seen[1:] == ("custom-model", "http://ollama.test", 3) for seen in prompts)
+    assert len(rows) == len(fixtures)
+    for row, fixture in zip(rows, fixtures):
+        assert REQUIRED_RECORD_KEYS.issubset(row.keys())
+        assert row["prompt_id"] == fixture["prompt_id"]
+        assert row["risk"] == fixture["risk"]
+        assert row["category"] == fixture["category"]
+        assert row["prompt"] == fixture["prompt"]
+        assert row["candidate_answer"] == row["generated_candidate"]
+        assert row["candidate_source"] == "ollama"
+        assert row["generation_mode"] == "ollama_capture"
+        assert row["provider"] == "ollama"
+        assert row["model"] == "custom-model"
+        assert row["generation_error"] is None
+        assert row["generation_failure"] is False
+        assert row["empty_candidate"] is False
+        assert row["expected_behavior"] == fixture["expected_behavior"]
+
+
+def test_ollama_mode_writes_jsonl_with_default_model(tmp_path: Path, monkeypatch) -> None:
+    output = tmp_path / "ollama_capture.jsonl"
+
+    def fake_generate(prompt: str, *, model: str, ollama_url: str, timeout: float):
+        assert model == DEFAULT_OLLAMA_MODEL
+        assert ollama_url == DEFAULT_OLLAMA_URL
+        assert timeout == 60.0
+        return OllamaGenerationResult(candidate="generated candidate", generation_error=None)
+
+    monkeypatch.setattr(capture, "generate_with_ollama", fake_generate)
+
+    rc = main(["--mode", "ollama", "--output", str(output)])
+
+    assert rc == 0
+    rows = _load_jsonl(output)
+    assert rows
+    assert all(row["candidate_source"] == "ollama" for row in rows)
+    assert all(row["generation_mode"] == "ollama_capture" for row in rows)
+    assert all(row["model"] == DEFAULT_OLLAMA_MODEL for row in rows)
+
+
+def test_ollama_generation_failure_records_empty_candidate(monkeypatch) -> None:
+    def fake_generate(prompt: str, *, model: str, ollama_url: str, timeout: float):
+        return OllamaGenerationResult(candidate="", generation_error="ollama_http_error_500")
+
+    monkeypatch.setattr(capture, "generate_with_ollama", fake_generate)
+
+    rows = build_ollama_candidates()
+
+    assert rows
+    assert all(row["generation_error"] == "ollama_http_error_500" for row in rows)
+    assert all(row["generation_failure"] is True for row in rows)
+    assert all(row["empty_candidate"] is True for row in rows)
+
+
+def test_ollama_mode_unavailable_fails_without_output(tmp_path: Path, monkeypatch, capsys) -> None:
+    output = tmp_path / "ollama_unavailable.jsonl"
+
+    def fake_generate(prompt: str, *, model: str, ollama_url: str, timeout: float):
+        raise OllamaUnavailableError("Unable to reach Ollama at http://localhost:11434/api/generate")
+
+    monkeypatch.setattr(capture, "generate_with_ollama", fake_generate)
+
+    rc = main(["--mode", "ollama", "--output", str(output)])
+
+    assert rc == 2
+    assert not output.exists()
+    assert "unable to reach ollama" in capsys.readouterr().out.lower()


### PR DESCRIPTION
### Motivation

- Provide an optional local generated-candidate capture lane for release-risk v4 that lets users capture outputs from a locally running Ollama model and feed them into the existing replay path without changing replay logic or SaC policy.
- Keep the deterministic fixture mode unchanged and avoid introducing provider keys or new production-safety claims.

### Description

- Add `--mode ollama` to `benchmarks/release_risk_v4_capture_candidates.py` plus `--model`, `--ollama-url`, and `--timeout` CLI options with defaults `qwen3:4b`, `http://localhost:11434`, and `60` seconds respectively, and implement `generate_with_ollama` that POSTs `{model, prompt, stream: False}` to `{ollama_url}/api/generate`.
- Implement `build_ollama_candidates` to reuse the existing fixture prompts, capture the generated text, and emit replay-compatible JSONL records including `prompt_id`, `prompt`, `generated_candidate` (and `candidate_answer`), `candidate_source: "ollama"`, `generation_mode: "ollama_capture"`, `provider: "ollama"`, `model`, `generation_error`, `generation_failure`, `empty_candidate`, and conservative `metadata` entries.
- Failure handling: an unreachable Ollama raises a clear `OllamaUnavailableError` and the CLI exits with status 2 without writing output; per-case generation errors are recorded in the record schema instead of crashing.
- Documentation updates: `docs/release_risk_v4_capture_to_replay.md` documents optional Ollama capture and example commands, and `docs/evidence_map.md` notes that Ollama capture is local-model evidence only; replay script `benchmarks/release_risk_v4_fixture_replay.py` and replay decision logic were not modified.
- Files changed: `benchmarks/release_risk_v4_capture_candidates.py`, `tests/test_release_risk_v4_capture_candidates.py` (mocked tests added), `docs/release_risk_v4_capture_to_replay.md`, `docs/evidence_map.md`.

### Testing

- Ran `git diff --check` with no issues.
- Ran unit tests `python -m pytest tests/test_release_risk_v4_capture_candidates.py -q` and observed `10 passed`.
- Ran full test suite with isolated base temp: `python -m pytest -q --basetemp=/tmp/pytest-sac-ollama-capture-XXXXXXXX` and observed `262 passed, 1 warning` (existing deprecation warning), indicating changes do not require Ollama to run tests.
- Manual local Ollama capture was not executed in CI; to validate locally when Ollama is available run: `python benchmarks/release_risk_v4_capture_candidates.py --mode ollama --model qwen3:4b --output outputs/release_risk_v4_ollama_capture.jsonl` and then replay with `python benchmarks/release_risk_v4_fixture_replay.py --input outputs/release_risk_v4_ollama_capture.jsonl --results-dir outputs/release_risk_v4_ollama_replay_results`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23b2e1ded083268d8c147e341c48ee)