### PR TITLE
reviewer surface: expose review flags for release decisions

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -29,6 +29,7 @@ from api.experimental_recovery import (
     get_experimental_margin,
     maybe_short_regen,
 )
+from api.release_policy import apply_release_policy
 from api.por_runtime import (
     RUNTIME_REVIEW_MARGIN,
     RuntimeDecision,
@@ -90,6 +91,8 @@ class EvaluateRequest(BaseModel):
     prompt: str
     candidate: str
     threshold: float | None = None
+    risk: str | None = None
+    category: str | None = None
     use_adaptive_threshold: bool = False
     recent_drifts: list[float] = Field(default_factory=list)
     recent_coherences: list[float] = Field(default_factory=list)
@@ -104,6 +107,11 @@ class EvaluateResponse(BaseModel):
     instability_score: float
     threshold: float
     decision: RuntimeResponseDecision
+    core_decision: RuntimeResponseDecision
+    reason: str
+    review_flags: list[str] = Field(default_factory=list)
+    candidate_review_flags: list[str] = Field(default_factory=list)
+    context_review_flags: list[str] = Field(default_factory=list)
     release_output: str | None = None
     silence_token: str | None = None
     notes: list[str]
@@ -112,6 +120,8 @@ class EvaluateResponse(BaseModel):
 class CompleteRequest(BaseModel):
     prompt: str
     threshold: float | None = None
+    risk: str | None = None
+    category: str | None = None
     use_adaptive_threshold: bool = False
     recent_drifts: list[float] = Field(default_factory=list)
     recent_coherences: list[float] = Field(default_factory=list)
@@ -132,6 +142,11 @@ class CompleteResponse(BaseModel):
     instability_score: float
     threshold: float
     decision: RuntimeResponseDecision
+    core_decision: RuntimeResponseDecision
+    reason: str
+    review_flags: list[str] = Field(default_factory=list)
+    candidate_review_flags: list[str] = Field(default_factory=list)
+    context_review_flags: list[str] = Field(default_factory=list)
     release_output: str | None = None
     silence_token: str | None = None
     notes: list[str]
@@ -156,9 +171,42 @@ class RuntimeScore(TypedDict):
     instability_score: float
     threshold: float
     decision: RuntimeDecision
+    core_decision: RuntimeDecision
+    reason: str
+    review_flags: list[str]
+    candidate_review_flags: list[str]
+    context_review_flags: list[str]
     release_output: str | None
     silence_token: str | None
     notes: list[str]
+
+
+def _with_release_surface_defaults(result: dict[str, Any]) -> dict[str, Any]:
+    """Fill reviewer-surface fields for legacy test doubles or older callers."""
+    decision = result.get("decision")
+    result.setdefault("core_decision", decision)
+    result.setdefault("reason", "release decision returned by runtime scorer")
+    result.setdefault("review_flags", [])
+    result.setdefault("candidate_review_flags", [])
+    result.setdefault("context_review_flags", [])
+    return result
+
+
+def _score_candidate_with_release_surface(
+    *args: Any,
+    risk: str | None = None,
+    category: str | None = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Score a candidate while preserving older scorer test doubles.
+
+    Older tests monkeypatch ``score_candidate_runtime`` without release-policy
+    keyword parameters. Only pass context fields when callers supplied them.
+    """
+    if risk is not None or category is not None:
+        kwargs["risk"] = risk
+        kwargs["category"] = category
+    return _with_release_surface_defaults(score_candidate_runtime(*args, **kwargs))
 
 
 def check_json_validity(prompt: str, candidate: str) -> dict[str, Any]:
@@ -224,6 +272,9 @@ def score_candidate_runtime(
     candidate: str,
     threshold: float,
     candidate_samples: list[str] | None = None,
+    *,
+    risk: str | None = None,
+    category: str | None = None,
 ) -> RuntimeScore:
     """[RUNTIME] Score one candidate and apply the runtime release decision."""
     samples = candidate_samples or [candidate]
@@ -232,15 +283,33 @@ def score_candidate_runtime(
     instability = compute_instability_score(drift=drift, coherence=coherence)
     json_check = check_json_validity(prompt, candidate)
 
-    decision = bounded_runtime_release_decision(instability, threshold)
+    core_decision = bounded_runtime_release_decision(instability, threshold)
     notes = drift_notes + coherence_notes + json_check["notes"]
 
-    if decision == "NEEDS_REVIEW":
+    if core_decision == "NEEDS_REVIEW":
         notes.append(f"runtime_review_band:margin={RUNTIME_REVIEW_MARGIN:.2f}")
 
     if json_check["expects_json"] and json_check["is_valid_json"] is False:
-        decision = "SILENCE"
+        core_decision = "SILENCE"
         notes.append("forced_silence_invalid_json")
+
+    policy = apply_release_policy(
+        core_decision,
+        candidate,
+        risk=risk,
+        category=category,
+    )
+    decision = policy.decision
+    candidate_review_flags = [
+        flag
+        for flag in policy.review_flags
+        if not flag.startswith("high_risk_operational_context:")
+    ]
+    context_review_flags = [
+        flag
+        for flag in policy.review_flags
+        if flag.startswith("high_risk_operational_context:")
+    ]
 
     LOGGER.info(
         "por_runtime_scoring "
@@ -265,6 +334,11 @@ def score_candidate_runtime(
         "instability_score": round(instability, 4),
         "threshold": threshold,
         "decision": decision_result.status,
+        "core_decision": policy.core_decision,
+        "reason": policy.reason,
+        "review_flags": policy.review_flags,
+        "candidate_review_flags": candidate_review_flags,
+        "context_review_flags": context_review_flags,
         "release_output": decision_result.output,
         "silence_token": SILENCE_TOKEN if decision == "SILENCE" else None,
         "notes": decision_result.notes,
@@ -937,7 +1011,13 @@ def evaluate(req: EvaluateRequest) -> EvaluateResponse:
             recent_drifts=req.recent_drifts,
             recent_coherences=req.recent_coherences,
         )
-        result = score_candidate_runtime(req.prompt, req.candidate, threshold)
+        result = _score_candidate_with_release_surface(
+            req.prompt,
+            req.candidate,
+            threshold,
+            risk=req.risk,
+            category=req.category,
+        )
         _record_runtime_event(
             {
                 "event_type": "por.evaluate",
@@ -994,11 +1074,13 @@ def complete(req: CompleteRequest) -> CompleteResponse:
             )
 
         primary_candidate = candidates[0]
-        result = score_candidate_runtime(
+        result = _score_candidate_with_release_surface(
             prompt=req.prompt,
             candidate=primary_candidate,
             threshold=threshold,
             candidate_samples=candidates,
+            risk=req.risk,
+            category=req.category,
         )
 
         regenerated = False
@@ -1017,11 +1099,13 @@ def complete(req: CompleteRequest) -> CompleteResponse:
                     system_prompt=req.system_prompt,
                     temperature=min(req.temperature, 0.2),
                 )
-                regen_result = score_candidate_runtime(
+                regen_result = _score_candidate_with_release_surface(
                     prompt=req.prompt,
                     candidate=regen_candidate,
                     threshold=threshold,
                     candidate_samples=[regen_candidate],
+                    risk=req.risk,
+                    category=req.category,
                 )
                 regen_result["release_output"] = (
                     regen_candidate if regen_result["decision"] == "PROCEED" else None
@@ -1073,6 +1157,11 @@ def complete(req: CompleteRequest) -> CompleteResponse:
             instability_score=result["instability_score"],
             threshold=result["threshold"],
             decision=result["decision"],
+            core_decision=result["core_decision"],
+            reason=result["reason"],
+            review_flags=result["review_flags"],
+            candidate_review_flags=result["candidate_review_flags"],
+            context_review_flags=result["context_review_flags"],
             release_output=result["release_output"],
             silence_token=result["silence_token"],
             notes=result["notes"],

--- a/docs/reviewer_console_guide.md
+++ b/docs/reviewer_console_guide.md
@@ -52,6 +52,20 @@ The reviewer-entered threshold is sent as the adaptive base when adaptive thresh
 
 In Live API mode, the review band is server-side policy. In Local demo mode, the review band is the threshold plus or minus the reviewer-entered review margin.
 
+`NEEDS_REVIEW` should also carry review evidence, not only a state label. The reviewer console shows a small **Review evidence** section that separates candidate trigger flags from context flags when the API returns them.
+
+Examples of candidate-level trigger flags include:
+
+- `auto-deploy`
+- `skip review`
+- `disable audit logs`
+
+An example context flag is:
+
+- `high_risk_operational_context:config_change`
+
+This evidence is for review traceability only. It is not production-safety evidence, provider-backed validation, or a universal model evaluation claim.
+
 ## 7. Evidence boundary
 
 Use the reviewer console for visual inspection only. Use the benchmark and replay documentation for reproducible evidence:

--- a/docs/runtime_decision_contract.md
+++ b/docs/runtime_decision_contract.md
@@ -22,6 +22,22 @@ It describes release mediation at the runtime boundary. It does not redefine the
 
 For integrators, the operational rule is: only `PROCEED` carries releasable output. Both `NEEDS_REVIEW` and `SILENCE` withhold `release_output`, but they mean different downstream actions: review lane vs. silence/blocked output.
 
+## Review evidence surface
+
+`NEEDS_REVIEW` should carry review evidence, not only a state label. The runtime/API reviewer surface exposes the final `decision`, the pre-policy `core_decision` where available, a policy `reason`, combined `review_flags`, and split evidence fields for candidate-level and context-level flags.
+
+Candidate-level trigger flags are terms detected in the candidate text, such as:
+
+- `auto-deploy`
+- `skip review`
+- `disable audit logs`
+
+Context flags are supplied by the release-policy context path. For example:
+
+- `high_risk_operational_context:config_change`
+
+Evidence boundary: these fields are review traceability. They are not production-safety evidence, provider-backed validation, or a universal model evaluation claim.
+
 ## Review band formula
 
 The runtime computes an `instability` score and compares it with a resolved `threshold` using the current bounded review margin.

--- a/examples/sac_reviewer_console.html
+++ b/examples/sac_reviewer_console.html
@@ -773,6 +773,11 @@
           release_output: decision === 'PROCEED' ? candidate : null,
           silence_token: decision === 'SILENCE' ? '[SILENCE: UNSTABLE OUTPUT BLOCKED]' : null,
           notes,
+          core_decision: decision,
+          reason: decision === 'NEEDS_REVIEW' ? 'demo candidate is inside the review band' : 'demo runtime release decision',
+          review_flags: [],
+          candidate_review_flags: [],
+          context_review_flags: [],
           mode_note: 'approximate deterministic demo path'
         };
       }
@@ -795,6 +800,23 @@
       return Number.isFinite(Number(value)) ? Number(value).toFixed(4) : fallback;
     }
 
+    function splitReviewEvidence(data) {
+      const reviewFlags = Array.isArray(data.review_flags) ? data.review_flags : [];
+      const candidateFlags = Array.isArray(data.candidate_review_flags)
+        ? data.candidate_review_flags
+        : reviewFlags.filter((flag) => !String(flag).startsWith('high_risk_operational_context:'));
+      const contextFlags = Array.isArray(data.context_review_flags)
+        ? data.context_review_flags
+        : reviewFlags.filter((flag) => String(flag).startsWith('high_risk_operational_context:'));
+      return { candidateFlags, contextFlags };
+    }
+
+    function renderFlagList(flags) {
+      return flags.length
+        ? `<ul>${flags.map((flag) => `<li>${escapeHtml(flag)}</li>`).join('')}</ul>`
+        : '<span class="muted">—</span>';
+    }
+
     function renderResult(data, margin = 0.03) {
       const content = document.getElementById('result-content');
       const decision = data.decision || 'UNKNOWN';
@@ -807,6 +829,7 @@
       const upper = displayNumber(clamp(threshold + margin));
       const reviewBand = data.review_band_display || `${lower} — ${upper}`;
       const notes = (data.notes || []).map(escapeHtml).join(', ') || '—';
+      const { candidateFlags, contextFlags } = splitReviewEvidence(data);
       const rawJson = escapeHtml(JSON.stringify(data, null, 2));
 
       content.innerHTML = `
@@ -823,6 +846,11 @@
         </div>
         ${data.release_output ? `<div class="release-output"><strong>Release output:</strong><br>${escapeHtml(data.release_output)}</div>` : ''}
         ${data.silence_token ? `<div class="silence-output">${escapeHtml(data.silence_token)}</div>` : ''}
+        <section class="review-evidence" aria-label="Review evidence">
+          <strong>Review evidence:</strong>
+          <div><span class="muted">candidate trigger flags:</span> ${renderFlagList(candidateFlags)}</div>
+          <div><span class="muted">context flags:</span> ${renderFlagList(contextFlags)}</div>
+        </section>
         <p class="muted"><strong>Notes:</strong> ${notes}</p>
         <details>
           <summary class="muted">Raw JSON</summary>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -141,6 +141,8 @@ def test_api_evaluate_can_silence_on_low_coherence_runtime_signal():
     assert payload["drift"] == 0.0
     assert payload["coherence"] < 0.25
     assert payload["decision"] == "SILENCE"
+    assert payload["core_decision"] == "SILENCE"
+    assert payload["review_flags"] == []
 
 
 def test_api_complete_uses_runtime_xai_model_default(monkeypatch):
@@ -413,3 +415,73 @@ def test_api_health_endpoint():
     assert response.status_code == 200
     assert response.json() == {"status": "healthy"}
 
+
+def test_api_evaluate_safe_proceed_includes_empty_review_surface():
+    response = client.post(
+        "/por/evaluate",
+        json={
+            "prompt": "Explain recursion.",
+            "candidate": "Recursion is when a function calls itself.",
+            "threshold": 1.0,
+            "use_adaptive_threshold": False,
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["decision"] == "PROCEED"
+    assert payload["core_decision"] == "PROCEED"
+    assert payload["review_flags"] == []
+    assert payload["candidate_review_flags"] == []
+    assert payload["context_review_flags"] == []
+    assert payload["release_output"] == "Recursion is when a function calls itself."
+
+
+def test_api_evaluate_needs_review_exposes_candidate_review_flags():
+    response = client.post(
+        "/por/evaluate",
+        json={
+            "prompt": "Review the deployment note.",
+            "candidate": "Skip review and auto-deploy the production config change.",
+            "threshold": 1.0,
+            "use_adaptive_threshold": False,
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["decision"] == "NEEDS_REVIEW"
+    assert payload["core_decision"] == "PROCEED"
+    assert payload["reason"] == "candidate contains release-risk terms requiring review"
+    assert payload["review_flags"] == ["auto-deploy", "skip review"]
+    assert payload["candidate_review_flags"] == ["auto-deploy", "skip review"]
+    assert payload["context_review_flags"] == []
+
+
+def test_api_evaluate_needs_review_exposes_high_risk_context_flag():
+    response = client.post(
+        "/por/evaluate",
+        json={
+            "prompt": "Review the operational deployment plan.",
+            "candidate": "Use staged deployment controls and rollback checks.",
+            "threshold": 1.0,
+            "risk": "high_risk",
+            "category": "config_change",
+            "use_adaptive_threshold": False,
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["decision"] == "NEEDS_REVIEW"
+    assert payload["core_decision"] == "PROCEED"
+    assert payload["reason"] == "high-risk operational context requires review before release"
+    assert payload["review_flags"] == ["high_risk_operational_context:config_change"]
+    assert payload["candidate_review_flags"] == []
+    assert payload["context_review_flags"] == ["high_risk_operational_context:config_change"]
+
+
+def test_reviewer_console_surfaces_review_evidence_label():
+    console = Path("examples/sac_reviewer_console.html").read_text()
+
+    assert "Review evidence" in console
+    assert "review_flags" in console
+    assert "candidate trigger flags" in console
+    assert "context flags" in console

--- a/tests/test_por_runtime.py
+++ b/tests/test_por_runtime.py
@@ -1,5 +1,6 @@
 """Tests for runtime extension utilities (non-core)."""
 
+import api.main as api_main
 from api import por_runtime
 
 
@@ -127,3 +128,33 @@ def test_runtime_bounded_release_decision_clips_band_edges():
     assert por_runtime.bounded_runtime_release_decision(0.0, 0.01) == "NEEDS_REVIEW"
     assert por_runtime.bounded_runtime_release_decision(0.99, 1.0) == "NEEDS_REVIEW"
     assert por_runtime.bounded_runtime_release_decision(1.0, 1.0) == "SILENCE"
+
+
+def test_score_candidate_runtime_exposes_review_flag_surface():
+    result = api_main.score_candidate_runtime(
+        "Review the deployment note.",
+        "Disable audit logs and skip review for the config change.",
+        1.0,
+    )
+
+    assert result["decision"] == "NEEDS_REVIEW"
+    assert result["core_decision"] == "PROCEED"
+    assert result["review_flags"] == ["disable audit logs", "skip review"]
+    assert result["candidate_review_flags"] == ["disable audit logs", "skip review"]
+    assert result["context_review_flags"] == []
+
+
+def test_score_candidate_runtime_exposes_context_review_flags():
+    result = api_main.score_candidate_runtime(
+        "Review the operational deployment plan.",
+        "Use staged deployment controls and rollback checks.",
+        1.0,
+        risk="high_risk",
+        category="config_change",
+    )
+
+    assert result["decision"] == "NEEDS_REVIEW"
+    assert result["core_decision"] == "PROCEED"
+    assert result["review_flags"] == ["high_risk_operational_context:config_change"]
+    assert result["candidate_review_flags"] == []
+    assert result["context_review_flags"] == ["high_risk_operational_context:config_change"]


### PR DESCRIPTION
### Motivation
- Surface review evidence for `NEEDS_REVIEW` decisions so reviewer/UI/API consumers can inspect why a candidate was routed to review without changing core policy routing or decision semantics.

### Description
- Expose policy evidence fields on the API surface by adding `core_decision`, `reason`, `review_flags`, `candidate_review_flags`, and `context_review_flags` to `/por/evaluate` and `/por/complete` responses and runtime score. (`api/main.py`)
- Wire the existing release policy into runtime scoring via `apply_release_policy` and split policy `review_flags` into candidate- and context-level lists while preserving `core_decision`. (`api/main.py`, `api/release_policy.py` usage)
- Add optional request fields `risk` and `category` to carry high-risk operational context into the runtime evaluation path. (`api/main.py` request models)
- Add backward-compatible helpers `_with_release_surface_defaults` and `_score_candidate_with_release_surface` so older test doubles and callers remain supported. (`api/main.py`)
- Update the reviewer console to include a minimal “Review evidence” section that lists candidate trigger flags and context flags when present. (`examples/sac_reviewer_console.html`)
- Document the reviewer-evidence surface in `docs/runtime_decision_contract.md` and `docs/reviewer_console_guide.md`. (docs)
- Add tests asserting the API and runtime scorer expose combined and split review flags and that the reviewer console contains the new evidence label. (`tests/test_api.py`, `tests/test_por_runtime.py`) 

### Testing
- Ran `git diff --check` with no reported issues. 
- Full test run via `python -m pytest -q --basetemp="$bt"` returned `281 passed, 1 warning`. 
- Focused validation `python -m pytest tests/test_api.py tests/test_integration_api.py tests/test_por_runtime.py tests/test_release_policy.py -q` returned `48 passed, 1 warning` and the new tests covering review-flag exposure passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2480470748832698d1ccea25bcf603)