### PR TITLE
deploy: make Dockerfile honor PORT environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN python -m pip install --no-cache-dir --upgrade pip \
 
 EXPOSE 8000
 
-CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["sh", "-c", "python -m uvicorn api.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN python -m pip install --no-cache-dir --upgrade pip \
 
 EXPOSE 8000
 
-CMD ["sh", "-c", "python -m uvicorn api.main:app --host 0.0.0.0 --port ${PORT:-8000}"]
+CMD ["sh", "-c", "exec python -m uvicorn api.main:app --host 0.0.0.0 --port ${PORT:-8000}"]


### PR DESCRIPTION
### Motivation
- Ensure the container runtime uses the platform-provided `PORT` (e.g. VibeNest/Coolify) to avoid port/proxy mismatches while preserving the existing local default of `8000`.

### Description
- Replace the fixed `CMD [

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25075959c48326ad9e18d3dc1550f9)