### PR TITLE
docs: add review/release receipt layer design note

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ You are here: documentation for architecture boundaries and public-facing guidan
 - `experimental_features.md` — optional non-core MAYBE_SHORT_REGEN behavior.
 - `api_walkthrough.md` — broader API walkthrough.
 - `runtime_observability.md` — local telemetry smoke walkthrough and report shape.
+- [Review/release receipt layer](review_release_receipt_layer.md) — conservative future design note for auditable review/release receipts.
 - `first_run_checklist.md` — no-key first-run verification path.
 - [Direct reproduction guide](direct_reproduction_guide.md) — local commands to verify the no-key release-control path.
 - `provider_configuration.md` — no-key vs provider-backed runtime configuration.

--- a/docs/project_navigation.md
+++ b/docs/project_navigation.md
@@ -30,6 +30,7 @@ docs/
   ├─ pilot_evaluation_packet.md      ← bounded pilot evaluation path
   ├─ pilot_case_log_template.md       ← bounded pilot case logging
   ├─ runtime_observability.md        ← telemetry verification
+  ├─ review_release_receipt_layer.md ← future receipt/audit design note
   ├─ provider_configuration.md       ← API/provider setup
   ├─ release_control_services.md     ← pilot/integration interest
   └─ roadmap_2026.md                 ← milestone planning
@@ -57,6 +58,7 @@ issues/
 | Log pilot cases | [Pilot case log template](pilot_case_log_template.md) |
 | Follow project chronology | [Project chronology](chronology.md) |
 | Inspect runtime telemetry | [Runtime observability](runtime_observability.md) |
+| Understand future review/release receipts | [Review/release receipt layer](review_release_receipt_layer.md) |
 | Configure provider-backed completion | [Provider configuration](provider_configuration.md) |
 | Understand pilot/integration fit | [Release-control services](release_control_services.md) |
 | See milestone planning | [Roadmap 2026](roadmap_2026.md) |

--- a/docs/review_release_receipt_layer.md
+++ b/docs/review_release_receipt_layer.md
@@ -1,0 +1,159 @@
+# Review/Release Receipt Layer
+
+## Core idea
+
+A release decision should be inspectable after it happens. `NEEDS_REVIEW` should carry structured evidence, not only a state label.
+
+The current runtime/API surface already exposes review evidence for review-routed decisions. A future receipt layer could preserve that evidence in a stable, auditable format so reviewers, replay tooling, and downstream operators can compare what was decided, why it was decided, and what evidence was available at the release boundary.
+
+## Boundary
+
+This is a design note for a future receipt layer. The current implementation exposes review evidence fields but does not yet mint canonical receipts.
+
+This note does not change runtime behavior, API schemas, release policy, replay logic, benchmark metrics, or tests. It is not provider-backed validation, not production-safety evidence, not a compliance certification, and not a universal AI safety claim. It is also not blockchain or token work.
+
+## Current available fields
+
+The current decision/review surface can expose these fields, depending on route and caller surface:
+
+- `decision`
+- `core_decision`
+- `reason`
+- `review_flags`
+- `candidate_review_flags`
+- `context_review_flags`
+- `release_output`
+- `silence_token`
+- `notes`
+
+These fields are review traceability fields. They are useful for inspection and handoff, but they are not yet a canonical receipt schema.
+
+## Future receipt fields
+
+A future receipt layer could define a stable schema with fields such as:
+
+- `receipt_id`
+- `decision`
+- `core_decision`
+- `reason`
+- `review_flags`
+- `candidate_review_flags`
+- `context_review_flags`
+- `prompt_hash`
+- `candidate_hash`
+- `policy_version`
+- `runtime_version`
+- `threshold`
+- `instability_score`
+- `timestamp`
+- `reviewer_required`
+- `reviewer_action`
+- `reviewer_id_hash` optional
+- `replay_run_id` optional
+- source metadata optional
+
+The schema should be conservative: stable enough for replay comparison and reviewer handoff, but explicit that it records release-gate evidence rather than proving model correctness or production safety.
+
+## Illustrative receipt example
+
+The following example uses placeholders. The `rr-...`, `sha256:...`, and `2026-..` values are illustrative only and are not real receipt IDs, hashes, or timestamps.
+
+```json
+{
+  "receipt_id": "rr-...",
+  "decision": "NEEDS_REVIEW",
+  "core_decision": "PROCEED",
+  "reason": "high-risk operational context requires review before release",
+  "review_flags": [
+    "auto-deploy",
+    "skip review",
+    "high_risk_operational_context:config_change"
+  ],
+  "candidate_review_flags": [
+    "auto-deploy",
+    "skip review"
+  ],
+  "context_review_flags": [
+    "high_risk_operational_context:config_change"
+  ],
+  "candidate_hash": "sha256:...",
+  "policy_version": "release-policy-v4-local25-boundary",
+  "timestamp": "2026-..",
+  "reviewer_required": true
+}
+```
+
+## Relationship to existing artifacts
+
+Current routing shape:
+
+```text
+candidate -> core runtime decision -> release policy -> decision + review evidence
+```
+
+Possible future routing shape:
+
+```text
+candidate -> core runtime decision -> release policy -> decision + review evidence -> receipt -> review/audit trail
+```
+
+A receipt layer would sit after the current release-policy decision. It should not move release authority into generation, provider output, replay tooling, or reviewer-console presentation. The receipt would record what the release-control boundary decided and what evidence was present at that boundary.
+
+## Receipt types
+
+### `PROCEED` receipt
+
+A `PROCEED` receipt would record that:
+
+- candidate output was released
+- no review was required
+- `release_output` was present
+- `review_flags` were empty or non-blocking
+
+### `NEEDS_REVIEW` receipt
+
+A `NEEDS_REVIEW` receipt would record that:
+
+- candidate output was not released automatically
+- a reviewer was required
+- `reason` and flags were included
+- `release_output` was `null`
+
+### `SILENCE` receipt
+
+A `SILENCE` receipt would record that:
+
+- candidate output was blocked
+- `silence_token` was emitted
+- `reason` was included
+- no automatic release occurred
+
+## Why this matters
+
+A receipt layer could support:
+
+- auditability of release-gate decisions
+- replay comparison across policy/runtime versions
+- reviewer handoff from automated routing into a human review lane
+- bounded pilot evaluation without claiming production safety
+- policy debugging when candidate-level and context-level flags disagree
+- incident review after a blocked, reviewed, or released candidate
+- a future enterprise/on-prem path where local operators need inspectable decision records
+
+## What this does not prove
+
+- It does not prove model correctness.
+- It does not prove production safety.
+- It does not certify compliance.
+- It does not generalize across all models/tasks.
+- It does not replace human review.
+
+## Next possible implementation steps
+
+- define stable receipt schema
+- add `receipt_id` and `policy_version`
+- add `candidate_hash`/`prompt_hash` helpers
+- expose receipt in `/por/evaluate` and `/por/complete` responses
+- add replay receipt export
+- add reviewer console receipt view
+- add tests for receipt schema stability

--- a/docs/runtime_decision_contract.md
+++ b/docs/runtime_decision_contract.md
@@ -38,6 +38,8 @@ Context flags are supplied by the release-policy context path. For example:
 
 Evidence boundary: these fields are review traceability. They are not production-safety evidence, provider-backed validation, or a universal model evaluation claim.
 
+For a conservative future design note on turning this evidence surface into auditable review/release receipts, see [Review/release receipt layer](review_release_receipt_layer.md).
+
 ## Review band formula
 
 The runtime computes an `instability` score and compares it with a resolved `threshold` using the current bounded review margin.


### PR DESCRIPTION
### Motivation

- The runtime/API now exposes structured review evidence for `NEEDS_REVIEW` decisions and the project needs a conservative, documented design direction for turning that evidence into auditable receipts later. 
- This note clarifies boundaries so future work can add a stable receipt schema without conflating runtime behavior, policy authority, or safety/compliance claims. 

### Description

- Add a new design note at `docs/review_release_receipt_layer.md` that documents the core idea, current available review-evidence fields, a proposed future receipt schema, illustrative example, receipt types, relationship to existing artifacts, limitations, and next steps. 
- Link the new design note from the docs index at `docs/README.md`, add it to the project navigation map at `docs/project_navigation.md`, and add a cross-reference from the review evidence section in `docs/runtime_decision_contract.md`. 
- Changes are documentation-only and explicitly state they do not change runtime code, API schemas, release policy, replay logic, benchmark metrics, tests, provider integrations, or make safety/compliance claims. 

### Testing

- Ran `git diff --check` and the tree-level check was clean. 
- Ran the full test suite with `python -m pytest -q --basetemp=...` which completed with `281 passed, 1 warning`. 
- The change set touches documentation files only and adds `docs/review_release_receipt_layer.md` alongside updated references in `docs/README.md`, `docs/project_navigation.md`, and `docs/runtime_decision_contract.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24899fa0c0832697bcac4f75eca080)